### PR TITLE
Fix thread sync bug in https listener.

### DIFF
--- a/Stack/transport/https/opcua_httpslistener.c
+++ b/Stack/transport/https/opcua_httpslistener.c
@@ -1147,7 +1147,7 @@ OpcUa_InitializeStatus(OpcUa_Module_HttpListener, "WriteEventHandler");
 
     /******************************************************************************************************/
 
-    OPCUA_P_MUTEX_UNLOCK(pListenerConnection->Mutex);
+    OPCUA_P_MUTEX_LOCK(pListenerConnection->Mutex);
 
     /* look for pending output stream */
     while(pListenerConnection->pSendQueue != OpcUa_Null)


### PR DESCRIPTION
The https listener connection was not being locked before its pending message queue was processed. Caused race condition with EndSendResponse/AddStreamToSendQueue.