### PR TITLE
Use consistent node ID format in sample server traces

### DIFF
--- a/AnsiCSample/ansicservermain.c
+++ b/AnsiCSample/ansicservermain.c
@@ -1491,6 +1491,26 @@ OpcUa_StatusCode fill_server_variable(OpcUa_ApplicationDescription* p_Server)
 	OpcUa_FinishErrorHandling;
 }
 
+const OpcUa_CharA*
+getNodeIdString(const OpcUa_NodeId* a_NodeId)
+{
+    static char buffer[256];
+
+    switch (a_NodeId->IdentifierType)
+    {
+    case OpcUa_IdentifierType_Numeric:
+        snprintf(buffer, sizeof(buffer), "NS%d|Numeric|%d", a_NodeId->NamespaceIndex, a_NodeId->Identifier.Numeric);
+        break;
+    case OpcUa_IdentifierType_String:
+        snprintf(buffer, sizeof(buffer), "NS%d|String|%s", a_NodeId->NamespaceIndex, OpcUa_String_GetRawString(&a_NodeId->Identifier.String));
+        break;
+    default:
+        snprintf(buffer, sizeof(buffer), "NS%d|Other", a_NodeId->NamespaceIndex);
+        break;
+    }
+
+    return buffer;
+}
 
 /*********************************************************************************************/
 /***********************        Application Main Entry Point          ************************/

--- a/AnsiCSample/browseservice.c
+++ b/AnsiCSample/browseservice.c
@@ -130,7 +130,7 @@ OpcUa_StatusCode my_Browse(
 			OpcUa_BrowseResult_Initialize((*a_pResults+m));
 			pointer_to_node= search_for_node((a_pNodesToBrowse+m)->NodeId);
 			#ifndef NO_DEBUGGING_
-			MY_TRACE("\nBrowse by NodeId:|%d|  NamespaceIndex: |%d|\n",(a_pNodesToBrowse+m)->NodeId.Identifier.Numeric,(a_pNodesToBrowse+m)->NodeId.NamespaceIndex);
+			MY_TRACE("\nBrowse by NodeId: %s\n",getNodeIdString(&(a_pNodesToBrowse+m)->NodeId));
 			#endif /*_DEBUGGING_*/
 			if(pointer_to_node!=OpcUa_Null) /* Browse only existing nodes */
 			{
@@ -240,7 +240,7 @@ OpcUa_StatusCode browse(OpcUa_BrowseDescription* a_pNodesToBrowse,OpcUa_BrowseRe
 									OpcUa_GotoErrorIfBad(uStatus);
 									(a_pResults ->References+NoofRef)->NodeId.ServerIndex=0;
 									#ifndef NO_DEBUGGING_
-										MY_TRACE("|%d| |%d|\n",pointer_to_targetnode->NodeId.NamespaceIndex,pointer_to_targetnode->NodeId.Identifier.Numeric);
+										MY_TRACE("%s\n",getNodeIdString(&pointer_to_targetnode->NodeId));
 									#endif /*_DEBUGGING_*/
 									/**********************/
 	

--- a/AnsiCSample/general_header.h
+++ b/AnsiCSample/general_header.h
@@ -69,6 +69,7 @@ OpcUa_StatusCode		my_GetDateTimeDiffInSeconds32								    (OpcUa_DateTime  ,Opc
 OpcUa_StatusCode		getEndpoints													(OpcUa_Int32*  ,OpcUa_EndpointDescription** );
 OpcUa_StatusCode		initialize_value_attribute_of_variablenodes_variabletypenodes	(OpcUa_Void);
 OpcUa_StatusCode		fill_server_variable											(OpcUa_ApplicationDescription* );
+const OpcUa_CharA*		getNodeIdString							(const OpcUa_NodeId* a_NodeId);
 
  
 

--- a/AnsiCSample/readservice.c
+++ b/AnsiCSample/readservice.c
@@ -386,7 +386,7 @@ OpcUa_StatusCode my_Read(
 	MY_TRACE("\nnumber of nodes :%d\n",a_nNoOfNodesToRead);
 	for(i=0;i<a_nNoOfNodesToRead;i++)
 	{
-		MY_TRACE("\n|%d|, |%d| attributeId:%u\n",(a_pNodesToRead+i)->NodeId.NamespaceIndex,(a_pNodesToRead+i)->NodeId.Identifier.Numeric,(a_pNodesToRead+i)->AttributeId);
+		MY_TRACE("\n%s attributeId:%u\n",getNodeIdString(&(a_pNodesToRead+i)->NodeId),(a_pNodesToRead+i)->AttributeId);
 		
 	}
 #endif /*_DEBUGGING_*/


### PR DESCRIPTION
Also show correctly for non-numeric NodeIds

Signed-off-by: Dave Thaler <dthaler@microsoft.com>