### PR TITLE
Use Compare and CopyTo APIs for NodeId and BrowseDescription

### DIFF
--- a/AnsiCSample/ansicservermain.c
+++ b/AnsiCSample/ansicservermain.c
@@ -103,13 +103,8 @@ OpcUa_StatusCode OPCUA_DLLCALL Timer_Callback(  OpcUa_Void*             pvCallba
 //---------------------------------------------------------------
 
 //CONTINUATION POINT--------------------------------
- OpcUa_Int			Continuation_Point_Identifier;
- OpcUa_Int			Cont_Point_Counter;
- enum
- {
-	free_to_use=0,
-	occupied=1
-}continuation_point;
+ _my_continuationpoint_	Continuation_Point_Data; /* Currently just one per session. */
+ OpcUa_Int		Cont_Point_Counter; /* Last continuation point ID used. Unique across sessions to make tracing more readable. */
 
  OpcUa_UInt32		max_ref_per_node;
 //--------------------------------------------------
@@ -368,6 +363,8 @@ static OpcUa_Void UaTestServer_SecurityClear(OpcUa_Void)
 /*===========================================================================================*/
 OpcUa_Void UaTestServer_Clear(OpcUa_Void)
 {
+	OpcUa_BrowseDescription_Clear(&Continuation_Point_Data.NodeToBrowse);
+
 	if(p_user_name!=OpcUa_Null)
 		username_free();
 	
@@ -967,6 +964,8 @@ OpcUa_StatusCode my_CloseSession(
 	
 	OpcUa_Timer_Delete(&Timer);
 	
+	Continuation_Point_Data.Cont_Point_Identifier=0;
+	OpcUa_BrowseDescription_Clear(&Continuation_Point_Data.NodeToBrowse);
 
 	session_flag=SESSION_NOT_ACTIVATED;
 
@@ -1345,7 +1344,7 @@ OpcUa_StatusCode response_header_fill(OpcUa_ResponseHeader*  a_pResponseHeader,c
 		if((OpcUa_UInt32)session_timeout<diff )
 		{
 			#ifndef NO_DEBUGGING_
-			MY_TRACE("\nService runtime:%u msec (TImeOut)\n", diff);
+			MY_TRACE("\nService runtime:%u msec (TimeOut)\n", diff);
 			#endif /*_DEBUGGING_*/
 			a_pResponseHeader->ServiceResult=OpcUa_BadTimeout;
 		}

--- a/AnsiCSample/browsenext.c
+++ b/AnsiCSample/browsenext.c
@@ -59,19 +59,14 @@ OpcUa_StatusCode my_BrowseNext(
     OpcUa_Int32*               a_pNoOfDiagnosticInfos,
     OpcUa_DiagnosticInfo**     a_pDiagnosticInfos)
 {
-	extern OpcUa_Int		Continuation_Point_Identifier;
+	extern _my_continuationpoint_	Continuation_Point_Data;
 	OpcUa_Int               m;
 	extern OpcUa_UInt32		securechannelId;
 	extern OpcUa_UInt32		session_flag;
 	extern OpcUa_Double		msec_counter;
 	extern OpcUa_String*	p_user_name;
-	extern enum
-	{
-		free_to_use=0,
-		occupied=1
-	}continuation_point;
 
-    OpcUa_InitializeStatus(OpcUa_Module_Server, "OpcUa_ServerApi_BrowseNext");
+    OpcUa_InitializeStatus(OpcUa_Module_Server, "my_BrowseNext");
 
     /* Validate arguments. */
     OpcUa_ReturnErrorIfArgumentNull(a_hEndpoint);
@@ -123,41 +118,35 @@ OpcUa_StatusCode my_BrowseNext(
 
 		*a_pNoOfResults=a_nNoOfContinuationPoints;
 
-		continuation_point=free_to_use;
-
 		for(m=0;m<a_nNoOfContinuationPoints;m++)
 		{
 			OpcUa_BrowseResult_Initialize((*a_pResults+m));
-			if((a_pContinuationPoints+m)->Data!=OpcUa_Null && (a_pContinuationPoints+m)->Length>=sizeof(_my_continuationpoint_))
+			if((a_pContinuationPoints+m)->Data!=OpcUa_Null && ((a_pContinuationPoints+m)->Length>=sizeof(OpcUa_Int)))
 			{
-				if((((_my_continuationpoint_*)(a_pContinuationPoints+m)->Data)->Cont_Point_Identifier)==Continuation_Point_Identifier)
+				OpcUa_Int cpid=*(OpcUa_Int*)(a_pContinuationPoints+m)->Data;
+				if(cpid==Continuation_Point_Data.Cont_Point_Identifier)
 				{
 					#ifndef NO_DEBUGGING_
-						MY_TRACE("\nContinuationPoint (Identifier:%d) was provided.\n",(((_my_continuationpoint_*)(a_pContinuationPoints+m)->Data)->Cont_Point_Identifier)); 
+						MY_TRACE("\nContinuationPoint (Identifier:%d) was provided.\n",cpid); 
 					#endif /*_DEBUGGING_*/
-					(*a_pResults+m)->StatusCode=browse(&(((_my_continuationpoint_*)(a_pContinuationPoints+m)->Data)->NodeToBrowse),(*a_pResults+m),((_my_continuationpoint_*)(a_pContinuationPoints+m)->Data)->Current_Ref);
-				}
-				else
-				{
-					(*a_pResults+m)->StatusCode=OpcUa_BadContinuationPointInvalid;
-					#ifndef NO_DEBUGGING_
-						MY_TRACE("\n%d. Invalid ContinuationPoint Identifier!!!\n", m); 
-					#endif /*_DEBUGGING_*/
-				}
 
+					/* Clear continuation point in case we need to continue again. */
+					Continuation_Point_Data.Cont_Point_Identifier=0;
+
+					(*a_pResults+m)->StatusCode=browse(&Continuation_Point_Data.NodeToBrowse,(*a_pResults+m),Continuation_Point_Data.Current_Ref);
+					continue;
+				}
 			}
-			else
-			{
-				(*a_pResults+m)->StatusCode=OpcUa_BadContinuationPointInvalid;
-				#ifndef NO_DEBUGGING_
-					MY_TRACE("\n%d. Invalid ContinuationPoint!!!\n", m); 
-				#endif /*_DEBUGGING_*/
-			}
+			(*a_pResults+m)->StatusCode=OpcUa_BadContinuationPointInvalid;
+			#ifndef NO_DEBUGGING_
+				MY_TRACE("\n%d. Invalid ContinuationPoint!!!\n", m); 
+			#endif /*_DEBUGGING_*/
 		}
 	}
 	else
 	{
-		Continuation_Point_Identifier=0;
+		Continuation_Point_Data.Cont_Point_Identifier=0;
+		OpcUa_BrowseDescription_Clear(&Continuation_Point_Data.NodeToBrowse);
 		#ifndef NO_DEBUGGING_
 			MY_TRACE("\nBrowseNext called, deleting Cont.Point");
 			MY_TRACE("\n..................ContinuationPoint deleted.\n");

--- a/AnsiCSample/browseservice.h
+++ b/AnsiCSample/browseservice.h
@@ -30,23 +30,21 @@
 #ifndef _browseservice_
 #define _browseservice_
 
+#include <opcua_memorystream.h>
+#include <opcua_binaryencoder.h>
+OPCUA_DECLARE_GENERIC_COMPARE(NodeId)
+OPCUA_DECLARE_GENERIC_COPY(NodeId)
+OPCUA_DECLARE_GENERIC_COPY(BrowseDescription)
+
 #define RESET_SESSION_COUNTER	msec_counter=0;
-
-#define Is_my_node(startNodeId,meinNode) (startNodeId.NamespaceIndex==meinNode.BaseAttribute.NodeId.NamespaceIndex) && (startNodeId.Identifier.Numeric==meinNode.BaseAttribute.NodeId.Identifier.Numeric) && (startNodeId.IdentifierType==meinNode.BaseAttribute.NodeId.IdentifierType)
-
-
 
 typedef struct
 {
-	OpcUa_Int					Cont_Point_Identifier;
-	OpcUa_Int					Current_Ref;
+	OpcUa_Int			Cont_Point_Identifier; /* Non-zero ID if in use, or 0 if free to use */
+	OpcUa_Int			Current_Ref;
 	OpcUa_BrowseDescription		NodeToBrowse;
 
 }_my_continuationpoint_;
-
-
- 
- 
 
 
 //@brief Browse Prototype

--- a/AnsiCSample/init_variables_of_addressspace.c
+++ b/AnsiCSample/init_variables_of_addressspace.c
@@ -38,10 +38,11 @@
 
 #include "addressspace.h"
 #include "general_header.h"
+#include "browseservice.h"
 
 OpcUa_StatusCode initialize_value_attribute_of_variablenodes_variabletypenodes(OpcUa_Void)
 {
-	extern OpcUa_Int			Continuation_Point_Identifier;
+	extern _my_continuationpoint_		Continuation_Point_Data;
 	extern OpcUa_Int			Cont_Point_Counter;
 	extern OpcUa_UInt32			session_flag;
 	extern OpcUa_String*		p_user_name;
@@ -50,7 +51,8 @@ OpcUa_StatusCode initialize_value_attribute_of_variablenodes_variabletypenodes(O
 	OpcUa_InitializeStatus(OpcUa_Module_Server, "initialize_value_attribute_of_variablenodes_variabletypenodes");
 
 /* Initialize relevant session variables. */
-	Continuation_Point_Identifier=0;
+	Continuation_Point_Data.Cont_Point_Identifier=0; /* None. */
+	OpcUa_BrowseDescription_Initialize(&Continuation_Point_Data.NodeToBrowse);
 	Cont_Point_Counter=0;
 	session_flag=SESSION_NOT_ACTIVATED;
 	p_user_name=OpcUa_Null;


### PR DESCRIPTION
The sample server hard codes a hard-to-read algorithm for NodeId_Compare
which only supports numeric namespace identifiers. Although the sample
server only uses numeric ones, actual clients/servers need to support
other types of namespace identifiers and hence need these APIs.  Also
updated the sample server to actually use them, to allow testing and
provide code that would work if copied into an actual server.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>