### PR TITLE
Make sample server session parameters be per-session not global

### DIFF
--- a/AnsiCSample/browseservice.h
+++ b/AnsiCSample/browseservice.h
@@ -36,8 +36,6 @@ OPCUA_DECLARE_GENERIC_COMPARE(NodeId)
 OPCUA_DECLARE_GENERIC_COPY(NodeId)
 OPCUA_DECLARE_GENERIC_COPY(BrowseDescription)
 
-#define RESET_SESSION_COUNTER	msec_counter=0;
-
 typedef struct
 {
 	OpcUa_Int			Cont_Point_Identifier; /* Non-zero ID if in use, or 0 if free to use */
@@ -90,11 +88,5 @@ OpcUa_Boolean			check_Mask					(OpcUa_UInt32 ,OpcUa_UInt32 );
 OpcUa_Boolean			check_dir					(OpcUa_BrowseDirection ,_ReferenceNode_* );
 
 OpcUa_Boolean			need_continuationpoint		(OpcUa_BrowseDescription* ,OpcUa_Int);
-
-OpcUa_StatusCode		check_authentication_token	(const OpcUa_RequestHeader* );
-
-OpcUa_StatusCode		response_header_fill	    (OpcUa_ResponseHeader*  ,const OpcUa_RequestHeader*, OpcUa_StatusCode);
-
-
 
 #endif /*_browseservice_*/

--- a/AnsiCSample/general_header.h
+++ b/AnsiCSample/general_header.h
@@ -31,26 +31,40 @@
 #define _GENERAL_HEADER_
 
 
-#define SESSION_NOT_ACTIVATED	0x80270000
-#define	SESSION_ACTIVATED		0x00000000
+#define SESSION_NOT_ACTIVATED   OpcUa_BadSessionNotActivated
+#define SESSION_ACTIVATED       OpcUa_Good
 
-#define RESET_SESSION_COUNTER	msec_counter=0;
+#define RESET_SESSION_COUNTER(session)  (session)->msec_counter=0;
 
 #define REVISED_SESSIONTIMEOUT  30000    
 
+//SESSION DATA  -----------------------------------------------
+typedef struct _SessionData
+{
+    struct _SessionData* Next;
+    struct _SessionData* Prev;
+
+    OpcUa_UInt32         securechannelId;
+    OpcUa_UInt32         session_flag;
+    OpcUa_Double         session_timeout;
+    OpcUa_String*        p_user_name;
+    OpcUa_Timer          Timer;
+    OpcUa_Double         msec_counter;
+    OpcUa_NodeId         SessionId;
+} SessionData;
 
 /*********************************************************************************************/
 /***********************                 Prototypes of services       ************************/
 /*********************************************************************************************/
 
-OpcUa_StatusCode		check_authentication_token										(const OpcUa_RequestHeader* );
-OpcUa_StatusCode		check_securechannelId											(OpcUa_Endpoint ,  OpcUa_Handle );
-OpcUa_StatusCode		check_useridentitytoken											(const OpcUa_ExtensionObject* );
-OpcUa_StatusCode		save_username												    (const OpcUa_ExtensionObject* );
-OpcUa_Void				username_free													(OpcUa_Void);
-OpcUa_StatusCode		check_username												    (const OpcUa_ExtensionObject*);
-OpcUa_StatusCode		check_password													(const OpcUa_ExtensionObject* );
-OpcUa_StatusCode		response_header_fill      										(OpcUa_ResponseHeader*  ,const OpcUa_RequestHeader*, OpcUa_StatusCode);
+SessionData*			UaTestServer_Session_Find                                       (const OpcUa_NodeId* a_SessionId);
+OpcUa_StatusCode		check_securechannelId											(SessionData*,OpcUa_Endpoint,OpcUa_Handle);
+OpcUa_StatusCode		check_useridentitytoken											(SessionData*,const OpcUa_ExtensionObject*);
+OpcUa_StatusCode		save_username												    (SessionData*,const OpcUa_ExtensionObject*);
+OpcUa_Void				username_free													(SessionData*);
+OpcUa_StatusCode		check_username												    (SessionData*,const OpcUa_ExtensionObject*);
+OpcUa_StatusCode		check_password													(const OpcUa_ExtensionObject*);
+OpcUa_StatusCode		response_header_fill      										(SessionData*,OpcUa_ResponseHeader*,const OpcUa_RequestHeader*, OpcUa_StatusCode);
 OpcUa_StatusCode		my_GetDateTimeDiffInSeconds32								    (OpcUa_DateTime  ,OpcUa_DateTime  , OpcUa_UInt32*  );
 OpcUa_StatusCode		getEndpoints													(OpcUa_Int32*  ,OpcUa_EndpointDescription** );
 OpcUa_StatusCode		initialize_value_attribute_of_variablenodes_variabletypenodes	(OpcUa_Void);

--- a/AnsiCSample/init_variables_of_addressspace.c
+++ b/AnsiCSample/init_variables_of_addressspace.c
@@ -44,9 +44,6 @@ OpcUa_StatusCode initialize_value_attribute_of_variablenodes_variabletypenodes(O
 {
 	extern _my_continuationpoint_		Continuation_Point_Data;
 	extern OpcUa_Int			Cont_Point_Counter;
-	extern OpcUa_UInt32			session_flag;
-	extern OpcUa_String*		p_user_name;
-	extern OpcUa_Double			session_timeout;
 	extern my_Variant			all_ValueAttribute_of_VariableTypeNodes_VariableNodes[];
 	OpcUa_InitializeStatus(OpcUa_Module_Server, "initialize_value_attribute_of_variablenodes_variabletypenodes");
 
@@ -54,9 +51,6 @@ OpcUa_StatusCode initialize_value_attribute_of_variablenodes_variabletypenodes(O
 	Continuation_Point_Data.Cont_Point_Identifier=0; /* None. */
 	OpcUa_BrowseDescription_Initialize(&Continuation_Point_Data.NodeToBrowse);
 	Cont_Point_Counter=0;
-	session_flag=SESSION_NOT_ACTIVATED;
-	p_user_name=OpcUa_Null;
-	session_timeout=REVISED_SESSIONTIMEOUT;
 /********************************/
 
 

--- a/AnsiCSample/readservice.c
+++ b/AnsiCSample/readservice.c
@@ -61,10 +61,7 @@ OpcUa_StatusCode my_Read(
 {
 	OpcUa_Int i,n;
 	OpcUa_Void* p_Node;
-	extern OpcUa_UInt32		securechannelId;
-	extern OpcUa_UInt32		session_flag;
-	extern OpcUa_Double		msec_counter;
-	extern OpcUa_String*	p_user_name;
+	SessionData* pSession = OpcUa_Null;
 
     OpcUa_InitializeStatus(OpcUa_Module_Server, "my_Read");
 
@@ -82,32 +79,27 @@ OpcUa_StatusCode my_Read(
 	*a_pNoOfDiagnosticInfos=0;
 	*a_pDiagnosticInfos=OpcUa_Null;
 
-	RESET_SESSION_COUNTER
-
- #ifndef NO_DEBUGGING_
+#ifndef NO_DEBUGGING_
 	MY_TRACE("\n\n\nREAD SERVICE==============================================\n");
-	if(p_user_name!=OpcUa_Null)
-		MY_TRACE("\nUser:%s\n",OpcUa_String_GetRawString(p_user_name)); 
 #endif /*_DEBUGGING_*/
-  
 
-	if(OpcUa_IsBad(session_flag))
+	pSession=UaTestServer_Session_Find(&a_pRequestHeader->AuthenticationToken);
+	OpcUa_GotoErrorIfNull(pSession,OpcUa_BadSecurityChecksFailed);
+
+	RESET_SESSION_COUNTER(pSession);
+
+#ifndef NO_DEBUGGING_
+	if(pSession->p_user_name!=OpcUa_Null)
+		MY_TRACE("\nUser: %s\n",OpcUa_String_GetRawString(pSession->p_user_name)); 
+#endif /*_DEBUGGING_*/
+
+	if(OpcUa_IsBad(pSession->session_flag))
 	{
 		/* Tell client that session is not active. */
 #ifndef NO_DEBUGGING_
 		MY_TRACE("\nSession not active\n"); 
 #endif /*_DEBUGGING_*/
 		uStatus=OpcUa_BadSessionNotActivated;
-		OpcUa_GotoError;
-	}
-
-	
-	uStatus=check_authentication_token(a_pRequestHeader);
-	if(OpcUa_IsBad(uStatus))
-	{
-#ifndef NO_DEBUGGING_
-		MY_TRACE("\nInvalid Authentication Token.\n"); 
-#endif /*_DEBUGGING_*/
 		OpcUa_GotoError;
 	}
 
@@ -401,7 +393,7 @@ OpcUa_StatusCode my_Read(
 
 
 	
-	uStatus = response_header_fill(a_pResponseHeader,a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(pSession,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -410,13 +402,11 @@ OpcUa_StatusCode my_Read(
 	MY_TRACE("\nSERVICE===END============================================\n\n\n"); 
 #endif /*_DEBUGGING_*/
 
-	RESET_SESSION_COUNTER
-
     OpcUa_ReturnStatusCode;
     OpcUa_BeginErrorHandling;
 
     
-	uStatus = response_header_fill(a_pResponseHeader,a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(pSession,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -424,7 +414,6 @@ OpcUa_StatusCode my_Read(
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\nSERVICE END (WITH ERROR)===========\n\n\n"); 
 #endif /*_DEBUGGING_*/
-	RESET_SESSION_COUNTER
     OpcUa_FinishErrorHandling;
 }
 

--- a/AnsiCSample/readservice.h
+++ b/AnsiCSample/readservice.h
@@ -31,9 +31,6 @@
 #define _readservice_
 
 
-#define RESET_SESSION_COUNTER	msec_counter=0; 
-
-
 OpcUa_StatusCode my_Read(
 							OpcUa_Endpoint             a_hEndpoint,
 							OpcUa_Handle               a_hContext,


### PR DESCRIPTION
Previously the sample server could not support multiple sessions,
and even attempting a second session could break an established
session.  This change moves session parameters to actually be
separate per session.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>