### PR TITLE
FIX OpcUa_P_OpenSSL_X509_SelfSigned_Custom_Create leaked memory when …

### DIFF
--- a/Stack/platforms/win32/opcua_p_openssl_x509.c
+++ b/Stack/platforms/win32/opcua_p_openssl_x509.c
@@ -235,10 +235,16 @@ OpcUa_StatusCode OpcUa_P_OpenSSL_X509_SelfSigned_Custom_Create(
     /* generate a unique number for a serial number if none provided. */
     if(a_serialNumber == 0)
     {
+        void*         ptrNew        = OpcUa_Null;
         ASN1_INTEGER* pSerialNumber = X509_get_serialNumber(pCert);
 
         pSerialNumber->type   = V_ASN1_INTEGER;
-        pSerialNumber->data   = OPENSSL_realloc(pSerialNumber->data, 16);
+
+        ptrNew = OPENSSL_realloc(pSerialNumber->data, 16);
+        OpcUa_GotoErrorIfAllocFailed(ptrNew);
+        pSerialNumber->data = (unsigned char*) ptrNew;
+        ptrNew = OpcUa_Null;
+
         pSerialNumber->length = 16;
 
         if(pSerialNumber->data == NULL || OpcUa_P_Guid_Create((OpcUa_Guid*)pSerialNumber->data) == NULL)


### PR DESCRIPTION
…OPENSSL_realloc failed

When OPENSSL_realloc returns a NULL ptr, the original memory of pSerialNumber->Data was lost.