### PR TITLE
Use consistent node ID format in sample server traces

### DIFF
--- a/AnsiCSample/ansicservermain.c
+++ b/AnsiCSample/ansicservermain.c
@@ -72,11 +72,6 @@
 #include "readservice.h"
 #include "general_header.h"
 
-#define SESSION_NOT_ACTIVATED	0x80270000
-#define	SESSION_ACTIVATED		0x00000000
-
-#define RESET_SESSION_COUNTER	msec_counter=0;
-
 #define REVISED_SESSIONTIMEOUT  30000    
 
 
@@ -88,15 +83,10 @@
 
 
 
+SessionData g_UaTestServer_SessionHead;
+
 char * UATESTSERVER_ENDPOINT_URL = "opc.tcp://localhost:4840";
 
-//SESSION DATA  -----------------------------------------------
-OpcUa_UInt32		securechannelId;
-OpcUa_UInt32		session_flag;
-OpcUa_Double		session_timeout;
-OpcUa_String*		p_user_name;
-OpcUa_Timer         Timer;
-OpcUa_Double		msec_counter;
 OpcUa_StatusCode OPCUA_DLLCALL Timer_Callback(  OpcUa_Void*             pvCallbackData, 
                                                 OpcUa_Timer             hTimer,
                                                 OpcUa_UInt32            msecElapsed);
@@ -309,6 +299,9 @@ OpcUa_StatusCode UaTestServer_Initialize(OpcUa_Void)
 {
 OpcUa_InitializeStatus(OpcUa_Module_Server, "UaTestServer_Initialize");
 
+    g_UaTestServer_SessionHead.Next = &g_UaTestServer_SessionHead;
+    g_UaTestServer_SessionHead.Prev = &g_UaTestServer_SessionHead;
+
     UaTestServer_g_pProxyStubConfiguration.bProxyStub_Trace_Enabled              = OpcUa_True;   //to deactivate Tracer set this variable to OpcUa_False.
     UaTestServer_g_pProxyStubConfiguration.uProxyStub_Trace_Level                = 0;
     UaTestServer_g_pProxyStubConfiguration.iSerializer_MaxAlloc                  = -1;
@@ -359,16 +352,81 @@ static OpcUa_Void UaTestServer_SecurityClear(OpcUa_Void)
 }
 
 /*===========================================================================================*/
+/** @brief Cleans up all resources for a given session.                                      */
+/*===========================================================================================*/
+OpcUa_Void UaTestServer_Session_Free(SessionData** a_ppSession)
+{
+    SessionData* pSession = *a_ppSession;
+
+    Continuation_Point_Data.Cont_Point_Identifier=0;
+    OpcUa_BrowseDescription_Clear(&Continuation_Point_Data.NodeToBrowse);
+
+    pSession->Next->Prev = pSession->Prev;
+    pSession->Prev->Next = pSession->Next;
+
+    if (pSession->p_user_name != OpcUa_Null)
+        username_free(pSession);
+    OpcUa_Timer_Delete(&pSession->Timer);
+    OpcUa_Memory_Free(pSession);
+    *a_ppSession = OpcUa_Null;
+}
+
+SessionData* UaTestServer_Session_Create(OpcUa_Void)
+{
+    SessionData* pSession = OpcUa_Memory_Alloc(sizeof(OpcUa_ApplicationDescription));
+    if (pSession == OpcUa_Null)
+    {
+        return OpcUa_Null;
+    }
+    memset(pSession, 0, sizeof(*pSession));
+
+    pSession->session_flag = SESSION_NOT_ACTIVATED;
+    pSession->session_timeout = REVISED_SESSIONTIMEOUT;
+
+    pSession->Next = g_UaTestServer_SessionHead.Next;
+    pSession->Prev = pSession->Next->Prev;
+    pSession->Next->Prev = pSession;
+    pSession->Prev->Next = pSession;
+
+    pSession->SessionId.Identifier.Numeric = ++g_UaTestServer_SessionHead.SessionId.Identifier.Numeric;
+    pSession->SessionId.IdentifierType = OpcUa_IdentifierType_Numeric;
+
+    return pSession;
+}
+
+SessionData* UaTestServer_Session_Find(const OpcUa_NodeId* a_SessionId)
+{
+    SessionData* pSession;
+
+OpcUa_InitializeStatus(OpcUa_Module_Server, "UaTestServer_Session_Find");
+
+    OpcUa_GotoErrorIfTrue(a_SessionId->IdentifierType != OpcUa_IdentifierType_Numeric, OpcUa_Bad);
+
+    for (pSession = g_UaTestServer_SessionHead.Next; pSession != &g_UaTestServer_SessionHead; pSession = pSession->Next)
+    {
+        if (pSession->SessionId.Identifier.Numeric == a_SessionId->Identifier.Numeric)
+        {
+            return pSession;
+        }
+    }
+
+OpcUa_BeginErrorHandling;
+    return OpcUa_Null;
+}
+
+/*===========================================================================================*/
 /** @brief Cleans up all resources from the demo application.                                */
 /*===========================================================================================*/
 OpcUa_Void UaTestServer_Clear(OpcUa_Void)
 {
-	OpcUa_BrowseDescription_Clear(&Continuation_Point_Data.NodeToBrowse);
+    OpcUa_BrowseDescription_Clear(&Continuation_Point_Data.NodeToBrowse);
 
-	if(p_user_name!=OpcUa_Null)
-		username_free();
-	
-	OpcUa_Timer_Delete(&Timer);
+    SessionData* pSession;
+    while (g_UaTestServer_SessionHead.Next != &g_UaTestServer_SessionHead)
+    {
+        pSession = g_UaTestServer_SessionHead.Next;
+        UaTestServer_Session_Free(&pSession);
+    }
 	
     UaTestServer_SecurityClear();
     OpcUa_ProxyStub_Clear();
@@ -510,7 +568,7 @@ OpcUa_StatusCode my_FindServers(
 
 	*a_pNoOfServers=1;
 
-	uStatus = response_header_fill(  a_pResponseHeader,  a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(OpcUa_Null,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -527,7 +585,7 @@ OpcUa_StatusCode my_FindServers(
 	}
 	
 	*a_pNoOfServers=0;
-	uStatus = response_header_fill(  a_pResponseHeader,  a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(OpcUa_Null,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -571,11 +629,6 @@ OpcUa_StatusCode myserverGetEndpointsService(
 	MY_TRACE("\n\n\nGETENDPOINTS SERVICE=================================\n"); 
 #endif /*_DEBUGGING_*/
   
-	session_flag=SESSION_NOT_ACTIVATED;
-	if(p_user_name!=OpcUa_Null)
-			username_free();
-	OpcUa_Timer_Delete(&Timer);
-
 	//need to pass CTT-test---------------------------------
 	for(i=0;i< a_nNoOfProfileUris;i++)
 	{
@@ -590,7 +643,7 @@ OpcUa_StatusCode myserverGetEndpointsService(
 	uStatus = getEndpoints(a_pNoOfEndpoints, a_ppEndpoints);
 	OpcUa_GotoErrorIfBad(uStatus);
 	
-	uStatus = response_header_fill(  a_pResponseHeader,  a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(OpcUa_Null,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -598,13 +651,12 @@ OpcUa_StatusCode myserverGetEndpointsService(
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\nSERVICE===END========================================\n\n\n"); 
 #endif /*_DEBUGGING_*/
-	RESET_SESSION_COUNTER
 
 	OpcUa_ReturnStatusCode;
     OpcUa_BeginErrorHandling;
 
    
-	uStatus =response_header_fill(  a_pResponseHeader,  a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(OpcUa_Null,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -612,7 +664,6 @@ OpcUa_StatusCode myserverGetEndpointsService(
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\nSERVICE END (WITH ERROR)===========\n\n\n"); 
 #endif /*_DEBUGGING_*/
-	RESET_SESSION_COUNTER
     OpcUa_FinishErrorHandling;
 }
 
@@ -644,7 +695,9 @@ OpcUa_StatusCode myserver_CreateSession(
     OpcUa_SignatureData*                a_pServerSignature,
     OpcUa_UInt32*                       a_pMaxRequestMessageSize)
  {
-	 OpcUa_InitializeStatus(OpcUa_Module_Server, "myserver_CreateSession");
+    SessionData* pSession = OpcUa_Null;
+
+    OpcUa_InitializeStatus(OpcUa_Module_Server, "myserver_CreateSession");
 
     /* Validate arguments. */
     OpcUa_ReturnErrorIfArgumentNull(a_hEndpoint);
@@ -669,14 +722,16 @@ OpcUa_StatusCode myserver_CreateSession(
     OpcUa_ReturnErrorIfArgumentNull(a_pServerSignature);
     OpcUa_ReturnErrorIfArgumentNull(a_pMaxRequestMessageSize);
 
-	
-	RESET_SESSION_COUNTER
-
 #ifndef NO_DEBUGGING_
-	MY_TRACE("\n\n\nCREATESESSION SERVICE=================================\n"); 
+    MY_TRACE("\n\n\nCREATESESSION SERVICE=================================\n"); 
 #endif /*_DEBUGGING_*/
 
-	if(OpcUa_IsGood(session_flag))
+    pSession = UaTestServer_Session_Create();
+    OpcUa_GotoErrorIfAllocFailed(pSession);
+    
+    RESET_SESSION_COUNTER(pSession);
+
+	if(OpcUa_IsGood(pSession->session_flag))
 	{
 		/* Tell client that no more sessions can be accepted. */
 		uStatus=OpcUa_BadTooManySessions;
@@ -686,19 +741,19 @@ OpcUa_StatusCode myserver_CreateSession(
 	// Set SessionTimeout --------------------------------------------------------------------
 		if(a_nRequestedSessionTimeout>0 && a_nRequestedSessionTimeout<REVISED_SESSIONTIMEOUT)  
 		{
-			session_timeout=a_nRequestedSessionTimeout/30;
+			pSession->session_timeout=a_nRequestedSessionTimeout/30;
 			*a_pRevisedSessionTimeout=a_nRequestedSessionTimeout;
 		}
 		else
 		{
-			session_timeout=REVISED_SESSIONTIMEOUT/30;
+			pSession->session_timeout=REVISED_SESSIONTIMEOUT/30;
 			*a_pRevisedSessionTimeout=REVISED_SESSIONTIMEOUT;
 		}
 	
 	//-----------------------------------------------------------------------------------------------
 		
 	// Set timer for SessionTimeout-----------------------------------
-	if(OpcUa_Timer_Create(  &Timer,1, &Timer_Callback, OpcUa_Null,OpcUa_Null)!= OpcUa_Good)
+	if(OpcUa_Timer_Create(&pSession->Timer,1,&Timer_Callback,OpcUa_Null,pSession)!=OpcUa_Good)
 	{
 		uStatus=OpcUa_BadInternalError;
 		OpcUa_GotoError;                                            
@@ -709,7 +764,7 @@ OpcUa_StatusCode myserver_CreateSession(
 	// Get securechannelId and store it. ----------------------------------------------------------
 		uStatus=OpcUa_Endpoint_GetMessageSecureChannelId(  a_hEndpoint,
 														    a_hContext,
-															&securechannelId);
+															&pSession->securechannelId);
 		if(OpcUa_IsBad(uStatus))
 		{
 			uStatus=OpcUa_BadInternalError;
@@ -719,10 +774,7 @@ OpcUa_StatusCode myserver_CreateSession(
 
 
 	// Make sessionId and authenticationToken known to the client.---------------------------------
-		a_pSessionId->Identifier.Numeric=12345;
-		a_pSessionId->IdentifierType=OpcUa_IdentifierType_Numeric;
-		a_pSessionId->NamespaceIndex=0;
-
+		*a_pSessionId = pSession->SessionId;
 		*a_pAuthenticationToken=*a_pSessionId;
 	//----------------------------------------------------------------------------------------------
 
@@ -745,7 +797,7 @@ OpcUa_StatusCode myserver_CreateSession(
 	uStatus = getEndpoints(a_pNoOfServerEndpoints, a_pServerEndpoints);
 	OpcUa_GotoErrorIfBad(uStatus);
 	
-	uStatus = response_header_fill(a_pResponseHeader,a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(pSession,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -753,13 +805,13 @@ OpcUa_StatusCode myserver_CreateSession(
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\nSERVICE===END============================================\n\n\n"); 
 #endif /*_DEBUGGING_*/
-	RESET_SESSION_COUNTER
+	RESET_SESSION_COUNTER(pSession);
 
 	OpcUa_ReturnStatusCode;
 	OpcUa_BeginErrorHandling;
     
     
-	uStatus=response_header_fill(  a_pResponseHeader,  a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(pSession,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -767,7 +819,7 @@ OpcUa_StatusCode myserver_CreateSession(
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\nSERVICE END (WITH ERROR)===========\n\n\n"); 
 #endif /*_DEBUGGING_*/
-	RESET_SESSION_COUNTER
+	RESET_SESSION_COUNTER(pSession);
 	OpcUa_FinishErrorHandling;
  }
 
@@ -793,6 +845,8 @@ OpcUa_StatusCode my_ActivateSession(
     OpcUa_Int32*                           a_pNoOfDiagnosticInfos,
     OpcUa_DiagnosticInfo**                 a_pDiagnosticInfos)
 {
+    SessionData* pSession = OpcUa_Null;
+
     OpcUa_InitializeStatus(OpcUa_Module_Server, "my_ActivateSession");
 
     /* Validate arguments. */
@@ -809,34 +863,24 @@ OpcUa_StatusCode my_ActivateSession(
     OpcUa_ReturnErrorIfArrayArgumentNull(a_pNoOfResults, a_pResults);
     OpcUa_ReturnErrorIfArrayArgumentNull(a_pNoOfDiagnosticInfos, a_pDiagnosticInfos);
 
-	RESET_SESSION_COUNTER
-
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\n\n\nACTIVATESESSION SERVICE===============================\n"); 
 #endif /*_DEBUGGING_*/
 	
-	/* Check Authentication Token. ******************************************************************/
-	uStatus=check_authentication_token(a_pRequestHeader);
-	if(OpcUa_IsBad(uStatus))
-	{
-#ifndef NO_DEBUGGING_
-		MY_TRACE("\nAuthentication Token ungültig.\n"); 
-#endif /*_DEBUGGING_*/
-		uStatus = OpcUa_BadSecurityChecksFailed;
-		OpcUa_GotoError;
-	}
-    /**********************************************************************************************/
+	pSession = UaTestServer_Session_Find(&a_pRequestHeader->AuthenticationToken);
+	OpcUa_GotoErrorIfNull(pSession, OpcUa_BadSecurityChecksFailed);
 
+	RESET_SESSION_COUNTER(pSession);
 
 	/* Check UserIdentityToken. ******************************************************************/
-	uStatus=check_useridentitytoken(a_pUserIdentityToken);
+	uStatus=check_useridentitytoken(pSession,a_pUserIdentityToken);
 	OpcUa_GotoErrorIfBad(uStatus)
     /********************************************************************************************/
 	
 	
-    if(OpcUa_IsBad(session_flag)) // Session not yet activated.
+	if(OpcUa_IsBad(pSession->session_flag)) // Session not yet activated.
 	{
-		uStatus=check_securechannelId(a_hEndpoint,a_hContext);
+		uStatus=check_securechannelId(pSession,a_hEndpoint,a_hContext);
 		if(OpcUa_IsBad(uStatus))
 		{
 			uStatus=OpcUa_BadSecurityChecksFailed;
@@ -848,7 +892,7 @@ OpcUa_StatusCode my_ActivateSession(
 	{
 		uStatus=OpcUa_Endpoint_GetMessageSecureChannelId(  a_hEndpoint,
 															a_hContext,
-															&securechannelId);
+															&pSession->securechannelId);
 		if(OpcUa_IsBad(uStatus))
 		{
 			uStatus =OpcUa_BadInternalError;
@@ -856,15 +900,15 @@ OpcUa_StatusCode my_ActivateSession(
 			OpcUa_GotoError;                                            
 		}
 		#ifndef NO_DEBUGGING_
-			MY_TRACE("\nNew Securechannel(%d) assigned to the current session\n",securechannelId);
+			MY_TRACE("\nNew Securechannel(%d) assigned to the current session\n",pSession->securechannelId);
 		#endif /*_DEBUGGING_*/
 	}
 
-	session_flag=SESSION_ACTIVATED;
+	pSession->session_flag=SESSION_ACTIVATED;
 
 #ifndef NO_DEBUGGING_
-	if(p_user_name!=OpcUa_Null)
-		MY_TRACE("\nUser(%s) logged in\n",OpcUa_String_GetRawString(p_user_name)); 
+	if(pSession->p_user_name!=OpcUa_Null)
+		MY_TRACE("\nUser(%s) logged in\n",OpcUa_String_GetRawString(pSession->p_user_name)); 
 #endif /*_DEBUGGING_*/
 
 
@@ -885,7 +929,7 @@ OpcUa_StatusCode my_ActivateSession(
 //-----------------------------------------------------------
 
 	
-	uStatus = response_header_fill(a_pResponseHeader,a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(pSession,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -893,13 +937,13 @@ OpcUa_StatusCode my_ActivateSession(
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\nSERVICE===END============================================\n\n\n"); 
 #endif /*_DEBUGGING_*/
-	RESET_SESSION_COUNTER
+	RESET_SESSION_COUNTER(pSession);
 
 	OpcUa_ReturnStatusCode;
     OpcUa_BeginErrorHandling;
 
   
-	uStatus = response_header_fill(a_pResponseHeader,a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(pSession,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -907,7 +951,6 @@ OpcUa_StatusCode my_ActivateSession(
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\nSERVICE END (WITH ERROR)===========\n\n\n"); 
 #endif /*_DEBUGGING_*/
-	RESET_SESSION_COUNTER
     OpcUa_FinishErrorHandling;
 }
 
@@ -921,6 +964,7 @@ OpcUa_StatusCode my_CloseSession(
     OpcUa_Boolean              a_bDeleteSubscriptions,
     OpcUa_ResponseHeader*      a_pResponseHeader)
 {
+    SessionData* pSession = OpcUa_Null;
     OpcUa_InitializeStatus(OpcUa_Module_Server, "my_CloseSession");
 
     /* Validate arguments. */
@@ -930,61 +974,19 @@ OpcUa_StatusCode my_CloseSession(
     OpcUa_ReferenceParameter(a_bDeleteSubscriptions);
     OpcUa_ReturnErrorIfArgumentNull(a_pResponseHeader);
 
-	RESET_SESSION_COUNTER
-	
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\n\n\nCLOSESESSION SERVICE========================================\n"); 
 #endif /*_DEBUGGING_*/
 
-	if(OpcUa_IsBad(session_flag))
-	{
-		/* Tell client that session is closed. */
-		if(p_user_name!=OpcUa_Null)
-			username_free();
+	pSession=UaTestServer_Session_Find(&a_pRequestHeader->AuthenticationToken);
+	OpcUa_GotoErrorIfNull(pSession,OpcUa_BadSecurityChecksFailed);
 
-		OpcUa_Timer_Delete(&Timer);
-		
-#ifndef NO_DEBUGGING_
-		MY_TRACE("\nSession already closed!\n"); 
-#endif /*_DEBUGGING_*/
-		uStatus = OpcUa_BadSessionIdInvalid;
-		OpcUa_GotoError;
-	}
-
-	uStatus=check_authentication_token(a_pRequestHeader);
-	if(OpcUa_IsBad(uStatus))
-	{
-#ifndef NO_DEBUGGING_
-		MY_TRACE("\nInvalid Authentication Token.\n"); 
-#endif /*_DEBUGGING_*/
-		uStatus =OpcUa_BadSecurityChecksFailed;
-		OpcUa_GotoError;
-	}
-    
-	
-	OpcUa_Timer_Delete(&Timer);
-	
-	Continuation_Point_Data.Cont_Point_Identifier=0;
-	OpcUa_BrowseDescription_Clear(&Continuation_Point_Data.NodeToBrowse);
-
-	session_flag=SESSION_NOT_ACTIVATED;
-
-#ifndef NO_DEBUGGING_
-	if(p_user_name!=OpcUa_Null)
-		MY_TRACE("\nUser(%s) logged out\n",OpcUa_String_GetRawString(p_user_name)); 
-#endif /*_DEBUGGING_*/
-	if(p_user_name!=OpcUa_Null)
-		username_free();
-
-#ifndef NO_DEBUGGING_
-	MY_TRACE("\nSession closed!\n"); 
-#endif /*_DEBUGGING_*/
-	
-	uStatus = response_header_fill(a_pResponseHeader,a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(pSession,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
 	}
+	UaTestServer_Session_Free(&pSession);
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\nSERVICE===END============================================\n\n\n"); 
 #endif /*_DEBUGGING_*/
@@ -993,12 +995,10 @@ OpcUa_StatusCode my_CloseSession(
 	*(all_ValueAttribute_of_VariableTypeNodes_VariableNodes[8].Value.Array.Value.DoubleArray+0)=3.14;
 	//---------------------------------
 
-	RESET_SESSION_COUNTER
-
     OpcUa_ReturnStatusCode;
     OpcUa_BeginErrorHandling;
 
-    uStatus =response_header_fill(a_pResponseHeader,a_pRequestHeader,uStatus);
+    uStatus=response_header_fill(OpcUa_Null,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -1006,7 +1006,6 @@ OpcUa_StatusCode my_CloseSession(
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\nSERVICE END (WITH ERROR)===========\n\n\n"); 
 #endif /*_DEBUGGING_*/
-	RESET_SESSION_COUNTER
     OpcUa_FinishErrorHandling;
 }
 
@@ -1085,31 +1084,31 @@ OpcUa_FinishErrorHandling;
 
 
 
-OpcUa_StatusCode save_username(const OpcUa_ExtensionObject* p_UserIdentityToken)
+OpcUa_StatusCode save_username(SessionData* a_pSession,const OpcUa_ExtensionObject* p_UserIdentityToken)
 {
 	OpcUa_StatusCode        uStatus     = OpcUa_Good;
-	OpcUa_ReturnErrorIfArgumentNull(p_UserIdentityToken)
-	p_user_name=OpcUa_Alloc(sizeof(OpcUa_String));
-	OpcUa_ReturnErrorIfAllocFailed(p_user_name)
-	uStatus=OpcUa_String_StrnCpy(p_user_name,&((OpcUa_UserNameIdentityToken*)p_UserIdentityToken->Body.EncodeableObject.Object)->UserName,OPCUA_STRING_LENDONTCARE);
+	OpcUa_ReturnErrorIfArgumentNull(p_UserIdentityToken);
+	a_pSession->p_user_name=OpcUa_Alloc(sizeof(OpcUa_String));
+	OpcUa_ReturnErrorIfAllocFailed(a_pSession->p_user_name);
+	uStatus=OpcUa_String_StrnCpy(a_pSession->p_user_name,&((OpcUa_UserNameIdentityToken*)p_UserIdentityToken->Body.EncodeableObject.Object)->UserName,OPCUA_STRING_LENDONTCARE);
 	return uStatus;
 }
 
-OpcUa_Void username_free(OpcUa_Void)
+OpcUa_Void username_free(SessionData* a_pSession)
 {
-	OpcUa_String_Delete(&p_user_name);
+	OpcUa_String_Delete(&a_pSession->p_user_name);
 }
 
-OpcUa_StatusCode check_username(const OpcUa_ExtensionObject* p_UserIdentityToken)
+OpcUa_StatusCode check_username(SessionData* a_pSession,const OpcUa_ExtensionObject* p_UserIdentityToken)
 {
 	OpcUa_StatusCode        uStatus     = OpcUa_Good;
-	OpcUa_ReturnErrorIfArgumentNull(p_UserIdentityToken)
-	OpcUa_ReturnErrorIfArgumentNull(p_user_name)
-	if(OpcUa_String_StrLen(p_user_name)!=OpcUa_String_StrLen(&((OpcUa_UserNameIdentityToken*)p_UserIdentityToken->Body.EncodeableObject.Object)->UserName))
+	OpcUa_ReturnErrorIfArgumentNull(p_UserIdentityToken);
+	OpcUa_ReturnErrorIfArgumentNull(a_pSession);
+	if(OpcUa_String_StrLen(a_pSession->p_user_name)!=OpcUa_String_StrLen(&((OpcUa_UserNameIdentityToken*)p_UserIdentityToken->Body.EncodeableObject.Object)->UserName))
 	{
 		return OpcUa_Bad;
 	}
-	if( (OpcUa_String_StrnCmp(   p_user_name, 
+	if( (OpcUa_String_StrnCmp(   a_pSession->p_user_name, 
 								&((OpcUa_UserNameIdentityToken*)p_UserIdentityToken->Body.EncodeableObject.Object)->UserName, 
 								OPCUA_STRING_LENDONTCARE, 
 								OpcUa_False))==0)
@@ -1157,11 +1156,11 @@ OpcUa_StatusCode check_password(const OpcUa_ExtensionObject* p_UserIdentityToken
 	return uStatus;
 }
 
-OpcUa_StatusCode check_useridentitytoken(const OpcUa_ExtensionObject* p_UserIdentityToken)
+OpcUa_StatusCode check_useridentitytoken(SessionData* a_pSession,const OpcUa_ExtensionObject* p_UserIdentityToken)
 {
 	OpcUa_InitializeStatus(OpcUa_Module_Server, "check_useridentitytoken");
 
-	OpcUa_ReturnErrorIfArgumentNull(p_UserIdentityToken)
+	OpcUa_ReturnErrorIfArgumentNull(p_UserIdentityToken);
 	
 	//to pass CTT-test-------------------
 	if((OpcUa_UInt32)(p_UserIdentityToken->Encoding)== OpcUa_ExtensionObjectEncoding_None)
@@ -1180,9 +1179,9 @@ OpcUa_StatusCode check_useridentitytoken(const OpcUa_ExtensionObject* p_UserIden
 	
 	if((OpcUa_UInt32)(p_UserIdentityToken->TypeId.NodeId.Identifier.Numeric)== OpcUaId_UserNameIdentityToken_Encoding_DefaultBinary)
 	{
-			if(p_user_name!=OpcUa_Null)
+			if(a_pSession->p_user_name!=OpcUa_Null)
 			{
-				uStatus=check_username(p_UserIdentityToken);
+				uStatus=check_username(a_pSession,p_UserIdentityToken);
 				if(OpcUa_IsGood(uStatus))
 				{
 					uStatus=check_password(p_UserIdentityToken);
@@ -1210,7 +1209,7 @@ OpcUa_StatusCode check_useridentitytoken(const OpcUa_ExtensionObject* p_UserIden
 			}
 			else
 			{
-				uStatus=save_username(p_UserIdentityToken);
+				uStatus=save_username(a_pSession,p_UserIdentityToken);
 				OpcUa_ReturnErrorIfBad(uStatus)
 				uStatus=check_password(p_UserIdentityToken);
 				if(OpcUa_IsBad(uStatus))
@@ -1238,7 +1237,7 @@ OpcUa_StatusCode check_useridentitytoken(const OpcUa_ExtensionObject* p_UserIden
 	OpcUa_FinishErrorHandling;
 }
 
-OpcUa_StatusCode check_securechannelId( OpcUa_Endpoint a_hEndpoint,  OpcUa_Handle a_hContext)
+OpcUa_StatusCode check_securechannelId(SessionData* a_pSession,OpcUa_Endpoint a_hEndpoint,OpcUa_Handle a_hContext)
 {
 	OpcUa_UInt32* p_securechannelId;
 
@@ -1258,7 +1257,7 @@ OpcUa_StatusCode check_securechannelId( OpcUa_Endpoint a_hEndpoint,  OpcUa_Handl
 		uStatus=OpcUa_Good;
 		OpcUa_GotoError 
 	}
-	if(*p_securechannelId==securechannelId)
+	if(*p_securechannelId==a_pSession->securechannelId)
 	{
 		OpcUa_Free(p_securechannelId);
 		uStatus=OpcUa_Good;
@@ -1275,42 +1274,21 @@ OpcUa_StatusCode check_securechannelId( OpcUa_Endpoint a_hEndpoint,  OpcUa_Handl
 	OpcUa_FinishErrorHandling;
 }
 
-OpcUa_StatusCode check_authentication_token (const OpcUa_RequestHeader* a_pRequestHeader)
-{
-	OpcUa_InitializeStatus(OpcUa_Module_Server, "check_authentication_token");
-
-	if(a_pRequestHeader==OpcUa_Null)
-	{
-		uStatus=OpcUa_BadSessionIdInvalid;
-		OpcUa_GotoError
-	}
-	if((a_pRequestHeader->AuthenticationToken.IdentifierType==OpcUa_IdentifierType_Numeric && a_pRequestHeader->AuthenticationToken.NamespaceIndex==0) && (a_pRequestHeader->AuthenticationToken.Identifier.Numeric==12345))
-	{
-		uStatus=OpcUa_Good;
-	}
-	else
-	{
-		uStatus=OpcUa_BadSessionIdInvalid;
-	}
-	return uStatus;
-	OpcUa_BeginErrorHandling;
-    
-    
-	OpcUa_FinishErrorHandling;
-
-}
-
 OpcUa_StatusCode OPCUA_DLLCALL Timer_Callback(  OpcUa_Void*             pvCallbackData, 
                                                 OpcUa_Timer             hTimer,
                                                 OpcUa_UInt32            msecElapsed)
 {
-	msec_counter++;
-	if(msec_counter>session_timeout)
+	SessionData* pSession = (SessionData*)pvCallbackData;
+	OpcUa_ReferenceParameter(hTimer);
+	OpcUa_ReferenceParameter(msecElapsed);
+
+	pSession->msec_counter++;
+	if(pSession->msec_counter>pSession->session_timeout)
 	{
-		session_flag=SESSION_NOT_ACTIVATED;
-		OpcUa_Timer_Delete(&Timer);
-		if(p_user_name!=OpcUa_Null)
-			username_free();
+		pSession->session_flag=SESSION_NOT_ACTIVATED;
+		OpcUa_Timer_Delete(&pSession->Timer);
+		if(pSession->p_user_name!=OpcUa_Null)
+			username_free(pSession);
 		#ifndef NO_DEBUGGING_
 		MY_TRACE("\nSession expired!!!\n"); 
 		#endif /*_DEBUGGING_*/
@@ -1325,7 +1303,7 @@ OpcUa_StatusCode OPCUA_DLLCALL Timer_Callback(  OpcUa_Void*             pvCallba
 
 
 
-OpcUa_StatusCode response_header_fill(OpcUa_ResponseHeader*  a_pResponseHeader,const OpcUa_RequestHeader* a_pRequestHeader,OpcUa_StatusCode  Status)
+OpcUa_StatusCode response_header_fill(SessionData* a_pSession,OpcUa_ResponseHeader* a_pResponseHeader,const OpcUa_RequestHeader* a_pRequestHeader,OpcUa_StatusCode Status)
 {
 	OpcUa_StatusCode    uStatus     = OpcUa_Good;
 	OpcUa_UInt32		diff;
@@ -1337,28 +1315,29 @@ OpcUa_StatusCode response_header_fill(OpcUa_ResponseHeader*  a_pResponseHeader,c
 	OpcUa_ResponseHeader_Initialize(a_pResponseHeader);
 	a_pResponseHeader->RequestHandle=a_pRequestHeader->RequestHandle;
 
-	uStatus=my_GetDateTimeDiffInSeconds32( (a_pRequestHeader->Timestamp),(OpcUa_DateTime_UtcNow()), &diff);
+	a_pResponseHeader->Timestamp=OpcUa_DateTime_UtcNow();
+	uStatus=my_GetDateTimeDiffInSeconds32( (a_pRequestHeader->Timestamp),(a_pResponseHeader->Timestamp), &diff);
 	if(OpcUa_IsGood(uStatus))
 	{
-		
-		if((OpcUa_UInt32)session_timeout<diff )
+		if(a_pSession!=OpcUa_Null)
 		{
-			#ifndef NO_DEBUGGING_
-			MY_TRACE("\nService runtime:%u msec (TimeOut)\n", diff);
-			#endif /*_DEBUGGING_*/
-			a_pResponseHeader->ServiceResult=OpcUa_BadTimeout;
+			if((OpcUa_UInt32)a_pSession->session_timeout<diff)
+			{
+				#ifndef NO_DEBUGGING_
+				MY_TRACE("\nService runtime:%u msec (TimeOut)\n", diff);
+			    	#endif /*_DEBUGGING_*/
+				Status=OpcUa_BadTimeout;
+			}
+			else
+			{
+				#ifndef NO_DEBUGGING_
+				MY_TRACE("\nService runtime:%u msec ServiceTimeOut:%.0f msec\n",diff,a_pSession->session_timeout);
+				#endif /*_DEBUGGING_*/
+			}
 		}
-		else
-		{
-			#ifndef NO_DEBUGGING_
-			MY_TRACE("\nService runtime:%u msec ServiceTimeOut:%.0f msec\n", diff, session_timeout);
-			#endif /*_DEBUGGING_*/
-			a_pResponseHeader->ServiceResult=Status;
-		}
+		a_pResponseHeader->ServiceResult=Status;
 	}
 	
-	a_pResponseHeader->Timestamp=OpcUa_DateTime_UtcNow();
-
 	if((a_pRequestHeader->ReturnDiagnostics) != 0x00000000) // If diagnostic information requested.
 	{
 		/* No diagnostic information available. */
@@ -1514,6 +1493,26 @@ OpcUa_StatusCode fill_server_variable(OpcUa_ApplicationDescription* p_Server)
 	OpcUa_FinishErrorHandling;
 }
 
+const OpcUa_CharA*
+getNodeIdString(const OpcUa_NodeId* a_NodeId)
+{
+    static char buffer[256];
+
+    switch (a_NodeId->IdentifierType)
+    {
+    case OpcUa_IdentifierType_Numeric:
+        snprintf(buffer, sizeof(buffer), "NS%d|Numeric|%d", a_NodeId->NamespaceIndex, a_NodeId->Identifier.Numeric);
+        break;
+    case OpcUa_IdentifierType_String:
+        snprintf(buffer, sizeof(buffer), "NS%d|String|%s", a_NodeId->NamespaceIndex, OpcUa_String_GetRawString(&a_NodeId->Identifier.String));
+        break;
+    default:
+        snprintf(buffer, sizeof(buffer), "NS%d|Other", a_NodeId->NamespaceIndex);
+        break;
+    }
+
+    return buffer;
+}
 
 /*********************************************************************************************/
 /***********************        Application Main Entry Point          ************************/

--- a/AnsiCSample/browseservice.c
+++ b/AnsiCSample/browseservice.c
@@ -66,13 +66,10 @@ OpcUa_StatusCode my_Browse(
 {
 	_BaseAttribute_*		pointer_to_node;
 	OpcUa_Int				m;
-	extern OpcUa_UInt32		securechannelId;
-	extern OpcUa_UInt32		session_flag;
-	extern OpcUa_Double		msec_counter;
-	extern OpcUa_String*	p_user_name;
+	SessionData*			pSession = OpcUa_Null;
 	extern OpcUa_UInt32		max_ref_per_node;
 
-    OpcUa_InitializeStatus(OpcUa_Module_Server, "OpcUa_ServerApi_Browse");
+    OpcUa_InitializeStatus(OpcUa_Module_Server, "my_Browse");
 
     /* validate arguments. */
     OpcUa_ReturnErrorIfArgumentNull(a_hEndpoint);
@@ -88,32 +85,27 @@ OpcUa_StatusCode my_Browse(
 	*a_pNoOfDiagnosticInfos=0;
 	*a_pDiagnosticInfos=OpcUa_Null;
 		 
-	RESET_SESSION_COUNTER
-
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\n\n\nBROWSE SERVICE=============================================\n");
-	if(p_user_name!=OpcUa_Null)
-		MY_TRACE("\nUser:%s\n",OpcUa_String_GetRawString(p_user_name));  
 #endif /*_DEBUGGING_*/
 
+	pSession=UaTestServer_Session_Find(&a_pRequestHeader->AuthenticationToken);
+	OpcUa_GotoErrorIfNull(pSession,OpcUa_BadSecurityChecksFailed);
 
-	if(OpcUa_IsBad(session_flag))
+	RESET_SESSION_COUNTER(pSession);
+
+#ifndef NO_DEBUGGING_
+	if(pSession->p_user_name!=OpcUa_Null)
+		MY_TRACE("\nUser:%s\n",OpcUa_String_GetRawString(pSession->p_user_name));  
+#endif /*_DEBUGGING_*/
+
+	if(OpcUa_IsBad(pSession->session_flag))
 	{
 		/* Tell client that session is not active. */
 #ifndef NO_DEBUGGING_
 		MY_TRACE("\nSession not active\n"); 
 #endif /*_DEBUGGING_*/
 		uStatus=OpcUa_BadSessionNotActivated;
-		OpcUa_GotoError;
-	}
-
-	
-	uStatus=check_authentication_token(a_pRequestHeader);
-	if(OpcUa_IsBad(uStatus))
-	{
-#ifndef NO_DEBUGGING_
-		MY_TRACE("\nAuthentication Token ungültig.\n"); 
-#endif /*_DEBUGGING_*/
 		OpcUa_GotoError;
 	}
 
@@ -138,7 +130,7 @@ OpcUa_StatusCode my_Browse(
 			OpcUa_BrowseResult_Initialize((*a_pResults+m));
 			pointer_to_node= search_for_node((a_pNodesToBrowse+m)->NodeId);
 			#ifndef NO_DEBUGGING_
-			MY_TRACE("\nBrowse by NodeId:|%d|  NamespaceIndex: |%d|\n",(a_pNodesToBrowse+m)->NodeId.Identifier.Numeric,(a_pNodesToBrowse+m)->NodeId.NamespaceIndex);
+			MY_TRACE("\nBrowse by NodeId: %s\n",getNodeIdString(&(a_pNodesToBrowse+m)->NodeId));
 			#endif /*_DEBUGGING_*/
 			if(pointer_to_node!=OpcUa_Null) /* Browse only existing nodes */
 			{
@@ -152,7 +144,7 @@ OpcUa_StatusCode my_Browse(
 		} /* End: (check all start nodes) */
 
 	
-	uStatus = response_header_fill(a_pResponseHeader,a_pRequestHeader,uStatus);
+	uStatus = response_header_fill(pSession,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -161,13 +153,11 @@ OpcUa_StatusCode my_Browse(
 	MY_TRACE("\nSERVICE===END============================================\n\n\n"); 
 #endif /*_DEBUGGING_*/
 
-	RESET_SESSION_COUNTER
-
     OpcUa_ReturnStatusCode;
     OpcUa_BeginErrorHandling;
 
    *a_pNoOfResults=0;
-	uStatus=response_header_fill(a_pResponseHeader,a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(pSession,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -175,7 +165,6 @@ OpcUa_StatusCode my_Browse(
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\nSERVICE END (WITH ERROR)===========\n\n\n"); 
 #endif /*_DEBUGGING_*/
-	RESET_SESSION_COUNTER
     OpcUa_FinishErrorHandling;
 }
 
@@ -251,7 +240,7 @@ OpcUa_StatusCode browse(OpcUa_BrowseDescription* a_pNodesToBrowse,OpcUa_BrowseRe
 									OpcUa_GotoErrorIfBad(uStatus);
 									(a_pResults ->References+NoofRef)->NodeId.ServerIndex=0;
 									#ifndef NO_DEBUGGING_
-										MY_TRACE("|%d| |%d|\n",pointer_to_targetnode->NodeId.NamespaceIndex,pointer_to_targetnode->NodeId.Identifier.Numeric);
+										MY_TRACE("%s\n",getNodeIdString(&pointer_to_targetnode->NodeId));
 									#endif /*_DEBUGGING_*/
 									/**********************/
 	

--- a/AnsiCSample/browseservice.h
+++ b/AnsiCSample/browseservice.h
@@ -36,8 +36,6 @@ OPCUA_DECLARE_GENERIC_COMPARE(NodeId)
 OPCUA_DECLARE_GENERIC_COPY(NodeId)
 OPCUA_DECLARE_GENERIC_COPY(BrowseDescription)
 
-#define RESET_SESSION_COUNTER	msec_counter=0;
-
 typedef struct
 {
 	OpcUa_Int			Cont_Point_Identifier; /* Non-zero ID if in use, or 0 if free to use */
@@ -90,11 +88,5 @@ OpcUa_Boolean			check_Mask					(OpcUa_UInt32 ,OpcUa_UInt32 );
 OpcUa_Boolean			check_dir					(OpcUa_BrowseDirection ,_ReferenceNode_* );
 
 OpcUa_Boolean			need_continuationpoint		(OpcUa_BrowseDescription* ,OpcUa_Int);
-
-OpcUa_StatusCode		check_authentication_token	(const OpcUa_RequestHeader* );
-
-OpcUa_StatusCode		response_header_fill	    (OpcUa_ResponseHeader*  ,const OpcUa_RequestHeader*, OpcUa_StatusCode);
-
-
 
 #endif /*_browseservice_*/

--- a/AnsiCSample/general_header.h
+++ b/AnsiCSample/general_header.h
@@ -31,30 +31,45 @@
 #define _GENERAL_HEADER_
 
 
-#define SESSION_NOT_ACTIVATED	0x80270000
-#define	SESSION_ACTIVATED		0x00000000
+#define SESSION_NOT_ACTIVATED   OpcUa_BadSessionNotActivated
+#define SESSION_ACTIVATED       OpcUa_Good
 
-#define RESET_SESSION_COUNTER	msec_counter=0;
+#define RESET_SESSION_COUNTER(session)  (session)->msec_counter=0;
 
 #define REVISED_SESSIONTIMEOUT  30000    
 
+//SESSION DATA  -----------------------------------------------
+typedef struct _SessionData
+{
+    struct _SessionData* Next;
+    struct _SessionData* Prev;
+
+    OpcUa_UInt32         securechannelId;
+    OpcUa_UInt32         session_flag;
+    OpcUa_Double         session_timeout;
+    OpcUa_String*        p_user_name;
+    OpcUa_Timer          Timer;
+    OpcUa_Double         msec_counter;
+    OpcUa_NodeId         SessionId;
+} SessionData;
 
 /*********************************************************************************************/
 /***********************                 Prototypes of services       ************************/
 /*********************************************************************************************/
 
-OpcUa_StatusCode		check_authentication_token										(const OpcUa_RequestHeader* );
-OpcUa_StatusCode		check_securechannelId											(OpcUa_Endpoint ,  OpcUa_Handle );
-OpcUa_StatusCode		check_useridentitytoken											(const OpcUa_ExtensionObject* );
-OpcUa_StatusCode		save_username												    (const OpcUa_ExtensionObject* );
-OpcUa_Void				username_free													(OpcUa_Void);
-OpcUa_StatusCode		check_username												    (const OpcUa_ExtensionObject*);
-OpcUa_StatusCode		check_password													(const OpcUa_ExtensionObject* );
-OpcUa_StatusCode		response_header_fill      										(OpcUa_ResponseHeader*  ,const OpcUa_RequestHeader*, OpcUa_StatusCode);
+SessionData*			UaTestServer_Session_Find                                       (const OpcUa_NodeId* a_SessionId);
+OpcUa_StatusCode		check_securechannelId											(SessionData*,OpcUa_Endpoint,OpcUa_Handle);
+OpcUa_StatusCode		check_useridentitytoken											(SessionData*,const OpcUa_ExtensionObject*);
+OpcUa_StatusCode		save_username												    (SessionData*,const OpcUa_ExtensionObject*);
+OpcUa_Void				username_free													(SessionData*);
+OpcUa_StatusCode		check_username												    (SessionData*,const OpcUa_ExtensionObject*);
+OpcUa_StatusCode		check_password													(const OpcUa_ExtensionObject*);
+OpcUa_StatusCode		response_header_fill      										(SessionData*,OpcUa_ResponseHeader*,const OpcUa_RequestHeader*, OpcUa_StatusCode);
 OpcUa_StatusCode		my_GetDateTimeDiffInSeconds32								    (OpcUa_DateTime  ,OpcUa_DateTime  , OpcUa_UInt32*  );
 OpcUa_StatusCode		getEndpoints													(OpcUa_Int32*  ,OpcUa_EndpointDescription** );
 OpcUa_StatusCode		initialize_value_attribute_of_variablenodes_variabletypenodes	(OpcUa_Void);
 OpcUa_StatusCode		fill_server_variable											(OpcUa_ApplicationDescription* );
+const OpcUa_CharA*		getNodeIdString							(const OpcUa_NodeId* a_NodeId);
 
  
 

--- a/AnsiCSample/init_variables_of_addressspace.c
+++ b/AnsiCSample/init_variables_of_addressspace.c
@@ -44,9 +44,6 @@ OpcUa_StatusCode initialize_value_attribute_of_variablenodes_variabletypenodes(O
 {
 	extern _my_continuationpoint_		Continuation_Point_Data;
 	extern OpcUa_Int			Cont_Point_Counter;
-	extern OpcUa_UInt32			session_flag;
-	extern OpcUa_String*		p_user_name;
-	extern OpcUa_Double			session_timeout;
 	extern my_Variant			all_ValueAttribute_of_VariableTypeNodes_VariableNodes[];
 	OpcUa_InitializeStatus(OpcUa_Module_Server, "initialize_value_attribute_of_variablenodes_variabletypenodes");
 
@@ -54,9 +51,6 @@ OpcUa_StatusCode initialize_value_attribute_of_variablenodes_variabletypenodes(O
 	Continuation_Point_Data.Cont_Point_Identifier=0; /* None. */
 	OpcUa_BrowseDescription_Initialize(&Continuation_Point_Data.NodeToBrowse);
 	Cont_Point_Counter=0;
-	session_flag=SESSION_NOT_ACTIVATED;
-	p_user_name=OpcUa_Null;
-	session_timeout=REVISED_SESSIONTIMEOUT;
 /********************************/
 
 

--- a/AnsiCSample/readservice.c
+++ b/AnsiCSample/readservice.c
@@ -61,10 +61,7 @@ OpcUa_StatusCode my_Read(
 {
 	OpcUa_Int i,n;
 	OpcUa_Void* p_Node;
-	extern OpcUa_UInt32		securechannelId;
-	extern OpcUa_UInt32		session_flag;
-	extern OpcUa_Double		msec_counter;
-	extern OpcUa_String*	p_user_name;
+	SessionData* pSession = OpcUa_Null;
 
     OpcUa_InitializeStatus(OpcUa_Module_Server, "my_Read");
 
@@ -82,32 +79,27 @@ OpcUa_StatusCode my_Read(
 	*a_pNoOfDiagnosticInfos=0;
 	*a_pDiagnosticInfos=OpcUa_Null;
 
-	RESET_SESSION_COUNTER
-
- #ifndef NO_DEBUGGING_
+#ifndef NO_DEBUGGING_
 	MY_TRACE("\n\n\nREAD SERVICE==============================================\n");
-	if(p_user_name!=OpcUa_Null)
-		MY_TRACE("\nUser:%s\n",OpcUa_String_GetRawString(p_user_name)); 
 #endif /*_DEBUGGING_*/
-  
 
-	if(OpcUa_IsBad(session_flag))
+	pSession=UaTestServer_Session_Find(&a_pRequestHeader->AuthenticationToken);
+	OpcUa_GotoErrorIfNull(pSession,OpcUa_BadSecurityChecksFailed);
+
+	RESET_SESSION_COUNTER(pSession);
+
+#ifndef NO_DEBUGGING_
+	if(pSession->p_user_name!=OpcUa_Null)
+		MY_TRACE("\nUser: %s\n",OpcUa_String_GetRawString(pSession->p_user_name)); 
+#endif /*_DEBUGGING_*/
+
+	if(OpcUa_IsBad(pSession->session_flag))
 	{
 		/* Tell client that session is not active. */
 #ifndef NO_DEBUGGING_
 		MY_TRACE("\nSession not active\n"); 
 #endif /*_DEBUGGING_*/
 		uStatus=OpcUa_BadSessionNotActivated;
-		OpcUa_GotoError;
-	}
-
-	
-	uStatus=check_authentication_token(a_pRequestHeader);
-	if(OpcUa_IsBad(uStatus))
-	{
-#ifndef NO_DEBUGGING_
-		MY_TRACE("\nInvalid Authentication Token.\n"); 
-#endif /*_DEBUGGING_*/
 		OpcUa_GotoError;
 	}
 
@@ -394,14 +386,14 @@ OpcUa_StatusCode my_Read(
 	MY_TRACE("\nnumber of nodes :%d\n",a_nNoOfNodesToRead);
 	for(i=0;i<a_nNoOfNodesToRead;i++)
 	{
-		MY_TRACE("\n|%d|, |%d| attributeId:%u\n",(a_pNodesToRead+i)->NodeId.NamespaceIndex,(a_pNodesToRead+i)->NodeId.Identifier.Numeric,(a_pNodesToRead+i)->AttributeId);
+		MY_TRACE("\n%s attributeId:%u\n",getNodeIdString(&(a_pNodesToRead+i)->NodeId),(a_pNodesToRead+i)->AttributeId);
 		
 	}
 #endif /*_DEBUGGING_*/
 
 
 	
-	uStatus = response_header_fill(a_pResponseHeader,a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(pSession,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -410,13 +402,11 @@ OpcUa_StatusCode my_Read(
 	MY_TRACE("\nSERVICE===END============================================\n\n\n"); 
 #endif /*_DEBUGGING_*/
 
-	RESET_SESSION_COUNTER
-
     OpcUa_ReturnStatusCode;
     OpcUa_BeginErrorHandling;
 
     
-	uStatus = response_header_fill(a_pResponseHeader,a_pRequestHeader,uStatus);
+	uStatus=response_header_fill(pSession,a_pResponseHeader,a_pRequestHeader,uStatus);
 	if(OpcUa_IsBad(uStatus))
 	{
        a_pResponseHeader->ServiceResult=OpcUa_BadInternalError;
@@ -424,7 +414,6 @@ OpcUa_StatusCode my_Read(
 #ifndef NO_DEBUGGING_
 	MY_TRACE("\nSERVICE END (WITH ERROR)===========\n\n\n"); 
 #endif /*_DEBUGGING_*/
-	RESET_SESSION_COUNTER
     OpcUa_FinishErrorHandling;
 }
 

--- a/AnsiCSample/readservice.h
+++ b/AnsiCSample/readservice.h
@@ -31,9 +31,6 @@
 #define _readservice_
 
 
-#define RESET_SESSION_COUNTER	msec_counter=0; 
-
-
 OpcUa_StatusCode my_Read(
 							OpcUa_Endpoint             a_hEndpoint,
 							OpcUa_Handle               a_hContext,


### PR DESCRIPTION
This replaces the original PR, removes the C99 use, and fixes the logic
error that resulted in a benign memory leak on cleanup before process exit.