### PR TITLE
Fixed argurment check in opcua_p_socket_interface service table callbacks

### DIFF
--- a/Stack/platforms/linux/opcua_p_socket_interface.c
+++ b/Stack/platforms/linux/opcua_p_socket_interface.c
@@ -714,6 +714,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_GetLastError(OpcUa_Socket a_pSocke
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketGetLastError(a_pSocket);
 }
@@ -745,6 +746,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_Read( OpcUa_Socket    a_pSocket,
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketRead(a_pSocket, a_pBuffer, a_nBufferSize, a_pBytesRead);
 }
@@ -761,6 +763,7 @@ OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_Socket_Write( OpcUa_Socket    a_pSocket,
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketWrite(a_pSocket, a_pBuffer, a_uBufferSize, a_bBlock);
 }
@@ -773,6 +776,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_Close(OpcUa_Socket a_pSocket)
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketClose(a_pSocket);
 }
@@ -787,6 +791,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_GetPeerInfo(  OpcUa_Socket a_pSock
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketGetPeerInfo(a_pSocket, a_achPeerInfoBuffer, a_uiPeerInfoBufferSize);
 }
@@ -820,6 +825,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_SetUserData( OpcUa_Socket a_pSocke
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketSetUserData(a_pSocket, a_pvUserData);
 

--- a/Stack/platforms/win32/opcua_p_socket_interface.c
+++ b/Stack/platforms/win32/opcua_p_socket_interface.c
@@ -641,6 +641,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_GetLastError(OpcUa_Socket a_pSocke
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketGetLastError(a_pSocket);
 }
@@ -672,6 +673,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_Read( OpcUa_Socket    a_pSocket,
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketRead(a_pSocket, a_pBuffer, a_nBufferSize, a_pBytesRead);
 }
@@ -688,6 +690,7 @@ OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_Socket_Write( OpcUa_Socket    a_pSocket,
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketWrite(a_pSocket, a_pBuffer, a_uBufferSize, a_bBlock);
 }
@@ -700,6 +703,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_Close(OpcUa_Socket a_pSocket)
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketClose(a_pSocket);
 }
@@ -714,6 +718,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_GetPeerInfo(  OpcUa_Socket a_pSock
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketGetPeerInfo(a_pSocket, a_achPeerInfoBuffer, a_uiPeerInfoBufferSize);
 }
@@ -747,6 +752,7 @@ OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_SetUserData( OpcUa_Socket a_pSocke
     OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
 
     OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(*ppSocketServiceTable);
 
     return (*ppSocketServiceTable)->SocketSetUserData(a_pSocket, a_pvUserData);
 


### PR DESCRIPTION
Possible NULL pointer dereference in OpcUa_P_Socket_GetLastError, OpcUa_P_Socket_Read, OpcUa_P_Socket_Write, OpcUa_P_Socket_Close, OpcUa_P_Socket_GetPeerInfo and OpcUa_P_Socket_SetUserData