### PR TITLE
Fixed ErrorIfAllocFailed in OpcUa_P_Thread_Create in Win32 

### DIFF
--- a/Stack/platforms/win32/opcua_p_thread.c
+++ b/Stack/platforms/win32/opcua_p_thread.c
@@ -132,7 +132,7 @@ OpcUa_StatusCode OpcUa_P_Thread_Create(OpcUa_RawThread* pRawThread)
 {
     OpcUa_StatusCode uStatus = OpcUa_Good;
     *pRawThread = (OpcUa_RawThread)OpcUa_Alloc(sizeof(pthread_t));
-    OpcUa_ReturnErrorIfAllocFailed(pRawThread);
+    OpcUa_ReturnErrorIfAllocFailed(*pRawThread);
 
     OpcUa_P_Thread_Initialize(*pRawThread);
 


### PR DESCRIPTION
Fixed _OpcUa_ReturnErrorIfAllocFailed_ is not checking for the allocated memory pointer in OpcUa_P_Thread_Create when OPCUA_USE_POSIX is defined with Win32