### PR TITLE
Expose proxy namespaces and encodable types from the shared library.

### DIFF
--- a/Stack/core/opcua_proxystub.h
+++ b/Stack/core/opcua_proxystub.h
@@ -31,6 +31,7 @@
 #include "opcua_types.h"
 #include "opcua_browsenames.h"
 #include "opcua_attributes.h"
+#include "opcua_stringtable.h"
 
 OPCUA_BEGIN_EXTERN_C
 
@@ -152,6 +153,16 @@ OPCUA_EXPORT OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetConfigString();
   * @return Pointer to a static string containing the options set by compiler switches. Must not be freed!
   */
 OPCUA_EXPORT OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetStaticConfigString();
+
+/*============================================================================
+ ** @brief Global table of known types.
+ *===========================================================================*/
+OPCUA_IMEXPORT extern OpcUa_EncodeableTypeTable OpcUa_ProxyStub_g_EncodeableTypes;
+
+/*============================================================================
+ ** @brief Global table of supported namespaces.
+ *===========================================================================*/
+OPCUA_IMEXPORT extern OpcUa_StringTable OpcUa_ProxyStub_g_NamespaceUris;
 
 OPCUA_END_EXTERN_C
 #endif /* _OpcUa_ProxyStub_H_ */

--- a/Stack/securechannel/opcua_securelistener.c
+++ b/Stack/securechannel/opcua_securelistener.c
@@ -2352,9 +2352,12 @@ OpcUa_InitializeStatus(OpcUa_Module_SecureListener, "ProcessOpenSecureChannelReq
     } /* if(a_bRequestComplete == OpcUa_False) */
 
     /*** clean up ***/
-    OpcUa_SecureListener_ChannelManager_ReleaseChannel(
-            pSecureListener->ChannelManager,
-            &pSecureChannel);
+    if(pSecureChannel != OpcUa_Null)
+    {
+        OpcUa_SecureListener_ChannelManager_ReleaseChannel(
+                pSecureListener->ChannelManager,
+                &pSecureChannel);
+    }
 
     if(pRequest != OpcUa_Null)
     {


### PR DESCRIPTION
Make OpcUa_ProxyStub_g_EncodeableTypes and OpcUa_ProxyStub_g_NamespaceUris available for library user.

The Stack provides Decoders API that is very useful for loading server predefined nodes. Though, it's not 
clear where OpcUa_MessageContext.KnownTypes and OpcUa_MessageContext.NamespaceUris are supposed to be initialized from. I believe that OpcUa_ProxyStub_g_EncodeableTypes and OpcUa_ProxyStub_g_NamespaceUris are suited for this purpose, but they are not exported.