### PR TITLE
Explicitly specify functions with no args

### DIFF
--- a/Stack/core/opcua.h
+++ b/Stack/core/opcua.h
@@ -52,22 +52,22 @@ extern OpcUa_ProxyStubConfiguration     OpcUa_ProxyStub_g_Configuration;
 /*============================================================================
  * OpcUa_ProxyStub_RegisterChannel
  *===========================================================================*/
-OpcUa_Void OpcUa_ProxyStub_RegisterChannel();
+OpcUa_Void OpcUa_ProxyStub_RegisterChannel(OpcUa_Void);
 
 /*============================================================================
  * OpcUa_ProxyStub_RegisterEndpoint
  *===========================================================================*/
-OpcUa_Void OpcUa_ProxyStub_RegisterEndpoint();
+OpcUa_Void OpcUa_ProxyStub_RegisterEndpoint(OpcUa_Void);
 
 /*============================================================================
  * OpcUa_ProxyStub_DeRegisterChannel
  *===========================================================================*/
-OpcUa_Void OpcUa_ProxyStub_DeRegisterChannel();
+OpcUa_Void OpcUa_ProxyStub_DeRegisterChannel(OpcUa_Void);
 
 /*============================================================================
  * OpcUa_ProxyStub_DeRegisterEndpoint
  *===========================================================================*/
-OpcUa_Void OpcUa_ProxyStub_DeRegisterEndpoint();
+OpcUa_Void OpcUa_ProxyStub_DeRegisterEndpoint(OpcUa_Void);
 
 OPCUA_END_EXTERN_C
 #endif /* _OpcUa_H_ */

--- a/Stack/core/opcua_core.c
+++ b/Stack/core/opcua_core.c
@@ -215,7 +215,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_CryptoProvider_Delete(OpcUa_CryptoProvider*
 }
 /*********************************************************************************/
 
-OpcUa_Void OPCUA_DLLCALL OpcUa_ThreadCleanupOpenSSL()
+OpcUa_Void OPCUA_DLLCALL OpcUa_ThreadCleanupOpenSSL(OpcUa_Void)
 {
     if(OpcUa_ProxyStub_g_PlatformLayerCalltable->ThreadCleanupOpenSSL != OpcUa_Null)
     {

--- a/Stack/core/opcua_core.h
+++ b/Stack/core/opcua_core.h
@@ -37,8 +37,8 @@ OPCUA_EXPORT OpcUa_Void       OPCUA_DLLCALL OpcUa_Mutex_Lock     (      OpcUa_Mu
 OPCUA_EXPORT OpcUa_Void       OPCUA_DLLCALL OpcUa_Mutex_Unlock   (      OpcUa_Mutex  hMutex);
 
 /* utils */
-OPCUA_EXPORT OpcUa_DateTime   OPCUA_DLLCALL OpcUa_DateTime_UtcNow();
-OPCUA_EXPORT OpcUa_UInt32     OPCUA_DLLCALL OpcUa_Utility_GetTickCount();
+OPCUA_EXPORT OpcUa_DateTime   OPCUA_DLLCALL OpcUa_DateTime_UtcNow(	OpcUa_Void);
+OPCUA_EXPORT OpcUa_UInt32     OPCUA_DLLCALL OpcUa_Utility_GetTickCount(	OpcUa_Void);
 
 /* Semaphore */
 OPCUA_EXPORT OpcUa_StatusCode OPCUA_DLLCALL OpcUa_Semaphore_Create   (  OpcUa_Semaphore*    phNewSemaphore,
@@ -110,7 +110,7 @@ OPCUA_EXPORT OpcUa_StatusCode OPCUA_DLLCALL OpcUa_CryptoProvider_Create(OpcUa_St
 OPCUA_EXPORT OpcUa_StatusCode OPCUA_DLLCALL OpcUa_CryptoProvider_Delete(OpcUa_CryptoProvider*   pProvider);
 
 /** @brief Called to clean up OpenSSL state information in client threads.  */
-OPCUA_EXPORT OpcUa_Void       OPCUA_DLLCALL OpcUa_ThreadCleanupOpenSSL();
+OPCUA_EXPORT OpcUa_Void       OPCUA_DLLCALL OpcUa_ThreadCleanupOpenSSL(	OpcUa_Void);
 
 /** @brief add new entropy to the pseudo-random-number-generator of openssl.  */
 OPCUA_EXPORT OpcUa_StatusCode OPCUA_DLLCALL OpcUa_OpenSSLSeedPRNG(      OpcUa_Byte*  pEntropy,

--- a/Stack/core/opcua_proxystub.c
+++ b/Stack/core/opcua_proxystub.c
@@ -61,7 +61,7 @@ static OpcUa_StringA            OpcUa_ProxyStub_StandardNamespaceUris[] =
 /*============================================================================
  * OpcUa_ProxyStub_UpdateConfigString
  *===========================================================================*/
-static OpcUa_StatusCode OpcUa_ProxyStub_UpdateConfigString()
+static OpcUa_StatusCode OpcUa_ProxyStub_UpdateConfigString(OpcUa_Void)
 {
     OpcUa_Int  iRes  = 0;
     OpcUa_Int  iPos  = 0;
@@ -497,7 +497,7 @@ OpcUa_FinishErrorHandling;
 /*============================================================================
  * OpcUa_ProxyStub_GetVersion
  *===========================================================================*/
-OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetVersion()
+OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetVersion(OpcUa_Void)
 {
     return OpcUa_ProxyStub_g_VersionString;
 }
@@ -505,7 +505,7 @@ OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetVersion()
 /*============================================================================
  * OpcUa_ProxyStub_GetConfigString
  *===========================================================================*/
-OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetConfigString()
+OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetConfigString(OpcUa_Void)
 {
 #if OPCUA_USE_SYNCHRONISATION
     if(OpcUa_ProxyStub_g_hGlobalsMutex == OpcUa_Null)
@@ -529,7 +529,7 @@ OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetConfigString()
 /*============================================================================
  * OpcUa_ProxyStub_GetStaticConfigString
  *===========================================================================*/
-OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetStaticConfigString()
+OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetStaticConfigString(OpcUa_Void)
 {
     return OpcUa_ProxyStub_g_StaticConfigString;
 }

--- a/Stack/core/opcua_proxystub.h
+++ b/Stack/core/opcua_proxystub.h
@@ -111,7 +111,7 @@ OPCUA_EXPORT OpcUa_StatusCode OPCUA_DLLCALL OpcUa_ProxyStub_ReInitialize( OpcUa_
  * OpcUa_ProxyStub_Clear
  *===========================================================================*/
 /** Clean up proxy stub library. */
-OPCUA_EXPORT OpcUa_Void OPCUA_DLLCALL OpcUa_ProxyStub_Clear();
+OPCUA_EXPORT OpcUa_Void OPCUA_DLLCALL OpcUa_ProxyStub_Clear(OpcUa_Void);
 
 /*============================================================================
  * OpcUa_ProxyStub_AddTypes
@@ -135,7 +135,7 @@ OPCUA_EXPORT OpcUa_StatusCode OpcUa_ProxyStub_SetNamespaceUris(OpcUa_StringA* a_
 /** Request the version string of the proxy stub.
   * @return Pointer to a static buffer containing the version information in string format. Must not be freed!
   */
-OPCUA_EXPORT OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetVersion();
+OPCUA_EXPORT OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetVersion(OpcUa_Void);
 
 /*============================================================================
  * OpcUa_ProxyStub_GetConfigString
@@ -143,7 +143,7 @@ OPCUA_EXPORT OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetVersion();
 /** Request the string encoded configuration table.
   * @return Pointer to a buffer containing the configuration string. Must not be freed!
   */
-OPCUA_EXPORT OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetConfigString();
+OPCUA_EXPORT OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetConfigString(OpcUa_Void);
 
 /*============================================================================
  * OpcUa_ProxyStub_GetStaticConfigString
@@ -151,7 +151,7 @@ OPCUA_EXPORT OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetConfigString();
 /** Request the string encoded built configuration of the stack.
   * @return Pointer to a static string containing the options set by compiler switches. Must not be freed!
   */
-OPCUA_EXPORT OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetStaticConfigString();
+OPCUA_EXPORT OpcUa_StringA OPCUA_DLLCALL OpcUa_ProxyStub_GetStaticConfigString(OpcUa_Void);
 
 OPCUA_END_EXTERN_C
 #endif /* _OpcUa_ProxyStub_H_ */

--- a/Stack/core/opcua_thread.h
+++ b/Stack/core/opcua_thread.h
@@ -100,7 +100,7 @@ OpcUa_Void OpcUa_Thread_Sleep(                  OpcUa_UInt32    msecTimeout);
  * @return The thread ID.
  */
 OPCUA_EXPORT
-OpcUa_UInt32 OpcUa_Thread_GetCurrentThreadId();
+OpcUa_UInt32 OpcUa_Thread_GetCurrentThreadId(	OpcUa_Void);
 
 /**
  * @brief Check if the main function of the given thread object is running.

--- a/Stack/core/opcua_trace.h
+++ b/Stack/core/opcua_trace.h
@@ -49,7 +49,7 @@ OPCUA_BEGIN_EXTERN_C
 /**
 * Initialize all resources needed for tracing.
 */
-OPCUA_EXPORT OpcUa_StatusCode OPCUA_DLLCALL OpcUa_Trace_Initialize();
+OPCUA_EXPORT OpcUa_StatusCode OPCUA_DLLCALL OpcUa_Trace_Initialize(OpcUa_Void);
 
 /*============================================================================
  * Trace Initialize
@@ -57,7 +57,7 @@ OPCUA_EXPORT OpcUa_StatusCode OPCUA_DLLCALL OpcUa_Trace_Initialize();
 /**
 * Clear all resources needed for tracing.
 */
-OPCUA_EXPORT OpcUa_Void OPCUA_DLLCALL OpcUa_Trace_Clear();
+OPCUA_EXPORT OpcUa_Void OPCUA_DLLCALL OpcUa_Trace_Clear(OpcUa_Void);
 
 /*============================================================================
  * Change Trace Level

--- a/Stack/core/opcua_utilities.c
+++ b/Stack/core/opcua_utilities.c
@@ -79,7 +79,7 @@ OpcUa_Void* OpcUa_BSearch(  OpcUa_Void*       a_pKey,
 /*============================================================================
  * Access to errno
  *===========================================================================*/
-OpcUa_UInt32 OpcUa_GetLastError()
+OpcUa_UInt32 OpcUa_GetLastError(OpcUa_Void)
 {
     return OPCUA_P_GETLASTERROR();
 }
@@ -87,7 +87,7 @@ OpcUa_UInt32 OpcUa_GetLastError()
 /*============================================================================
  * OpcUa_GetTickCount
  *===========================================================================*/
-OpcUa_UInt32 OpcUa_GetTickCount()
+OpcUa_UInt32 OpcUa_GetTickCount(OpcUa_Void)
 {
     return OPCUA_P_GETTICKCOUNT();
 }

--- a/Stack/core/opcua_utilities.h
+++ b/Stack/core/opcua_utilities.h
@@ -68,13 +68,13 @@ OpcUa_Void* OpcUa_BSearch(  OpcUa_Void*       pKey,
  * @brief Returns the CRT errno constant.
  */
 OPCUA_EXPORT
-OpcUa_UInt32 OpcUa_GetLastError();
+OpcUa_UInt32 OpcUa_GetLastError(OpcUa_Void);
 
 /**
  * @brief Returns the number of milliseconds since the system or process was started.
  */
 OPCUA_EXPORT
-OpcUa_UInt32 OpcUa_GetTickCount();
+OpcUa_UInt32 OpcUa_GetTickCount(OpcUa_Void);
 
 /**
  * @brief Convert string to integer.

--- a/Stack/platforms/linux/opcua_p_datetime.c
+++ b/Stack/platforms/linux/opcua_p_datetime.c
@@ -66,7 +66,7 @@ OpcUa_Void OpcUa_P_DateTime_GetTimeOfDay(OpcUa_TimeVal* a_pTimeVal)
 /*============================================================================
 * The OpcUa_UtcNow function (returns the time in OpcUa_DateTime format)
 *===========================================================================*/
-OpcUa_DateTime OpcUa_P_DateTime_UtcNow()
+OpcUa_DateTime OpcUa_P_DateTime_UtcNow(OpcUa_Void)
 {
     struct timeval now;
     OpcUa_Int64 unixtime = 0;

--- a/Stack/platforms/linux/opcua_p_interface.h
+++ b/Stack/platforms/linux/opcua_p_interface.h
@@ -199,7 +199,7 @@ struct S_OpcUa_Port_CallTable
     /** @brief Returns the current time in the OpcUa_DateTime format.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_DateTime      (OPCUA_DLLCALL* UtcNow)                   ();
+    OpcUa_DateTime      (OPCUA_DLLCALL* UtcNow)                   ( OpcUa_Void);
 
     /** @brief Returns the current time in the OpcUa_TimeVal format.
      *  @ingroup opcua_platformlayer_interface
@@ -343,7 +343,7 @@ struct S_OpcUa_Port_CallTable
     /** @brief Get an unique id for the calling system thread.
      *  @ingroup opcua_platformlayer_interface
      */
-    unsigned long       (OPCUA_DLLCALL* ThreadGetCurrentId)       ();
+    unsigned long       (OPCUA_DLLCALL* ThreadGetCurrentId)       ( OpcUa_Void);
 
     /**@} Thread Functions */
     /**@name Trace Functions */
@@ -363,12 +363,12 @@ struct S_OpcUa_Port_CallTable
     /** @brief Initialize tracing functionality during stack initialization before any call to Trace is made.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_StatusCode    (OPCUA_DLLCALL* TraceInitialize)          ();
+    OpcUa_StatusCode    (OPCUA_DLLCALL* TraceInitialize)          ( OpcUa_Void);
 
     /** @brief Clean up the tracing functionality after stack clean up after the last call to Trace was made.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_Void          (OPCUA_DLLCALL* TraceClear)               ();
+    OpcUa_Void          (OPCUA_DLLCALL* TraceClear)               ( OpcUa_Void);
 
     /**@} Trace Functions */
     /**@name String Functions */
@@ -443,12 +443,12 @@ struct S_OpcUa_Port_CallTable
     /** @brief Get last error (aka errno);
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_UInt32        (OPCUA_DLLCALL* UtilGetLastError)         ();
+    OpcUa_UInt32        (OPCUA_DLLCALL* UtilGetLastError)         ( OpcUa_Void);
 
     /** @brief Get the current millisecond tick count of the system.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_UInt32        (OPCUA_DLLCALL* UtilGetTickCount)         ();
+    OpcUa_UInt32        (OPCUA_DLLCALL* UtilGetTickCount)         ( OpcUa_Void);
 
     /** @brief Convert the given string containing a number into OpcUa_Int32.
      *  @ingroup opcua_platformlayer_interface
@@ -605,12 +605,12 @@ struct S_OpcUa_Port_CallTable
     /** @brief Initialize all network resources required by the platform layer. Called during proxystub initialization.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_StatusCode    (OPCUA_DLLCALL* NetworkInitialize)        ();
+    OpcUa_StatusCode    (OPCUA_DLLCALL* NetworkInitialize)        ( OpcUa_Void);
 
     /** @brief Clean up and free all network resources. Called during proxystub cleanup procedure.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_StatusCode    (OPCUA_DLLCALL* NetworkCleanup)           ();
+    OpcUa_StatusCode    (OPCUA_DLLCALL* NetworkCleanup)           ( OpcUa_Void);
 
     /**@} Network Functions */
     /**@name Crypto and PKI Functions */
@@ -660,14 +660,14 @@ struct S_OpcUa_Port_CallTable
     /** @brief Called before cleanup to stop all active timers and invoke timer delete callbacks.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_Void          (OPCUA_DLLCALL* TimersCleanup)            ();
+    OpcUa_Void          (OPCUA_DLLCALL* TimersCleanup)            ( OpcUa_Void);
 
     /**@} Timer Functions */
 
     /** @brief Called to clean up OpenSSL state information in client threads.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_Void          (OPCUA_DLLCALL* ThreadCleanupOpenSSL)     ();
+    OpcUa_Void          (OPCUA_DLLCALL* ThreadCleanupOpenSSL)     ( OpcUa_Void);
 
     /** @brief seeds pseudo-random-number-generator of openssl.
      *  @ingroup opcua_platformlayer_interface

--- a/Stack/platforms/linux/opcua_p_openssl.c
+++ b/Stack/platforms/linux/opcua_p_openssl.c
@@ -101,7 +101,7 @@ static void OpcUa_P_OpenSSL_Lock(int mode, int type, const char *file, int line)
 /*============================================================================
  * OpcUa_P_OpenSSL_Initialize
  *===========================================================================*/
-OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize()
+OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize(OpcUa_Void)
 {
 #if OPCUA_USE_SYNCHRONISATION
     OpcUa_StatusCode uStatus = OpcUa_P_Mutex_Create(&OpenSSL_Mutex);
@@ -120,7 +120,7 @@ OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize()
 /*============================================================================
  * OpcUa_P_OpenSSL_Cleanup
  *===========================================================================*/
-void OpcUa_P_OpenSSL_Cleanup()
+void OpcUa_P_OpenSSL_Cleanup(OpcUa_Void)
 {
 #if OPCUA_P_SOCKETMANAGER_SUPPORT_SSL
 #if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(OPENSSL_NO_COMP)
@@ -141,7 +141,7 @@ void OpcUa_P_OpenSSL_Cleanup()
 /*============================================================================
  * OpcUa_P_OpenSSL_Thread_Cleanup()
  *===========================================================================*/
-void OPCUA_DLLCALL OpcUa_P_OpenSSL_Thread_Cleanup()
+void OPCUA_DLLCALL OpcUa_P_OpenSSL_Thread_Cleanup(OpcUa_Void)
 {
     ERR_remove_state(0);
 #if OPENSSL_VERSION_NUMBER >= 0x1010000fL

--- a/Stack/platforms/linux/opcua_p_openssl.h
+++ b/Stack/platforms/linux/opcua_p_openssl.h
@@ -35,17 +35,17 @@ OPCUA_BEGIN_EXTERN_C
 /**
   @brief Initializes the OpenSSL library.
 */
-OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize();
+OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize(OpcUa_Void);
 
 /**
   @brief cleans up the OpenSSL library.
 */
-void OpcUa_P_OpenSSL_Cleanup();
+OpcUa_Void OpcUa_P_OpenSSL_Cleanup(OpcUa_Void);
 
 /**
   @brief cleans up the OpenSSL library.
 */
-void OPCUA_DLLCALL OpcUa_P_OpenSSL_Thread_Cleanup();
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_OpenSSL_Thread_Cleanup(OpcUa_Void);
 
 /**
   @brief seeds pseudo-random-number-generator of openssl.
@@ -56,8 +56,8 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_OpenSSL_SeedPRNG( OpcUa_Byte* seed,
 /**
   @brief destroys secret data values in a cyptographically safe way.
 */
-void OPCUA_DLLCALL OpcUa_P_OpenSSL_DestroySecretData(    OpcUa_Void*  data,
-                                                         OpcUa_UInt32 bytes);
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_OpenSSL_DestroySecretData(OpcUa_Void*  data,
+                                                           OpcUa_UInt32 bytes);
 
 /**
   @brief Encrypts data using Advanced Encryption Standard (AES) with the Cipher Block Chaining (CBC) mode.

--- a/Stack/platforms/linux/opcua_p_trace.h
+++ b/Stack/platforms/linux/opcua_p_trace.h
@@ -33,7 +33,7 @@
 /**
  * Initialize all resources needed for tracing.
  */
-OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Trace_Initialize(void);
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Trace_Initialize(OpcUa_Void);
 
 /*============================================================================
  * Trace Initialize
@@ -41,7 +41,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Trace_Initialize(void);
 /**
  * Clear all resources needed for tracing.
  */
-OpcUa_Void OPCUA_DLLCALL OpcUa_P_Trace_Clear(void);
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Trace_Clear(OpcUa_Void);
 
 /*============================================================================
  * Tracefunction

--- a/Stack/platforms/linux/opcua_p_utilities.c
+++ b/Stack/platforms/linux/opcua_p_utilities.c
@@ -73,7 +73,7 @@ OpcUa_Void* OPCUA_DLLCALL OpcUa_P_BSearch(  OpcUa_Void*       pKey,
 /*============================================================================
  * Access to errno
  *===========================================================================*/
-OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetLastError()
+OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetLastError(OpcUa_Void)
 {
     return errno;
 }
@@ -81,7 +81,7 @@ OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetLastError()
 /*============================================================================
  * OpcUa_GetTickCount
  *===========================================================================*/
-OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetTickCount()
+OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetTickCount(OpcUa_Void)
 {
     struct timeval now;
     OpcUa_UInt32 ticks = 0;

--- a/Stack/platforms/win32/opcua_p_datetime.c
+++ b/Stack/platforms/win32/opcua_p_datetime.c
@@ -75,7 +75,7 @@ OpcUa_Void OPCUA_DLLCALL OpcUa_P_DateTime_GetTimeOfDay(OpcUa_TimeVal* a_pTimeVal
 /*============================================================================
  * The OpcUa_UtcNow function (returns the time in OpcUa_DateTime format)
  *===========================================================================*/
-OpcUa_DateTime OPCUA_DLLCALL OpcUa_P_DateTime_UtcNow()
+OpcUa_DateTime OPCUA_DLLCALL OpcUa_P_DateTime_UtcNow(OpcUa_Void)
 {
     FILETIME ftTime;
 #ifdef _WIN32_WCE

--- a/Stack/platforms/win32/opcua_p_interface.h
+++ b/Stack/platforms/win32/opcua_p_interface.h
@@ -199,7 +199,7 @@ struct S_OpcUa_Port_CallTable
     /** @brief Returns the current time in the OpcUa_DateTime format.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_DateTime      (OPCUA_DLLCALL* UtcNow)                   ();
+    OpcUa_DateTime      (OPCUA_DLLCALL* UtcNow)                   ( OpcUa_Void);
 
     /** @brief Returns the current time in the OpcUa_TimeVal format.
      *  @ingroup opcua_platformlayer_interface
@@ -343,7 +343,7 @@ struct S_OpcUa_Port_CallTable
     /** @brief Get an unique id for the calling system thread.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_UInt32        (OPCUA_DLLCALL* ThreadGetCurrentId)       ();
+    OpcUa_UInt32        (OPCUA_DLLCALL* ThreadGetCurrentId)       ( OpcUa_Void);
 
     /** @brief Output the given zero terminated string to the systems tracing device.
      *  @ingroup opcua_platformlayer_interface
@@ -359,12 +359,12 @@ struct S_OpcUa_Port_CallTable
     /** @brief Initialize tracing functionality during stack initialization before any call to Trace is made.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_StatusCode    (OPCUA_DLLCALL* TraceInitialize)          ();
+    OpcUa_StatusCode    (OPCUA_DLLCALL* TraceInitialize)          ( OpcUa_Void);
 
     /** @brief Clean up the tracing functionality after stack clean up after the last call to Trace was made.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_Void          (OPCUA_DLLCALL* TraceClear)               ();
+    OpcUa_Void          (OPCUA_DLLCALL* TraceClear)               ( OpcUa_Void);
 
     /**@} Trace Functions */
     /**@name String Functions */
@@ -439,12 +439,12 @@ struct S_OpcUa_Port_CallTable
     /** @brief Get last error (aka errno);
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_UInt32        (OPCUA_DLLCALL* UtilGetLastError)         ();
+    OpcUa_UInt32        (OPCUA_DLLCALL* UtilGetLastError)         ( OpcUa_Void);
 
     /** @brief Get the current millisecond tick count of the system.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_UInt32        (OPCUA_DLLCALL* UtilGetTickCount)         ();
+    OpcUa_UInt32        (OPCUA_DLLCALL* UtilGetTickCount)         ( OpcUa_Void);
 
     /** @brief Convert the given string containing a number into OpcUa_Int32.
      *  @ingroup opcua_platformlayer_interface
@@ -611,12 +611,12 @@ struct S_OpcUa_Port_CallTable
     /** @brief Initialize all network resources required by the platform layer. Called during proxystub initialization.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_StatusCode    (OPCUA_DLLCALL* NetworkInitialize)        ();
+    OpcUa_StatusCode    (OPCUA_DLLCALL* NetworkInitialize)        ( OpcUa_Void);
 
     /** @brief Clean up and free all network resources. Called during proxystub cleanup procedure.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_StatusCode    (OPCUA_DLLCALL* NetworkCleanup)           ();
+    OpcUa_StatusCode    (OPCUA_DLLCALL* NetworkCleanup)           ( OpcUa_Void);
 
     /**@} Network Functions */
     /**@name Crypto and PKI Functions */
@@ -666,14 +666,14 @@ struct S_OpcUa_Port_CallTable
     /** @brief Called before cleanup to stop all active timers and invoke timer delete callbacks.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_Void          (OPCUA_DLLCALL* TimersCleanup)            ();
+    OpcUa_Void          (OPCUA_DLLCALL* TimersCleanup)            ( OpcUa_Void);
 
     /**@} Timer Functions */
 
     /** @brief Called to clean up OpenSSL state information in client threads.
      *  @ingroup opcua_platformlayer_interface
      */
-    OpcUa_Void          (OPCUA_DLLCALL* ThreadCleanupOpenSSL)     ();
+    OpcUa_Void          (OPCUA_DLLCALL* ThreadCleanupOpenSSL)     ( OpcUa_Void);
 
     /** @brief seeds pseudo-random-number-generator of openssl.
      *  @ingroup opcua_platformlayer_interface

--- a/Stack/platforms/win32/opcua_p_openssl.c
+++ b/Stack/platforms/win32/opcua_p_openssl.c
@@ -100,7 +100,7 @@ static void OpcUa_P_OpenSSL_Lock(int mode, int type, const char *file, int line)
 /*============================================================================
  * OpcUa_P_OpenSSL_Initialize
  *===========================================================================*/
-OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize()
+OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize(OpcUa_Void)
 {
 #if OPCUA_USE_SYNCHRONISATION
     OpcUa_StatusCode uStatus = OpcUa_P_Mutex_Create(&OpenSSL_Mutex);
@@ -121,7 +121,7 @@ OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize()
 /*============================================================================
  * OpcUa_P_OpenSSL_Cleanup
  *===========================================================================*/
-void OpcUa_P_OpenSSL_Cleanup()
+void OpcUa_P_OpenSSL_Cleanup(OpcUa_Void)
 {
 #if OPCUA_P_SOCKETMANAGER_SUPPORT_SSL
 #if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(OPENSSL_NO_COMP)
@@ -141,7 +141,7 @@ void OpcUa_P_OpenSSL_Cleanup()
 /*============================================================================
  * OpcUa_P_OpenSSL_Thread_Cleanup()
  *===========================================================================*/
-void OPCUA_DLLCALL OpcUa_P_OpenSSL_Thread_Cleanup()
+void OPCUA_DLLCALL OpcUa_P_OpenSSL_Thread_Cleanup(OpcUa_Void)
 {
     ERR_remove_state(0);
 #if OPENSSL_VERSION_NUMBER >= 0x1010000fL

--- a/Stack/platforms/win32/opcua_p_openssl.h
+++ b/Stack/platforms/win32/opcua_p_openssl.h
@@ -35,17 +35,17 @@ OPCUA_BEGIN_EXTERN_C
 /**
   @brief Initializes the OpenSSL library.
 */
-OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize();
+OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize(OpcUa_Void);
 
 /**
   @brief cleans up the OpenSSL library.
 */
-void OpcUa_P_OpenSSL_Cleanup();
+OpcUa_Void OpcUa_P_OpenSSL_Cleanup(OpcUa_Void);
 
 /**
   @brief cleans up the OpenSSL library.
 */
-void OPCUA_DLLCALL OpcUa_P_OpenSSL_Thread_Cleanup(void);
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_OpenSSL_Thread_Cleanup(OpcUa_Void);
 
 /**
   @brief seeds pseudo-random-number-generator of openssl.
@@ -56,8 +56,8 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_OpenSSL_SeedPRNG( OpcUa_Byte* seed,
 /**
   @brief destroys secret data values in a cyptographically safe way.
 */
-void OPCUA_DLLCALL OpcUa_P_OpenSSL_DestroySecretData(    OpcUa_Void*  data,
-                                                         OpcUa_UInt32 bytes);
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_OpenSSL_DestroySecretData(OpcUa_Void*  data,
+                                                           OpcUa_UInt32 bytes);
 
 /**
   @brief Encrypts data using Advanced Encryption Standard (AES) with the Cipher Block Chaining (CBC) mode.

--- a/Stack/platforms/win32/opcua_p_thread.c
+++ b/Stack/platforms/win32/opcua_p_thread.c
@@ -74,7 +74,7 @@ typedef struct _OpcUa_P_ThreadArg
 * is calling the InternalThreadMain from OpcUa_Thread.c and your internal stuff.
 */
 
-void* pthread_start(void* args)
+OpcUa_Void* pthread_start(OpcUa_Void* args)
 {
     OpcUa_P_ThreadArg*  p_P_ThreadArgs      = OpcUa_Null;
     OpcUa_Thread*       pThread             = OpcUa_Null;
@@ -235,7 +235,7 @@ OpcUa_UInt32 OpcUa_P_Thread_GetCurrentThreadId(OpcUa_Void)
 * is calling the InternalThreadMain from OpcUa_Thread.c and your internal stuff.
 */
 
-void* win32thread_start(void* args)
+OpcUa_Void* win32thread_start(OpcUa_Void* args)
 {
     OpcUa_P_ThreadArg*  pThreadArgs         = OpcUa_Null;
     OpcUa_Void*         pArguments          = OpcUa_Null;

--- a/Stack/platforms/win32/opcua_p_thread.h
+++ b/Stack/platforms/win32/opcua_p_thread.h
@@ -56,4 +56,4 @@ OpcUa_Void          OPCUA_DLLCALL OpcUa_P_Thread_Sleep(     OpcUa_UInt32    msec
 /*============================================================================
  * Get Current Thread Id
  *===========================================================================*/
-OpcUa_UInt32        OPCUA_DLLCALL OpcUa_P_Thread_GetCurrentThreadId(void);
+OpcUa_UInt32        OPCUA_DLLCALL OpcUa_P_Thread_GetCurrentThreadId(OpcUa_Void);

--- a/Stack/platforms/win32/opcua_p_timer.h
+++ b/Stack/platforms/win32/opcua_p_timer.h
@@ -83,12 +83,12 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Timer_Delete(    OpcUa_Timer*            
 /*============================================================================
  * Initialize the Timer System
  *===========================================================================*/
-OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_InitializeTimers(void);
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_InitializeTimers( OpcUa_Void);
 
 /*============================================================================
  * Cleanup the Timer System
  *===========================================================================*/
-OpcUa_Void OPCUA_DLLCALL OpcUa_P_Timer_CleanupTimers(void);
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Timer_CleanupTimers(	OpcUa_Void);
 
 #if !OPCUA_MULTITHREADED
 /*============================================================================

--- a/Stack/platforms/win32/opcua_p_trace.h
+++ b/Stack/platforms/win32/opcua_p_trace.h
@@ -37,7 +37,7 @@
 /**
  * Initialize all resources needed for tracing.
  */
-OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Trace_Initialize(void);
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Trace_Initialize(OpcUa_Void);
 
 /*============================================================================
  * Trace Initialize
@@ -45,7 +45,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Trace_Initialize(void);
 /**
  * Clear all resources needed for tracing.
  */
-OpcUa_Void OPCUA_DLLCALL OpcUa_P_Trace_Clear(void);
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Trace_Clear(OpcUa_Void);
 
 /*============================================================================
  * Tracefunction

--- a/Stack/platforms/win32/opcua_p_utilities.c
+++ b/Stack/platforms/win32/opcua_p_utilities.c
@@ -152,7 +152,7 @@ OpcUa_Void* OPCUA_DLLCALL OpcUa_P_BSearch(  OpcUa_Void*       pKey,
 /*============================================================================
  * Access to errno
  *===========================================================================*/
-OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetLastError()
+OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetLastError(OpcUa_Void)
 {
 #ifdef _WIN32_WCE
     return GetLastError();
@@ -164,7 +164,7 @@ OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetLastError()
 /*============================================================================
  * OpcUa_GetTickCount
  *===========================================================================*/
-OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetTickCount()
+OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetTickCount(OpcUa_Void)
 {
     return GetTickCount();
 }


### PR DESCRIPTION
Some compilers generate errors with the current code, as does GCC with
-Wstrict-prototypes.

For more background, see
https://stackoverflow.com/questions/51032/is-there-a-difference-between-foovoid-and-foo-in-c-or-c

Signed-off-by: Dave Thaler <dthaler@microsoft.com>