### PR TITLE
add the OPC-UA abstraction layers for VxWorks.

### DIFF
--- a/AnsiCSample/ansicservermain.c
+++ b/AnsiCSample/ansicservermain.c
@@ -27,6 +27,14 @@
  * http://opcfoundation.org/License/MIT/1.00/
  * ======================================================================*/
 
+/* Copyright (c) 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+27jul18,lan  port to vxWorks.
+*/
+ 
 /*********************************************************************************************/
 /*****************     A simple UA test server based on the Ansi C Stack     *****************/
 /*********************************************************************************************/
@@ -250,7 +258,7 @@ OpcUa_ServiceType*  UaTestServer_SupportedServices[] =
 /***********************               Internal Helpers               ************************/
 /*********************************************************************************************/
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__VXWORKS__)
 #include <sys/select.h>
 int _kbhit(void)
 {
@@ -1523,7 +1531,12 @@ OpcUa_StatusCode fill_server_variable(OpcUa_ApplicationDescription* p_Server)
 /*===========================================================================================*/
 /** @brief Main entry function.                                                              */
 /*===========================================================================================*/
+
+#ifdef _WRS_KERNEL
+int ansicserver_main(void)
+#else
 int main(void)
+#endif
   {
 	OpcUa_StatusCode    uStatus					= OpcUa_Good;
 
@@ -1538,8 +1551,11 @@ int main(void)
 	dummy_CreateSubscription.ResponseType       = &OpcUa_CreateSubscriptionResponse_EncodeableType;
 
     printf("Warning: The sample server is intended to show how to use the ANSI C stack and is has not gone through any sort of quality assurance process. Therefore, it cannot be used in any production system.\n");
+	
+#ifndef _WRS_KERNEL
     printf("Press enter to proceed or CTRL-C to exit now!\n");
     getchar();
+#endif
 	
 	
     /* Initialize Stack */

--- a/Stack/platforms/vxworks/endian.h
+++ b/Stack/platforms/vxworks/endian.h
@@ -1,0 +1,38 @@
+/* endian.h - minimal endian library  */
+
+#ifndef __INCendianh
+#define __INCendianh
+
+/* includes */
+#include <types/vxCpu.h>
+#include <types/vxArch.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+/* defines */
+
+#ifndef BYTE_ORDER
+# if _BYTE_ORDER == _LITTLE_ENDIAN
+#  undef LITTLE_ENDIAN  
+#  define  LITTLE_ENDIAN  _LITTLE_ENDIAN 
+#  define BYTE_ORDER LITTLE_ENDIAN
+# elif _BYTE_ORDER == _BIG_ENDIAN
+#  undef BIG_ENDIAN
+#  define BIG_ENDIAN _BIG_ENDIAN
+#  define BYTE_ORDER BIG_ENDIAN
+# else
+#  error "don't know byte order"
+# endif
+#endif
+
+/* typedefs */
+
+/* function declarations */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __INCendianh */

--- a/Stack/platforms/vxworks/memory.h
+++ b/Stack/platforms/vxworks/memory.h
@@ -1,0 +1,1 @@
+/* this file is intentionally empty */

--- a/Stack/platforms/vxworks/opcua_p_binary.c
+++ b/Stack/platforms/vxworks/opcua_p_binary.c
@@ -1,0 +1,343 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#include <memory.h>
+#include <opcua_platformdefs.h>
+#include <opcua_statuscodes.h>
+#include <opcua_errorhandling.h>
+#include <opcua_trace.h>
+#include <opcua_p_binary.h>
+
+/*============================================================================
+ * OpcUa_Boolean_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Boolean_P_NativeToWire(OpcUa_Boolean_Wire* wire, OpcUa_Boolean* native)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    *wire = *native;
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Boolean_P_WireToNative
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Boolean_P_WireToNative(OpcUa_Boolean_Wire* native, OpcUa_Boolean_Wire* wire)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    *native = *wire;
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_SByte_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_SByte_P_NativeToWire(OpcUa_SByte_Wire* wire, OpcUa_SByte* native)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    *wire = *native;
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_SByte_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_SByte_P_WireToNative(OpcUa_SByte* native, OpcUa_SByte_Wire* wire)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    *native = *wire;
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Byte_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Byte_P_NativeToWire(OpcUa_Byte_Wire* wire, OpcUa_Byte* native)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    *wire = *native;
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Byte_P_WireToNative
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Byte_P_WireToNative(OpcUa_Byte* native, OpcUa_Byte_Wire* wire)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    *native = *wire;
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Int16_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Int16_P_NativeToWire(OpcUa_Int16_Wire* wire, OpcUa_Int16* native)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(wire, native, sizeof(OpcUa_Int16));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Int16_P_WireToNative
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Int16_P_WireToNative(OpcUa_Int16* native, OpcUa_Int16_Wire* wire)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(native, wire, sizeof(OpcUa_Int16));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_UInt16_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_UInt16_P_NativeToWire(OpcUa_UInt16_Wire* wire, OpcUa_UInt16* native)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(wire, native, sizeof(OpcUa_UInt16));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_UInt16_P_WireToNative
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_UInt16_P_WireToNative(OpcUa_UInt16* native, OpcUa_UInt16_Wire* wire)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(native, wire, sizeof(OpcUa_UInt16));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Int32_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Int32_P_NativeToWire(OpcUa_Int32_Wire* wire, OpcUa_Int32* native)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(wire, native, sizeof(OpcUa_Int32));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Int32_P_WireToNative
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Int32_P_WireToNative(OpcUa_Int32* native, OpcUa_Int32_Wire* wire)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(native, wire, sizeof(OpcUa_Int32));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_UInt32_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_UInt32_P_NativeToWire(OpcUa_UInt32_Wire* wire, OpcUa_UInt32* native)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(wire, native, sizeof(OpcUa_UInt32));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_UInt32_P_WireToNative
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_UInt32_P_WireToNative(OpcUa_UInt32* native, OpcUa_UInt32_Wire* wire)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(native, wire, sizeof(OpcUa_UInt32));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Int64_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Int64_P_NativeToWire(OpcUa_Int64_Wire* wire, OpcUa_Int64* native)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(wire, native, sizeof(OpcUa_Int64));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Int64_P_WireToNative
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Int64_P_WireToNative(OpcUa_Int64* native, OpcUa_Int64_Wire* wire)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(native, wire, sizeof(OpcUa_Int64));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_UInt64_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_UInt64_P_NativeToWire(OpcUa_UInt64_Wire* wire, OpcUa_UInt64* native)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(wire, native, sizeof(OpcUa_UInt64));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_UInt64_P_WireToNative
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_UInt64_P_WireToNative(OpcUa_UInt64* native, OpcUa_UInt64_Wire* wire)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(native, wire, sizeof(OpcUa_UInt64));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Float_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Float_P_NativeToWire(OpcUa_Float_Wire* wire, OpcUa_Float* native)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(wire, native, sizeof(OpcUa_Float));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Float_P_WireToNative
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Float_P_WireToNative(OpcUa_Float* native, OpcUa_Float_Wire* wire)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(native, wire, sizeof(OpcUa_Float));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Double_P_NativeToWire
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Double_P_NativeToWire(OpcUa_Double_Wire* wire, OpcUa_Double* native)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(wire, native, sizeof(OpcUa_Double));
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_Double_P_WireToNative
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Double_P_WireToNative(OpcUa_Double* native, OpcUa_Double_Wire* wire)
+{
+    OpcUa_DeclareErrorTraceModule(OpcUa_Module_BinarySerializer);
+    OpcUa_ReturnErrorIfArgumentNull(wire);
+    OpcUa_ReturnErrorIfArgumentNull(native);
+
+    OpcUa_SwapBytes(native, wire, sizeof(OpcUa_Double));
+
+    return OpcUa_Good;
+}

--- a/Stack/platforms/vxworks/opcua_p_binary.h
+++ b/Stack/platforms/vxworks/opcua_p_binary.h
@@ -1,0 +1,149 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_P_Binary_H_
+#define _OpcUa_P_Binary_H_ 1
+
+
+OPCUA_BEGIN_EXTERN_C
+
+
+/*============================================================================
+ * OpcUa_Boolean_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Boolean_P_NativeToWire(OpcUa_Boolean_Wire* wire, OpcUa_Boolean* native);
+
+/*============================================================================
+ * OpcUa_Boolean_P_WireToNative
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Boolean_P_WireToNative(OpcUa_Boolean_Wire* native, OpcUa_Boolean_Wire* wire);
+
+/*============================================================================
+ * OpcUa_SByte_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_SByte_P_NativeToWire(OpcUa_SByte_Wire* wire, OpcUa_SByte* native);
+
+/*============================================================================
+ * OpcUa_SByte_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_SByte_P_WireToNative(OpcUa_SByte* native, OpcUa_SByte_Wire* wire);
+
+/*============================================================================
+ * OpcUa_Byte_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Byte_P_NativeToWire(OpcUa_Byte_Wire* wire, OpcUa_Byte* native);
+
+/*============================================================================
+ * OpcUa_Byte_P_WireToNative
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Byte_P_WireToNative(OpcUa_Byte* native, OpcUa_Byte_Wire* wire);
+
+/*============================================================================
+ * OpcUa_Int16_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Int16_P_NativeToWire(OpcUa_Int16_Wire* wire, OpcUa_Int16* native);
+
+/*============================================================================
+ * OpcUa_Int16_P_WireToNative
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Int16_P_WireToNative(OpcUa_Int16* native, OpcUa_Int16_Wire* wire);
+
+/*============================================================================
+ * OpcUa_UInt16_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_UInt16_P_NativeToWire(OpcUa_UInt16_Wire* wire, OpcUa_UInt16* native);
+
+/*============================================================================
+ * OpcUa_UInt16_P_WireToNative
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_UInt16_P_WireToNative(OpcUa_UInt16* native, OpcUa_UInt16_Wire* wire);
+
+/*============================================================================
+ * OpcUa_Int32_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Int32_P_NativeToWire(OpcUa_Int32_Wire* wire, OpcUa_Int32* native);
+
+/*============================================================================
+ * OpcUa_Int32_P_WireToNative
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Int32_P_WireToNative(OpcUa_Int32* native, OpcUa_Int32_Wire* wire);
+
+/*============================================================================
+ * OpcUa_UInt32_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_UInt32_P_NativeToWire(OpcUa_UInt32_Wire* wire, OpcUa_UInt32* native);
+
+/*============================================================================
+ * OpcUa_UInt32_P_WireToNative
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_UInt32_P_WireToNative(OpcUa_UInt32* native, OpcUa_UInt32_Wire* wire);
+
+/*============================================================================
+ * OpcUa_Int64_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Int64_P_NativeToWire(OpcUa_Int64_Wire* wire, OpcUa_Int64* native);
+
+/*============================================================================
+ * OpcUa_Int64_P_WireToNative
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Int64_P_WireToNative(OpcUa_Int64* native, OpcUa_Int64_Wire* wire);
+
+/*============================================================================
+ * OpcUa_UInt64_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_UInt64_P_NativeToWire(OpcUa_UInt64_Wire* wire, OpcUa_UInt64* native);
+
+/*============================================================================
+ * OpcUa_UInt64_P_WireToNative
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_UInt64_P_WireToNative(OpcUa_UInt64* native, OpcUa_UInt64_Wire* wire);
+
+/*============================================================================
+ * OpcUa_Float_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Float_P_NativeToWire(OpcUa_Float_Wire* wire, OpcUa_Float* native);
+
+/*============================================================================
+ * OpcUa_Float_P_WireToNative
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Float_P_WireToNative(OpcUa_Float* native, OpcUa_Float_Wire* wire);
+
+/*============================================================================
+ * OpcUa_Double_P_NativeToWire
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Double_P_NativeToWire(OpcUa_Double_Wire* wire, OpcUa_Double* native);
+
+/*============================================================================
+ * OpcUa_Double_P_WireToNative
+ *===========================================================================*/
+OPCUA_EXPORT OpcUa_StatusCode OpcUa_Double_P_WireToNative(OpcUa_Double* native, OpcUa_Double_Wire* wire);
+
+OPCUA_END_EXTERN_C
+
+#endif /* _OpcUa_P_Binary_H_ */

--- a/Stack/platforms/vxworks/opcua_p_crypto.h
+++ b/Stack/platforms/vxworks/opcua_p_crypto.h
@@ -1,0 +1,111 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_P_Crypto_H_
+#define _OpcUa_P_Crypto_H_ 1
+
+OPCUA_BEGIN_EXTERN_C
+
+/* MESSAGE DIGEST */
+#define OPCUA_P_SHA_160 160
+#define OPCUA_P_SHA_224 224
+#define OPCUA_P_SHA_256 256
+#define OPCUA_P_SHA_384 384
+#define OPCUA_P_SHA_512 512
+
+/* SecurityPolicies */
+#define OpcUa_SecurityPolicy_None                   "http://opcfoundation.org/UA/SecurityPolicy#None"
+#define OpcUa_SecurityPolicy_Basic128Rsa15          "http://opcfoundation.org/UA/SecurityPolicy#Basic128Rsa15"
+#define OpcUa_SecurityPolicy_Basic256               "http://opcfoundation.org/UA/SecurityPolicy#Basic256"
+#define OpcUa_SecurityPolicy_Basic256Sha256         "http://opcfoundation.org/UA/SecurityPolicy#Basic256Sha256"
+#define OpcUa_SecurityPolicy_Aes128Sha256RsaOaep    "http://opcfoundation.org/UA/SecurityPolicy#Aes128_Sha256_RsaOaep"
+#define OpcUa_SecurityPolicy_Aes256Sha256RsaPss     "http://opcfoundation.org/UA/SecurityPolicy#Aes256_Sha256_RsaPss"
+
+/* Signature Algorithm Uris */
+#define OpcUa_AlgorithmUri_Signature_RsaSha1        "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+#define OpcUa_AlgorithmUri_Signature_RsaSha256      "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
+#define OpcUa_AlgorithmUri_Signature_HmacSha1       "http://www.w3.org/2000/09/xmldsig#hmac-sha1"
+#define OpcUa_AlgorithmUri_Signature_HmacSha256     "http://www.w3.org/2001/04/xmldsig-more#hmac-sha256"
+#define OpcUa_AlgorithmUri_Signature_RsaPssSha256   "http://opcfoundation.org/UA/security/rsa-pss-sha2-256"
+
+/* Encryption Algorithms Uris */
+#define OpcUa_AlgorithmUri_Ecryption_Aes128Cbc      "http://www.w3.org/2001/04/xmlenc#aes128-cbc"
+#define OpcUa_AlgorithmUri_Ecryption_Aes256Cbc      "http://www.w3.org/2001/04/xmlenc#aes256-cbc"
+#define OpcUa_AlgorithmUri_Encryption_RsaOaep       "http://www.w3.org/2001/04/xmlenc#rsa-oaep"
+#define OpcUa_AlgorithmUri_Encryption_Rsa15         "http://www.w3.org/2001/04/xmlenc#rsa-1_5"
+#define OpcUa_AlgorithmUri_Encryption_RsaOaepSha256 "http://opcfoundation.org/UA/security/rsa-oaep-sha2-256"
+
+/* Encryption Algs */
+#define OpcUa_P_NoEncryption_Name                   ""
+#define OpcUa_P_NoEncryption_Id                     0
+
+#define OpcUa_P_AES_128_CBC_Name                    "AES-128-CBC"
+#define OpcUa_P_AES_128_CBC_Id                      1
+
+#define OpcUa_P_AES_256_CBC_Name                    "AES-256-CBC"
+#define OpcUa_P_AES_256_CBC_Id                      2
+
+#define OpcUa_P_RSA_PKCS1_V15_Name                  "RSA-PKCS-#1-V1.5"
+#define OpcUa_P_RSA_PKCS1_V15_Id                    3
+
+#define OpcUa_P_RSA_OAEP_Name                       "RSA-OAEP"
+#define OpcUa_P_RSA_OAEP_Id                         4
+
+#define OpcUa_P_RSA_OAEP_SHA256_Name                "RSA-OAEP-SHA256"
+#define OpcUa_P_RSA_OAEP_SHA256_Id                  5
+
+/* Signature Algs */
+#define OpcUa_P_NoSignature_Name                    ""
+#define OpcUa_P_NoSignature_Id                      0
+
+#define OpcUa_P_RSA_PKCS1_V15_SHA1_Name             "RSA-PKCS-#1-V1.5-SHA1"
+#define OpcUa_P_RSA_PKCS1_V15_SHA1_Id               6
+
+#define OpcUa_P_RSA_PKCS1_V15_SHA256_Name           "RSA-PKCS-#1-V1.5-SHA256"
+#define OpcUa_P_RSA_PKCS1_V15_SHA256_Id             7
+
+#define OpcUa_P_HMAC_SHA1_Name                      "HMAC-SHA1"
+#define OpcUa_P_HMAC_SHA1_Id                        8
+
+#define OpcUa_P_HMAC_SHA256_Name                    "HMAC-SHA256"
+#define OpcUa_P_HMAC_SHA256_Id                      9
+
+#define OpcUa_P_RSA_PSS_SHA256_Name                 "RSA-PSS-SHA256"
+#define OpcUa_P_RSA_PSS_SHA256_Id                   10
+
+/* Key Derivation Algs */
+#define OpcUa_P_PSHA1_Name                          "P-SHA1"
+#define OpcUa_P_PSHA1_Id                            12
+
+#define OpcUa_P_PSHA256_Name                        "P-SHA256"
+#define OpcUa_P_PSHA256_Id                          13
+
+OPCUA_END_EXTERN_C
+
+#endif

--- a/Stack/platforms/vxworks/opcua_p_cryptofactory.c
+++ b/Stack/platforms/vxworks/opcua_p_cryptofactory.c
@@ -1,0 +1,479 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#include <stdlib.h>
+#include <memory.h>
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_string.h>
+#include <opcua_p_memory.h>
+#include <opcua_p_trace.h>
+
+/* own headers */
+#include <opcua_p_cryptofactory.h>
+
+#include <opcua_p_openssl.h>
+
+/*============================================================================
+ * OpcUa_P_CryptoFactory_CreateCryptoProvider
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_CryptoFactory_CreateCryptoProvider(  OpcUa_StringA           a_Uri,
+                                                                            OpcUa_CryptoProvider*   a_pProvider)
+
+{
+OpcUa_InitializeStatus(OpcUa_Module_P_CryptoFactory, "CreateCryptoProvider");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_Uri);
+
+    OpcUa_MemSet(a_pProvider, 0, sizeof(OpcUa_CryptoProvider));
+
+    a_pProvider->Name = (OpcUa_StringA)OpcUa_P_Memory_Alloc(OpcUa_P_String_strlen(a_Uri) + 1);
+    OpcUa_GotoErrorIfAllocFailed(a_pProvider->Name);
+
+    OpcUa_P_String_strncpy( a_pProvider->Name,
+                            OpcUa_P_String_strlen(a_Uri) + 1,
+                            a_Uri,
+                            OpcUa_P_String_strlen(a_Uri));
+
+    /* Check whether a noSecurityPolicy is passed in */
+    if(a_Uri == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+#if OPCUA_SUPPORT_SECURITYPOLICY_NONE
+    else if((OpcUa_P_String_strncmp(OpcUa_SecurityPolicy_None, a_Uri, OpcUa_P_String_strlen(OpcUa_SecurityPolicy_None)) == 0))
+    {
+        a_pProvider->SymmetricKeyLength               = 0;
+        a_pProvider->DerivedEncryptionKeyLength       = 0;
+        a_pProvider->DerivedSignatureKeyLength        = 0;
+        a_pProvider->SignatureDataLength              = 0;
+
+        a_pProvider->MaximumAsymmetricKeyLength       = 0;
+        a_pProvider->MinimumAsymmetricKeyLength       = 0;
+
+        a_pProvider->AsymmetricEncryptionOverhead     = 0;
+
+        a_pProvider->AsymmetricSignatureAlgorithmId   = 0;
+        a_pProvider->AsymmetricEncryptionAlgorithmId  = 0;
+        a_pProvider->SymmetricSignatureAlgorithmId    = 0;
+        a_pProvider->SymmetricEncryptionAlgorithmId   = 0;
+        a_pProvider->SymmetricKeyDeviationAlgorithmId = 0;
+
+        /* asymmetric key generation */
+        a_pProvider->GenerateAsymmetricKeypair  = OpcUa_P_Crypto_NoSecurity_GenerateAsymmetricKeyPair;
+
+        /* get the length of an asymmetric key */
+        a_pProvider->GetAsymmetricKeyLength     = OpcUa_P_Crypto_NoSecurity_GetAsymmetricKeyLength;
+
+        /* symmetric signature algorithm */
+        a_pProvider->SymmetricSign              = OpcUa_P_Crypto_NoSecurity_SymmetricSign;
+        a_pProvider->SymmetricVerify            = OpcUa_P_Crypto_NoSecurity_SymmetricVerify;
+
+        /* symmetric encryption algorithm */
+        a_pProvider->SymmetricEncrypt           = OpcUa_P_Crypto_NoSecurity_SymmetricEncrypt;
+        a_pProvider->SymmetricDecrypt           = OpcUa_P_Crypto_NoSecurity_SymmetricDecrypt;
+
+        /* asymmetric signature algorithm */
+        a_pProvider->AsymmetricSign             = OpcUa_P_Crypto_NoSecurity_AsymmetricSign;
+        a_pProvider->AsymmetricVerify           = OpcUa_P_Crypto_NoSecurity_AsymmetricVerify;
+
+        /* asymmetric encryption algorithm */
+        a_pProvider->AsymmetricEncrypt          = OpcUa_P_Crypto_NoSecurity_AsymmetricEncrypt;
+        a_pProvider->AsymmetricDecrypt          = OpcUa_P_Crypto_NoSecurity_AsymmetricDecrypt;
+
+        /* key derivation algorithm */
+        a_pProvider->DeriveChannelKeysets       = OpcUa_P_Crypto_NoSecurity_DeriveChannelKeysets;
+        a_pProvider->DeriveKey                  = OpcUa_P_Crypto_NoSecurity_DeriveKey;
+
+        /* random key generation */
+        a_pProvider->GenerateKey                = OpcUa_P_Crypto_NoSecurity_GenerateKey;
+
+        /* certificate functions */
+        a_pProvider->CreateCertificate          = OpcUa_P_Crypto_NoSecurity_CreateCertificate;
+        a_pProvider->GetPublicKeyFromCert       = OpcUa_P_Crypto_NoSecurity_GetPublicKeyFromCert;
+        a_pProvider->GetSignatureFromCert       = OpcUa_P_Crypto_NoSecurity_GetSignatureFromCert;
+        a_pProvider->GetCertificateThumbprint   = OpcUa_P_Crypto_NoSecurity_GetCertificateThumbprint;
+    }
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_NONE */
+#if OPCUA_SUPPORT_SECURITYPOLICY_BASIC128RSA15
+    else if(OpcUa_P_String_strncmp( OpcUa_SecurityPolicy_Basic128Rsa15,
+                                    a_Uri,
+                                    OpcUa_P_String_strlen(OpcUa_SecurityPolicy_Basic128Rsa15))==0)
+    {
+        a_pProvider->SymmetricKeyLength               = 16;
+        a_pProvider->DerivedEncryptionKeyLength       = 16;
+        a_pProvider->DerivedSignatureKeyLength        = 16;
+        a_pProvider->SignatureDataLength              = 20;
+
+        a_pProvider->MaximumAsymmetricKeyLength       = 512;
+        a_pProvider->MinimumAsymmetricKeyLength       = 128;
+
+        a_pProvider->AsymmetricEncryptionOverhead     = 11;
+
+        a_pProvider->AsymmetricSignatureAlgorithmId   = OpcUa_P_RSA_PKCS1_V15_SHA1_Id;
+        a_pProvider->AsymmetricEncryptionAlgorithmId  = OpcUa_P_RSA_PKCS1_V15_Id;
+        a_pProvider->SymmetricSignatureAlgorithmId    = OpcUa_P_HMAC_SHA1_Id;
+        a_pProvider->SymmetricEncryptionAlgorithmId   = OpcUa_P_AES_128_CBC_Id;
+        a_pProvider->SymmetricKeyDeviationAlgorithmId = OpcUa_P_PSHA1_Id;
+
+        /* asymmetric key generation */
+        a_pProvider->GenerateAsymmetricKeypair  = OpcUa_P_OpenSSL_GenerateAsymmetricKeyPair;
+
+        /* get the length of an asymmetric key */
+        a_pProvider->GetAsymmetricKeyLength     = OpcUa_P_OpenSSL_RSA_Public_GetKeyLength;
+
+        /* symmetric signature algorithm */
+        a_pProvider->SymmetricSign              = OpcUa_P_OpenSSL_HMAC_SHA1_Sign;
+        a_pProvider->SymmetricVerify            = OpcUa_P_OpenSSL_HMAC_SHA1_Verify;
+
+        /* symmetric encryption algorithm */
+        a_pProvider->SymmetricEncrypt           = OpcUa_P_OpenSSL_AES_128_CBC_Encrypt;
+        a_pProvider->SymmetricDecrypt           = OpcUa_P_OpenSSL_AES_128_CBC_Decrypt;
+
+        /* asymmetric signature algorithm */
+        a_pProvider->AsymmetricSign             = OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA1_Sign;
+        a_pProvider->AsymmetricVerify           = OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA1_Verify;
+
+        /* asymmetric encryption algorithm */
+        a_pProvider->AsymmetricEncrypt          = OpcUa_P_OpenSSL_RSA_PKCS1_V15_Encrypt;
+        a_pProvider->AsymmetricDecrypt          = OpcUa_P_OpenSSL_RSA_PKCS1_V15_Decrypt;
+
+        /* key derivation algorithm */
+        a_pProvider->DeriveChannelKeysets       = OpcUa_P_OpenSSL_DeriveChannelKeysets;
+        a_pProvider->DeriveKey                  = OpcUa_P_OpenSSL_Random_Key_Derive;
+
+        /* random key generation */
+        a_pProvider->GenerateKey                = OpcUa_P_OpenSSL_Random_Key_Generate;
+
+        /* certificate functions */
+        a_pProvider->CreateCertificate          = OpcUa_P_OpenSSL_X509_SelfSigned_Custom_Create;
+        a_pProvider->GetPublicKeyFromCert       = OpcUa_P_OpenSSL_X509_GetPublicKey;
+        a_pProvider->GetSignatureFromCert       = OpcUa_P_OpenSSL_X509_GetSignature;
+        a_pProvider->GetCertificateThumbprint   = OpcUa_P_OpenSSL_X509_GetCertificateThumbprint;
+    }
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_BASIC128RSA15 */
+#if OPCUA_SUPPORT_SECURITYPOLICY_AES128SHA256RSAOAEP
+    else if(OpcUa_P_String_strncmp( OpcUa_SecurityPolicy_Aes128Sha256RsaOaep,
+                                    a_Uri,
+                                    OpcUa_P_String_strlen(OpcUa_SecurityPolicy_Aes128Sha256RsaOaep))==0)
+    {
+        a_pProvider->SymmetricKeyLength               = 32;
+        a_pProvider->DerivedEncryptionKeyLength       = 16;
+        a_pProvider->DerivedSignatureKeyLength        = 32;
+        a_pProvider->SignatureDataLength              = 32;
+
+        a_pProvider->MaximumAsymmetricKeyLength       = 512;
+        a_pProvider->MinimumAsymmetricKeyLength       = 256;
+
+        a_pProvider->AsymmetricEncryptionOverhead     = 42;
+
+        a_pProvider->AsymmetricSignatureAlgorithmId   = OpcUa_P_RSA_PKCS1_V15_SHA256_Id;
+        a_pProvider->AsymmetricEncryptionAlgorithmId  = OpcUa_P_RSA_OAEP_Id;
+        a_pProvider->SymmetricSignatureAlgorithmId    = OpcUa_P_HMAC_SHA256_Id;
+        a_pProvider->SymmetricEncryptionAlgorithmId   = OpcUa_P_AES_128_CBC_Id;
+        a_pProvider->SymmetricKeyDeviationAlgorithmId = OpcUa_P_PSHA256_Id;
+
+        /* asymmetric key generation */
+        a_pProvider->GenerateAsymmetricKeypair  = OpcUa_P_OpenSSL_GenerateAsymmetricKeyPair;
+
+        /* get the length of an asymmetric key */
+        a_pProvider->GetAsymmetricKeyLength     = OpcUa_P_OpenSSL_RSA_Public_GetKeyLength;
+
+        /* symmetric signature algorithm */
+        a_pProvider->SymmetricSign              = OpcUa_P_OpenSSL_HMAC_SHA256_Sign;
+        a_pProvider->SymmetricVerify            = OpcUa_P_OpenSSL_HMAC_SHA256_Verify;
+
+        /* symmetric encryption algorithm */
+        a_pProvider->SymmetricEncrypt           = OpcUa_P_OpenSSL_AES_128_CBC_Encrypt;
+        a_pProvider->SymmetricDecrypt           = OpcUa_P_OpenSSL_AES_128_CBC_Decrypt;
+
+        /* asymmetric signature algorithm */
+        a_pProvider->AsymmetricSign             = OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA256_Sign;
+        a_pProvider->AsymmetricVerify           = OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA256_Verify;
+
+        /* asymmetric encryption algorithm */
+        a_pProvider->AsymmetricEncrypt          = OpcUa_P_OpenSSL_RSA_OAEP_Encrypt;
+        a_pProvider->AsymmetricDecrypt          = OpcUa_P_OpenSSL_RSA_OAEP_Decrypt;
+
+        /* key derivation algorithm */
+        a_pProvider->DeriveChannelKeysets       = OpcUa_P_OpenSSL_DeriveChannelKeysets;
+        a_pProvider->DeriveKey                  = OpcUa_P_OpenSSL_Random_Key_PSHA256_Derive;
+
+        /* random key generation */
+        a_pProvider->GenerateKey                = OpcUa_P_OpenSSL_Random_Key_Generate;
+
+        /* certificate functions */
+        a_pProvider->CreateCertificate          = OpcUa_P_OpenSSL_X509_SelfSigned_Custom_Create;
+        a_pProvider->GetPublicKeyFromCert       = OpcUa_P_OpenSSL_X509_GetPublicKey;
+        a_pProvider->GetSignatureFromCert       = OpcUa_P_OpenSSL_X509_GetSignature;
+        a_pProvider->GetCertificateThumbprint   = OpcUa_P_OpenSSL_X509_GetCertificateThumbprint;
+    }
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_AES128SHA256RSAOAEP */
+#if OPCUA_SUPPORT_SECURITYPOLICY_AES256SHA256RSAPSS
+    else if(OpcUa_P_String_strncmp( OpcUa_SecurityPolicy_Aes256Sha256RsaPss,
+                                    a_Uri,
+                                    OpcUa_P_String_strlen(OpcUa_SecurityPolicy_Aes256Sha256RsaPss))==0)
+    {
+        a_pProvider->SymmetricKeyLength               = 32;
+        a_pProvider->DerivedEncryptionKeyLength       = 32;
+        a_pProvider->DerivedSignatureKeyLength        = 32;
+        a_pProvider->SignatureDataLength              = 32;
+
+        a_pProvider->MaximumAsymmetricKeyLength       = 512;
+        a_pProvider->MinimumAsymmetricKeyLength       = 256;
+
+        a_pProvider->AsymmetricEncryptionOverhead     = 66;
+
+        a_pProvider->AsymmetricSignatureAlgorithmId   = OpcUa_P_RSA_PSS_SHA256_Id;
+        a_pProvider->AsymmetricEncryptionAlgorithmId  = OpcUa_P_RSA_OAEP_SHA256_Id;
+        a_pProvider->SymmetricSignatureAlgorithmId    = OpcUa_P_HMAC_SHA256_Id;
+        a_pProvider->SymmetricEncryptionAlgorithmId   = OpcUa_P_AES_256_CBC_Id;
+        a_pProvider->SymmetricKeyDeviationAlgorithmId = OpcUa_P_PSHA256_Id;
+
+        /* asymmetric key generation */
+        a_pProvider->GenerateAsymmetricKeypair  = OpcUa_P_OpenSSL_GenerateAsymmetricKeyPair;
+
+        /* get the length of an asymmetric key */
+        a_pProvider->GetAsymmetricKeyLength     = OpcUa_P_OpenSSL_RSA_Public_GetKeyLength;
+
+        /* symmetric signature algorithm */
+        a_pProvider->SymmetricSign              = OpcUa_P_OpenSSL_HMAC_SHA256_Sign;
+        a_pProvider->SymmetricVerify            = OpcUa_P_OpenSSL_HMAC_SHA256_Verify;
+
+        /* symmetric encryption algorithm */
+        a_pProvider->SymmetricEncrypt           = OpcUa_P_OpenSSL_AES_256_CBC_Encrypt;
+        a_pProvider->SymmetricDecrypt           = OpcUa_P_OpenSSL_AES_256_CBC_Decrypt;
+
+        /* asymmetric signature algorithm */
+        a_pProvider->AsymmetricSign             = OpcUa_P_OpenSSL_RSA_PSS_SHA256_Sign;
+        a_pProvider->AsymmetricVerify           = OpcUa_P_OpenSSL_RSA_PSS_SHA256_Verify;
+
+        /* asymmetric encryption algorithm */
+        a_pProvider->AsymmetricEncrypt          = OpcUa_P_OpenSSL_RSA_OAEP_SHA256_Encrypt;
+        a_pProvider->AsymmetricDecrypt          = OpcUa_P_OpenSSL_RSA_OAEP_SHA256_Decrypt;
+
+        /* key derivation algorithm */
+        a_pProvider->DeriveChannelKeysets       = OpcUa_P_OpenSSL_DeriveChannelKeysets;
+        a_pProvider->DeriveKey                  = OpcUa_P_OpenSSL_Random_Key_PSHA256_Derive;
+
+        /* random key generation */
+        a_pProvider->GenerateKey                = OpcUa_P_OpenSSL_Random_Key_Generate;
+
+        /* certificate functions */
+        a_pProvider->CreateCertificate          = OpcUa_P_OpenSSL_X509_SelfSigned_Custom_Create;
+        a_pProvider->GetPublicKeyFromCert       = OpcUa_P_OpenSSL_X509_GetPublicKey;
+        a_pProvider->GetSignatureFromCert       = OpcUa_P_OpenSSL_X509_GetSignature;
+        a_pProvider->GetCertificateThumbprint   = OpcUa_P_OpenSSL_X509_GetCertificateThumbprint;
+    }
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_AES256SHA256RSAPSS */
+#if OPCUA_SUPPORT_SECURITYPOLICY_BASIC256SHA256
+    else if(OpcUa_P_String_strncmp( OpcUa_SecurityPolicy_Basic256Sha256,
+                                    a_Uri,
+                                    OpcUa_P_String_strlen(OpcUa_SecurityPolicy_Basic256Sha256))==0)
+    {
+        a_pProvider->SymmetricKeyLength               = 32;
+        a_pProvider->DerivedEncryptionKeyLength       = 32;
+        a_pProvider->DerivedSignatureKeyLength        = 32;
+        a_pProvider->SignatureDataLength              = 32;
+
+        a_pProvider->MaximumAsymmetricKeyLength       = 512;
+        a_pProvider->MinimumAsymmetricKeyLength       = 256;
+
+        a_pProvider->AsymmetricEncryptionOverhead     = 42;
+
+        a_pProvider->AsymmetricSignatureAlgorithmId   = OpcUa_P_RSA_PKCS1_V15_SHA256_Id;
+        a_pProvider->AsymmetricEncryptionAlgorithmId  = OpcUa_P_RSA_OAEP_Id;
+        a_pProvider->SymmetricSignatureAlgorithmId    = OpcUa_P_HMAC_SHA256_Id;
+        a_pProvider->SymmetricEncryptionAlgorithmId   = OpcUa_P_AES_256_CBC_Id;
+        a_pProvider->SymmetricKeyDeviationAlgorithmId = OpcUa_P_PSHA256_Id;
+
+        /* asymmetric key generation */
+        a_pProvider->GenerateAsymmetricKeypair  = OpcUa_P_OpenSSL_GenerateAsymmetricKeyPair;
+
+        /* get the length of an asymmetric key */
+        a_pProvider->GetAsymmetricKeyLength     = OpcUa_P_OpenSSL_RSA_Public_GetKeyLength;
+
+        /* symmetric signature algorithm */
+        a_pProvider->SymmetricSign              = OpcUa_P_OpenSSL_HMAC_SHA256_Sign;
+        a_pProvider->SymmetricVerify            = OpcUa_P_OpenSSL_HMAC_SHA256_Verify;
+
+        /* symmetric encryption algorithm */
+        a_pProvider->SymmetricEncrypt           = OpcUa_P_OpenSSL_AES_256_CBC_Encrypt;
+        a_pProvider->SymmetricDecrypt           = OpcUa_P_OpenSSL_AES_256_CBC_Decrypt;
+
+        /* asymmetric signature algorithm */
+        a_pProvider->AsymmetricSign             = OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA256_Sign;
+        a_pProvider->AsymmetricVerify           = OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA256_Verify;
+
+        /* asymmetric encryption algorithm */
+        a_pProvider->AsymmetricEncrypt          = OpcUa_P_OpenSSL_RSA_OAEP_Encrypt;
+        a_pProvider->AsymmetricDecrypt          = OpcUa_P_OpenSSL_RSA_OAEP_Decrypt;
+
+        /* key derivation algorithm */
+        a_pProvider->DeriveChannelKeysets       = OpcUa_P_OpenSSL_DeriveChannelKeysets;
+        a_pProvider->DeriveKey                  = OpcUa_P_OpenSSL_Random_Key_PSHA256_Derive;
+
+        /* random key generation */
+        a_pProvider->GenerateKey                = OpcUa_P_OpenSSL_Random_Key_Generate;
+
+        /* certificate functions */
+        a_pProvider->CreateCertificate          = OpcUa_P_OpenSSL_X509_SelfSigned_Custom_Create;
+        a_pProvider->GetPublicKeyFromCert       = OpcUa_P_OpenSSL_X509_GetPublicKey;
+        a_pProvider->GetSignatureFromCert       = OpcUa_P_OpenSSL_X509_GetSignature;
+        a_pProvider->GetCertificateThumbprint   = OpcUa_P_OpenSSL_X509_GetCertificateThumbprint;
+    }
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_BASIC256SHA256 */
+#if OPCUA_SUPPORT_SECURITYPOLICY_BASIC256
+    else if(OpcUa_P_String_strncmp( OpcUa_SecurityPolicy_Basic256,
+                                    a_Uri,
+                                    OpcUa_P_String_strlen(OpcUa_SecurityPolicy_Basic256))==0)
+    {
+        a_pProvider->SymmetricKeyLength               = 32;
+        a_pProvider->DerivedEncryptionKeyLength       = 32;
+        a_pProvider->DerivedSignatureKeyLength        = 24;
+        a_pProvider->SignatureDataLength              = 20;
+
+        a_pProvider->MaximumAsymmetricKeyLength       = 512;
+        a_pProvider->MinimumAsymmetricKeyLength       = 128;
+
+        a_pProvider->AsymmetricEncryptionOverhead     = 42;
+
+        a_pProvider->AsymmetricSignatureAlgorithmId   = OpcUa_P_RSA_PKCS1_V15_SHA1_Id;
+        a_pProvider->AsymmetricEncryptionAlgorithmId  = OpcUa_P_RSA_OAEP_Id;
+        a_pProvider->SymmetricSignatureAlgorithmId    = OpcUa_P_HMAC_SHA1_Id;
+        a_pProvider->SymmetricEncryptionAlgorithmId   = OpcUa_P_AES_256_CBC_Id;
+        a_pProvider->SymmetricKeyDeviationAlgorithmId = OpcUa_P_PSHA1_Id;
+
+        /* asymmetric key generation */
+        a_pProvider->GenerateAsymmetricKeypair  = OpcUa_P_OpenSSL_GenerateAsymmetricKeyPair;
+
+        /* get the length of an asymmetric key */
+        a_pProvider->GetAsymmetricKeyLength     = OpcUa_P_OpenSSL_RSA_Public_GetKeyLength;
+
+        /* symmetric signature algorithm */
+        a_pProvider->SymmetricSign              = OpcUa_P_OpenSSL_HMAC_SHA1_Sign;
+        a_pProvider->SymmetricVerify            = OpcUa_P_OpenSSL_HMAC_SHA1_Verify;
+
+        /* symmetric encryption algorithm */
+        a_pProvider->SymmetricEncrypt           = OpcUa_P_OpenSSL_AES_256_CBC_Encrypt;
+        a_pProvider->SymmetricDecrypt           = OpcUa_P_OpenSSL_AES_256_CBC_Decrypt;
+
+        /* asymmetric signature algorithm */
+        a_pProvider->AsymmetricSign             = OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA1_Sign;
+        a_pProvider->AsymmetricVerify           = OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA1_Verify;
+
+        /* asymmetric encryption algorithm */
+        a_pProvider->AsymmetricEncrypt          = OpcUa_P_OpenSSL_RSA_OAEP_Encrypt;
+        a_pProvider->AsymmetricDecrypt          = OpcUa_P_OpenSSL_RSA_OAEP_Decrypt;
+
+        /* key derivation algorithm */
+        a_pProvider->DeriveChannelKeysets       = OpcUa_P_OpenSSL_DeriveChannelKeysets;
+        a_pProvider->DeriveKey                  = OpcUa_P_OpenSSL_Random_Key_Derive;
+
+        /* random key generation */
+        a_pProvider->GenerateKey                = OpcUa_P_OpenSSL_Random_Key_Generate;
+
+        /* certificate functions */
+        a_pProvider->CreateCertificate          = OpcUa_P_OpenSSL_X509_SelfSigned_Custom_Create;
+        a_pProvider->GetPublicKeyFromCert       = OpcUa_P_OpenSSL_X509_GetPublicKey;
+        a_pProvider->GetSignatureFromCert       = OpcUa_P_OpenSSL_X509_GetSignature;
+        a_pProvider->GetCertificateThumbprint   = OpcUa_P_OpenSSL_X509_GetCertificateThumbprint;
+    }
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_BASIC256 */
+    else
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadSecurityPolicyRejected);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(a_pProvider->Name != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(a_pProvider->Name);
+        a_pProvider->Name = OpcUa_Null;
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_CryptoFactory_DeleteCryptoProvider
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_CryptoFactory_DeleteCryptoProvider(OpcUa_CryptoProvider* a_pProvider)
+{
+OpcUa_InitializeStatus(OpcUa_Module_P_CryptoFactory, "DeleteCryptoProvider");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+
+    if(a_pProvider->Name != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(a_pProvider->Name);
+        a_pProvider->Name = OpcUa_Null;
+    }
+
+    /* asymmetric key generation */
+    a_pProvider->GenerateAsymmetricKeypair    = OpcUa_Null;
+
+    /* symmetric signature algorithm */
+    a_pProvider->SymmetricSign                = OpcUa_Null;
+    a_pProvider->SymmetricVerify              = OpcUa_Null;
+
+    /* symmetric encryption algorithm */
+    a_pProvider->SymmetricEncrypt             = OpcUa_Null;
+    a_pProvider->SymmetricDecrypt             = OpcUa_Null;
+
+    /* asymmetric signature algorithm */
+    a_pProvider->AsymmetricSign               = OpcUa_Null;
+    a_pProvider->AsymmetricVerify             = OpcUa_Null;
+
+    /* asymmetric encryption algorithm */
+    a_pProvider->AsymmetricEncrypt            = OpcUa_Null;
+    a_pProvider->AsymmetricDecrypt            = OpcUa_Null;
+
+    /* key derivation algorithm */
+    a_pProvider->DeriveChannelKeysets         = OpcUa_Null;
+    a_pProvider->DeriveKey                    = OpcUa_Null;
+
+    /* random key generation */
+    a_pProvider->GenerateKey                  = OpcUa_Null;
+
+    /* certificate functions */
+    a_pProvider->CreateCertificate            = OpcUa_Null;
+    a_pProvider->GetPublicKeyFromCert         = OpcUa_Null;
+    a_pProvider->GetSignatureFromCert         = OpcUa_Null;
+
+    a_pProvider->GetCertificateThumbprint     = OpcUa_Null;
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}

--- a/Stack/platforms/vxworks/opcua_p_cryptofactory.h
+++ b/Stack/platforms/vxworks/opcua_p_cryptofactory.h
@@ -1,0 +1,53 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_P_CryptoFactory_H_
+#define _OpcUa_P_CryptoFactory_H_ 1
+
+OPCUA_BEGIN_EXTERN_C
+
+/**
+  @brief OpcUa_CryptoFactory_CreateCryptoProvider.
+
+  @param securityPolicy     [in]  The security policy.
+  @param pProvider          [out] The resulting CryptoProvider.
+*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_CryptoFactory_CreateCryptoProvider(  OpcUa_StringA           Uri,
+                                                                            OpcUa_CryptoProvider*   pProvider);
+
+/**
+  @brief OpcUa_CryptoFactory_DeleteCryptoProvider.
+
+  @param pProvider         [out] The resulting CryptoProvider.
+*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_CryptoFactory_DeleteCryptoProvider(  OpcUa_CryptoProvider* pProvider);
+
+OPCUA_END_EXTERN_C
+
+#endif

--- a/Stack/platforms/vxworks/opcua_p_datetime.c
+++ b/Stack/platforms/vxworks/opcua_p_datetime.c
@@ -1,0 +1,370 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#include <opcua_p_internal.h>
+
+#include <opcua_datetime.h>
+#include <opcua_p_datetime.h>
+#include <sys/time.h>
+#include <time.h>
+#include <stdlib.h>
+
+static const OpcUa_Int64 SECS_BETWEEN_EPOCHS = 11644473600LL;
+static const OpcUa_Int64 SECS_TO_100NS = 10000000LL; /* 10^7 */
+static const OpcUa_Int64 MSECS_TO_100NS = 10000LL; /* 10^4 */
+static const OpcUa_Int64 MICROSECS_TO_100NS = 10LL; /* 10 */
+static int daysInMonth[2][12] = {
+    {31,28,31,30,31,30,31,31,30,31,30,31},
+    {31,29,31,30,31,30,31,31,30,31,30,31}
+};
+#define IS_LEAP(n)      ((!((n) % 400) || (!((n) % 4) && ((n) % 100))) != 0)
+#define LEAP_YEARS_SINCE_1601(year) (((year)-1601) / 4) - (((year)-1601) / 100) + (((year)-1601) / 400)
+
+/*============================================================================
+* The OpcUa_GetTimeOfDay function (returns the time in OpcUa_TimeVal format)
+*===========================================================================*/
+OpcUa_Void OpcUa_P_DateTime_GetTimeOfDay(OpcUa_TimeVal* a_pTimeVal)
+{
+    OpcUa_DateTime dateTime = OpcUa_P_DateTime_UtcNow();
+    OpcUa_Int64 unixtime = dateTime.dwHighDateTime;
+
+    unixtime <<= 32;
+    unixtime += dateTime.dwLowDateTime;
+    unixtime /= MICROSECS_TO_100NS;
+    a_pTimeVal->uintMicroSeconds = (OpcUa_UInt32)(unixtime % 1000000);
+    unixtime /= 1000000;
+    unixtime -= SECS_BETWEEN_EPOCHS;
+    a_pTimeVal->uintSeconds = unixtime;
+}
+
+/*============================================================================
+* The OpcUa_UtcNow function (returns the time in OpcUa_DateTime format)
+*===========================================================================*/
+OpcUa_DateTime OpcUa_P_DateTime_UtcNow(OpcUa_Void)
+{
+    struct timeval now;
+    OpcUa_Int64 unixtime = 0;
+    OpcUa_DateTime dateTime;
+
+    if(gettimeofday(&now, NULL) == 0)
+    {
+        unixtime = now.tv_sec;
+        unixtime += SECS_BETWEEN_EPOCHS;
+        unixtime *= SECS_TO_100NS;
+        unixtime += now.tv_usec * MICROSECS_TO_100NS;
+    }
+    dateTime.dwHighDateTime = unixtime >> 32;
+    dateTime.dwLowDateTime  = unixtime & 0xffffffff;
+
+    return dateTime;
+}
+
+/*============================================================================
+* Convert DateTime into String
+*===========================================================================*/
+OpcUa_StatusCode OpcUa_P_DateTime_GetStringFromDateTime(    OpcUa_DateTime a_DateTime,
+                                                            OpcUa_StringA  a_pBuffer,
+                                                            OpcUa_UInt32   a_uLength)
+{
+    const char*         formatString = "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ";
+    OpcUa_UInt64 unixtime = a_DateTime.dwHighDateTime;
+    int ms;
+    int tm_sec, tm_min, tm_hour;
+    int tm_year, tm_mon, tm_mday;
+    int apiResult;
+    int leapYears;
+
+    unixtime <<= 32;
+    unixtime += a_DateTime.dwLowDateTime;
+    unixtime /= MSECS_TO_100NS;
+    ms = (int)(unixtime % 1000);
+    unixtime /= 1000;
+    tm_sec = (int)(unixtime % 60);
+    unixtime /= 60;
+    tm_min = (int)(unixtime % 60);
+    unixtime /= 60;
+    tm_hour = (int)(unixtime % 24);
+    unixtime /= 24;
+    tm_mday = (int)unixtime; /* days never cause overflow */
+
+    /* calculate years and remaining days in year according to leap years */
+    /* first assumption, assume every year has 365 days */
+    tm_year = 1601 + tm_mday / 365;
+    tm_mday = tm_mday % 365;
+
+    leapYears = LEAP_YEARS_SINCE_1601(tm_year);
+    /* correct remaining days according to "used" leap days */
+    tm_mday -= leapYears;
+    /* handle possible remaining days underflow
+      A loop can be implemented here since the correction has to be executed maximal 5 times */
+    while(tm_mday < 0)
+    {
+        tm_year--;
+        if(IS_LEAP(tm_year))
+        {
+            tm_mday += 366;
+        }
+        else
+        {
+            tm_mday += 365;
+        }
+    }
+
+    if(tm_year > 9999)
+    {
+        return OpcUa_Bad;
+    }
+
+    tm_mon = 0;
+    while(tm_mon < 11)
+    {
+        if(tm_mday < daysInMonth[IS_LEAP(tm_year)][tm_mon])
+        {
+            break;
+        }
+        tm_mday -= daysInMonth[IS_LEAP(tm_year)][tm_mon];
+        tm_mon++;
+    }
+
+    apiResult = snprintf(a_pBuffer, a_uLength, formatString,
+        tm_year, tm_mon+1, tm_mday+1,
+        tm_hour, tm_min, tm_sec, ms);
+
+    if(apiResult < 20)
+    {
+        return OpcUa_Bad;
+    }
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+* Convert String into DateTime
+*===========================================================================*/
+OpcUa_StatusCode OpcUa_P_DateTime_GetDateTimeFromString(OpcUa_StringA   a_pchDateTimeString,
+                                                        OpcUa_DateTime* a_pDateTime)
+{
+    int         milliSet    = 0;
+    int         tm_sec, tm_min, tm_hour;
+    int         tm_year, tm_mon, tm_mday;
+    int         ms          = 0;
+    size_t      stringLength;
+    size_t      maxStringLength;
+    char        years[5]    = "YYYY";
+    char        months[3]   = "MM";
+    char        days[3]     = "DD";
+    char        hours[3]    = "HH";
+    char        minutes[3]  = "MM";
+    char        seconds[3]  = "SS";
+    char        millis[4]   = "000";
+    char        timeZone[4] = "000";
+    int         zoneValue   = 0;
+    int         signPosition;
+    int         tmpVar;
+    OpcUa_Int64 unixtime;
+
+    /***************************************************************
+    *  ToDo:
+    *  Timezone can have values from -12 to +14
+    *  At the moment only timezones from -12 to +12 are expected
+    *  timezones can also have minutes
+    *  at the moment minutes are ignored
+    ***************************************************************/
+
+    if(    a_pchDateTimeString  == OpcUa_Null
+        || a_pDateTime          == OpcUa_Null)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    /* ToDo: set max stringlength we accept */
+    maxStringLength = 50;
+
+    stringLength = strlen(a_pchDateTimeString);
+
+    /*  check length of string -> there can be any number of digits behind ms */
+    /*  we'll ignore anything beyond 3 */
+    if(stringLength < 20 || stringLength > maxStringLength)
+    {
+        return OpcUa_BadSyntaxError;
+    }
+
+    /* simple syntax check */
+    /* ToDo: we might add some syntax checks here */
+    if(a_pchDateTimeString[4] == '-' && a_pchDateTimeString[7] == '-' && (a_pchDateTimeString[10] == 'T' || a_pchDateTimeString[10] == 't') && a_pchDateTimeString[13] == ':' &&  a_pchDateTimeString[16] == ':' )
+    {
+        /* copy strings */
+        strncpy(years, a_pchDateTimeString, 4);
+        strncpy(months, a_pchDateTimeString+5, 2);
+        strncpy(days, a_pchDateTimeString+8, 2);
+        strncpy(hours, a_pchDateTimeString+11, 2);
+        strncpy(minutes, a_pchDateTimeString+14, 2);
+        strncpy(seconds, a_pchDateTimeString+17, 2);
+
+        /* parse date and time */
+        tm_year = strtol(years, 0, 10);
+        if(tm_year < 1601 || tm_year > 9999)
+        {
+            return OpcUa_BadOutOfRange;
+        }
+        tm_mon = strtol(months, 0, 10) - 1;
+        if(tm_mon < 0 || tm_mon > 11)
+        {
+            return OpcUa_BadOutOfRange;
+        }
+        tm_mday = strtol(days, 0, 10) - 1;
+        if(tm_mday < 0 || tm_mday >= daysInMonth[IS_LEAP(tm_year)][tm_mon])
+        {
+            return OpcUa_BadOutOfRange;
+        }
+        tm_hour = strtol(hours, 0, 10);
+        if(tm_hour < 0 || tm_hour > 23)
+        {
+            return OpcUa_BadOutOfRange;
+        }
+        tm_min = strtol(minutes, 0, 10);
+        if(tm_min < 0 || tm_min > 59)
+        {
+            return OpcUa_BadOutOfRange;
+        }
+        tm_sec = strtol(seconds, 0, 10);
+        if(tm_sec < 0 || tm_sec > 59)
+        {
+            return OpcUa_BadOutOfRange;
+        }
+
+        signPosition = 19;
+
+        /* check if ms are set */
+        if(a_pchDateTimeString[signPosition] == '.')
+        {
+            milliSet = 1;
+        }
+
+        /* find sign for timezone or Z (we accept 'z' and 'Z' here) */
+        while(a_pchDateTimeString[signPosition] != '\0' && a_pchDateTimeString[signPosition] != '+' && a_pchDateTimeString[signPosition] != '-' && a_pchDateTimeString[signPosition] != 'Z' && a_pchDateTimeString[signPosition] != 'z')
+        {
+            ++signPosition;
+        }
+
+        if(a_pchDateTimeString[signPosition] == 'z' ||a_pchDateTimeString[signPosition] == 'Z')
+        {
+            /* utc time */
+            if(milliSet)
+            {
+                /* be careful we can have more or less than 3 digits of milliseconds */
+                tmpVar = signPosition - 20;
+                if(tmpVar > 3)
+                {
+                    tmpVar = 3;
+                }
+                strncpy(millis, a_pchDateTimeString+20, tmpVar);
+                ms = strtol(millis, 0, 10);
+            }
+        }
+        else if(a_pchDateTimeString[signPosition] == '+' || a_pchDateTimeString[signPosition] == '-')
+        {
+            /* copy timezone */
+            strncpy(timeZone, a_pchDateTimeString+signPosition, 3);
+            /* strtol will take care of the sign */
+            zoneValue = strtol(timeZone, 0, 10);
+
+            if(zoneValue < -12 || zoneValue > 12)
+            {
+                return OpcUa_BadOutOfRange;
+            }
+
+            if(milliSet)
+            {
+                /* be careful we can have more or less than 3 digits of milliseconds */
+                tmpVar = signPosition - 20;
+                if(tmpVar > 3)
+                {
+                    tmpVar = 3;
+                }
+                strncpy(millis, a_pchDateTimeString+20, tmpVar);
+                ms = strtol(millis, 0, 10);
+            }
+        }
+        else
+        {
+            /* error -> no timezone specified */
+            /* a time without timezone is not an absolute time but a time span */
+            /* we might handle this as UTC */
+            return OpcUa_BadSyntaxError;
+        }
+
+        /* correct time to UTC */
+        tmpVar = tm_hour - zoneValue;
+        if(tmpVar > 23)
+        {
+            tm_hour = tmpVar - 24;
+            tm_mday++;     /* add one day to date */
+        }
+        else if(tmpVar < 0)
+        {
+            tm_hour = tmpVar + 24;
+            tm_mday--;    /* substract one day from date */
+        }
+        else
+        {
+            tm_hour = tm_hour - zoneValue;
+        }
+    }
+    else /* if(strchr(a_pchDateTimeString, ':')) */
+    {
+        /* other formats are not supported at the moment */
+        /* 20060606T06:48:48Z */
+        /* 20060606T064848Z */
+        return OpcUa_BadSyntaxError;
+    }
+
+    /* compute days in year */
+    for(tmpVar = 0; tmpVar < tm_mon; tmpVar++)
+    {
+        tm_mday += daysInMonth[IS_LEAP(tm_year)][tmpVar];
+    }
+
+    /* compute days since 1.1.1601, (including leap days) */
+    unixtime = 365*(tm_year-1601) + tm_mday + LEAP_YEARS_SINCE_1601(tm_year);
+
+    /* convert to seconds */
+    unixtime *= 24*3600;
+    /* add day time to 64 bit value */
+    unixtime += 3600*tm_hour + 60*tm_min + tm_sec;
+    /* convert to FILETIME */
+    unixtime *= SECS_TO_100NS;
+    /* add the milliseconds */
+    unixtime += ms * MSECS_TO_100NS;
+
+    a_pDateTime->dwHighDateTime = unixtime >> 32;
+    a_pDateTime->dwLowDateTime  = unixtime & 0xffffffff;
+
+    return OpcUa_Good;
+}

--- a/Stack/platforms/vxworks/opcua_p_datetime.h
+++ b/Stack/platforms/vxworks/opcua_p_datetime.h
@@ -1,0 +1,63 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/**
+ * @brief Returns the current time in UTC.
+ */
+OpcUa_DateTime  OpcUa_P_DateTime_UtcNow(void);
+
+/**
+ * @brief Returns the time in OpcUa_TimeVal format.
+ */
+OpcUa_Void      OpcUa_P_DateTime_GetTimeOfDay(OpcUa_TimeVal*  pValue);
+
+/**
+* @brief Converts the given OpcUa_DateTime into an ascii string.
+*
+* @param DateTime   [in]        The DateTime value to convert.
+* @param Buffer     [in/out]    At least 20+1 bytes of buffer.
+* @param DateTime   [in]        The length of the given buffer.
+*
+* @return Error Code
+*/
+OpcUa_StatusCode OpcUa_P_DateTime_GetStringFromDateTime(OpcUa_DateTime datetime,
+                                                        OpcUa_StringA  buffer,
+                                                        OpcUa_UInt32   length);
+
+
+/**
+* @brief Converts the given (ascii) string into OpcUa_DateTime format.
+*
+* @param DateTimeString [in]    Buffer containing the DateTime string. Must not be OpcUa_Null!
+* @param DateTime      [out]    Pointer to the OpcUa_DateTime value in which the converted value will be stored.
+*
+* @return Status Code.
+*/
+OpcUa_StatusCode  OpcUa_P_DateTime_GetDateTimeFromString( OpcUa_StringA   DateTimeString,
+                                                        OpcUa_DateTime* DateTime);

--- a/Stack/platforms/vxworks/opcua_p_guid.c
+++ b/Stack/platforms/vxworks/opcua_p_guid.c
@@ -1,0 +1,83 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#include <stdlib.h>
+#include <time.h>
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+
+#if OPCUA_REQUIRE_OPENSSL
+#include <openssl/rand.h>
+#endif
+
+/* own headers */
+#include <opcua_guid.h>
+#include <opcua_p_guid.h>
+/*============================================================================
+ * CreateGuid
+ *===========================================================================*/
+/**
+* CreateGuid generates a global unique identifier.
+*/
+OpcUa_Guid* OpcUa_P_Guid_Create(OpcUa_Guid* guid)
+{
+#if OPCUA_REQUIRE_OPENSSL
+    if(RAND_bytes((unsigned char*)guid, sizeof(OpcUa_Guid)) <= 0)
+    {
+        return OpcUa_Null;
+    }
+#else
+    unsigned int *data = (unsigned int*)guid;
+    int chunks = 16 / sizeof(unsigned int);
+    static const int intbits = sizeof(int)*8;
+    static int randbits = 0;
+    if(!randbits)
+    {
+        int max = RAND_MAX;
+        do { ++randbits; } while ((max=max>>1));
+        srand(time(NULL));
+        rand(); /* Skip first */
+    }
+
+    while(chunks--)
+    {
+        unsigned int randNumber = 0;
+        int filled;
+        for (filled = 0; filled < intbits; filled += randbits)
+            randNumber |= (unsigned int)rand()<<filled;
+        memcpy(data+chunks, &randNumber, sizeof(randNumber));
+    }
+#endif /* OPCUA_REQUIRE_OPENSSL */
+
+    guid->Data4[0] = (guid->Data4[0] & 0x3F) | 0x80; /* UV_DCE */
+    guid->Data3 = (guid->Data3 & 0x0FFF) | 0x4000;   /* UV_Random */
+
+    return guid;
+}

--- a/Stack/platforms/vxworks/opcua_p_guid.h
+++ b/Stack/platforms/vxworks/opcua_p_guid.h
@@ -1,0 +1,36 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/*============================================================================
+ * CreateGuid
+ *===========================================================================*/
+/**
+* Create a GUID in binary format.
+*/
+OpcUa_Guid* OPCUA_DLLCALL OpcUa_P_Guid_Create(OpcUa_Guid* Guid);

--- a/Stack/platforms/vxworks/opcua_p_interface.c
+++ b/Stack/platforms/vxworks/opcua_p_interface.c
@@ -1,0 +1,258 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright (c) 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+16oct18,lan  port to vxWorks.
+*/
+
+/* system includes */
+#include <stdlib.h>
+#include <stdio.h>
+
+/* platform layer base */
+#include <opcua_p_internal.h>
+
+/* all platform modules */
+#include <opcua_p_datetime.h>
+#include <opcua_p_guid.h>
+#include <opcua_p_memory.h>
+#include <opcua_p_mutex.h>
+#include <opcua_p_semaphore.h>
+#include <opcua_p_socket_interface.h>
+#include <opcua_p_socket_ssl.h>
+#include <opcua_p_string.h>
+#include <opcua_p_thread.h>
+#include <opcua_p_trace.h>
+#include <opcua_p_socket.h>
+#include <opcua_p_timer.h>
+#include <opcua_p_utilities.h>
+#include <opcua_p_cryptofactory.h>
+#include <opcua_p_pkifactory.h>
+#include <opcua_p_openssl.h>
+
+int OpcUa_Stack_P_Priority = 100;
+
+/*============================================================================
+ * g_OpcUa_Port_CallTable
+ *===========================================================================*/
+/** @brief static calltable for accessing platform layer functions. */
+OpcUa_Port_CallTable g_OpcUa_Port_CallTable =
+{
+    0,                      /* version number */
+    OpcUa_Null,
+
+    /* Memory */
+    OpcUa_P_Memory_Alloc,
+    OpcUa_P_Memory_Free,
+    OpcUa_P_Memory_ReAlloc,
+    OpcUa_P_Memory_MemCpy,  /* OpcUa_P_Memory_MemCpy may be removed */
+    OpcUa_Null,             /* OpcUa_P_Memory_MemSet may be removed */
+
+    /* DateTime */
+    OpcUa_P_DateTime_UtcNow,
+    OpcUa_P_DateTime_GetTimeOfDay,
+    OpcUa_P_DateTime_GetStringFromDateTime,
+    OpcUa_P_DateTime_GetDateTimeFromString,
+
+    /* Mutex */
+    OpcUa_P_Mutex_CreateImp,
+    OpcUa_P_Mutex_DeleteImp,
+    OpcUa_P_Mutex_LockImp,
+    OpcUa_P_Mutex_UnlockImp,
+
+    /* Guid */
+    OpcUa_P_Guid_Create,
+
+    /* Semaphore */
+    OpcUa_P_Semaphore_Create,
+    OpcUa_P_Semaphore_Delete,
+    OpcUa_P_Semaphore_Wait,
+    OpcUa_P_Semaphore_TimedWait,
+    OpcUa_P_Semaphore_Post,
+
+    /* Thread */
+    OpcUa_P_Thread_Create,
+    OpcUa_P_Thread_Delete,
+    OpcUa_P_Thread_Start,
+    OpcUa_P_Thread_Sleep,
+    OpcUa_P_Thread_GetCurrentThreadId,
+
+    /* Trace */
+    OpcUa_P_Trace,
+    OpcUa_P_Trace_Initialize,
+    OpcUa_P_Trace_Clear,
+
+    /* String */
+    OpcUa_P_String_strncpy,
+    OpcUa_P_String_strncat,
+    OpcUa_P_String_strlen,
+    OpcUa_P_String_strncmp,
+    OpcUa_P_String_strnicmp,
+    OpcUa_P_String_vsnprintf,
+
+    /* Utilities */
+    OpcUa_P_QSort,
+    OpcUa_P_BSearch,
+    OpcUa_P_GetLastError,
+    OpcUa_P_GetTickCount,
+    OpcUa_P_CharAToInt,
+
+    /* Network */
+    OpcUa_P_Socket_InetAddr,
+    OpcUa_P_SocketManager_Create,
+    OpcUa_P_SocketManager_Delete,
+    OpcUa_P_SocketManager_CreateServer,
+    OpcUa_P_SocketManager_CreateClient,
+#if OPCUA_P_SOCKETMANAGER_SUPPORT_SSL
+    OpcUa_P_SocketManager_CreateSslServer,
+    OpcUa_P_SocketManager_CreateSslClient,
+#else
+    OpcUa_Null,
+    OpcUa_Null,
+#endif
+    OpcUa_P_SocketManager_SignalEvent,
+    OpcUa_P_SocketManager_ServeLoop,
+    OpcUa_P_Socket_Read,
+    OpcUa_P_Socket_Write,
+    OpcUa_P_Socket_Close,
+    OpcUa_P_Socket_GetPeerInfo,
+    OpcUa_P_Socket_GetLastError,
+    OpcUa_P_Socket_SetUserData,
+    OpcUa_P_Socket_InitializeNetwork,
+    OpcUa_P_Socket_CleanupNetwork,
+
+    /* Security */
+    OpcUa_P_CryptoFactory_CreateCryptoProvider,
+    OpcUa_P_CryptoFactory_DeleteCryptoProvider,
+    OpcUa_P_PKIFactory_CreatePKIProvider,
+    OpcUa_P_PKIFactory_DeletePKIProvider,
+
+    /* Timer */
+    OpcUa_P_Timer_Create,
+    OpcUa_P_Timer_Delete,
+    OpcUa_P_Timer_CleanupTimers,
+
+    /* OpenSSL */
+#if OPCUA_REQUIRE_OPENSSL
+    OpcUa_P_OpenSSL_Thread_Cleanup,
+    OpcUa_P_OpenSSL_SeedPRNG,
+    OpcUa_P_OpenSSL_DestroySecretData
+#else
+    OpcUa_Null,
+    OpcUa_Null,
+    OpcUa_Null
+#endif
+};
+
+/*============================================================================
+ * OpcUa_P_Initialize
+ *===========================================================================*/
+/**
+ * Description
+ * @param ppCallTable Description
+ * @return Description
+ */
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Initialize(OpcUa_Handle* a_pPlatformLayerHandle)
+{
+    OpcUa_StatusCode uStatus = OpcUa_Good;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pPlatformLayerHandle);
+
+    /* was this function called before */
+    if(g_OpcUa_Port_CallTable.pReserved != OpcUa_Null)
+    {
+        return OpcUa_BadInvalidState;
+    }
+
+#if OPCUA_REQUIRE_OPENSSL
+#ifdef VXWORKS_OPENSSL_REQUIRE_INIT
+    uStatus = OpcUa_P_OpenSSL_Initialize();
+    OpcUa_ReturnErrorIfBad(uStatus);
+#endif
+#endif /* OPCUA_REQUIRE_OPENSSL */
+
+    uStatus = OpcUa_P_InitializeTimers();
+    if(OpcUa_IsBad(uStatus))
+    {
+#if OPCUA_REQUIRE_OPENSSL
+        OpcUa_P_OpenSSL_Cleanup();
+#endif /* OPCUA_REQUIRE_OPENSSL */
+        return uStatus;
+    }
+
+    /* marked as initialized */
+    g_OpcUa_Port_CallTable.pReserved = (OpcUa_Void*)1;
+
+    /* assign call table */
+    *a_pPlatformLayerHandle = (OpcUa_Handle)&g_OpcUa_Port_CallTable;
+
+    return uStatus;
+}
+
+/*============================================================================
+ * OpcUa_P_Clean
+ *===========================================================================*/
+/**
+ * Description
+ * @param ppCallTable Description
+ * @return Description
+ */
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Clean(OpcUa_Handle* a_pPlatformLayerHandle)
+{
+    if(*a_pPlatformLayerHandle == OpcUa_Null)
+    {
+        return OpcUa_BadInvalidState;
+    }
+
+    if(*a_pPlatformLayerHandle != &g_OpcUa_Port_CallTable)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    /* check if initialized */
+    if(g_OpcUa_Port_CallTable.pReserved == OpcUa_Null)
+    {
+        return OpcUa_BadInvalidState;
+    }
+
+#if OPCUA_REQUIRE_OPENSSL
+    OpcUa_P_OpenSSL_Cleanup();
+#endif /* OPCUA_REQUIRE_OPENSSL */
+
+    /* marked as cleared */
+    g_OpcUa_Port_CallTable.pReserved = OpcUa_Null;
+
+    *a_pPlatformLayerHandle = OpcUa_Null;
+
+    return OpcUa_Good;
+}

--- a/Stack/platforms/vxworks/opcua_p_interface.h
+++ b/Stack/platforms/vxworks/opcua_p_interface.h
@@ -1,0 +1,695 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* platformdefs and types must be known before including this file */
+
+#ifndef _OpcUa__P_Interface_H_
+#define _OpcUa__P_Interface_H_ 1
+
+#include <stdarg.h>
+#include "opcua_p_crypto.h"
+#include "opcua_p_pki.h"
+
+OPCUA_BEGIN_EXTERN_C
+
+/***********************************************************************************************/
+/** @brief The handle for the platform thread. */
+typedef OpcUa_Void* OpcUa_RawThread;
+
+/***********************************************************************************************/
+
+/** @brief Function prototype for receiving callbacks from the timer module. */
+typedef OpcUa_StatusCode (OPCUA_DLLCALL OpcUa_P_Timer_Callback)(OpcUa_Void*     pvCallbackData,
+                                                                OpcUa_Timer     hTimer,
+                                                                OpcUa_UInt32    msecElapsed);
+
+/***********************************************************************************************/
+
+/** @brief Trace hook function type. */
+typedef OpcUa_Void (OPCUA_DLLCALL *OpcUa_P_TraceHook)(OpcUa_CharA* sMessage);
+
+/***********************************************************************************************/
+
+/** @brief returned on error, where other type than statuscode is used (write). */
+#define OPCUA_SOCKET_ERROR ((OpcUa_Int32)(-1))
+
+/** @brief maximum time to wait for a send operation to complete. */
+#define OPCUA_SOCKET_SELECT_TIMEOUT 1000
+
+/**
+ * These types of events can be sent to the registered callback function from the socket.
+ * The receiver can register to them has to react on this events.
+ */
+#define OPCUA_SOCKET_NO_EVENT        0x0000 /* no event happened... */
+#define OPCUA_SOCKET_READ_EVENT      0x0001 /* socket ready for receiving */
+#define OPCUA_SOCKET_WRITE_EVENT     0x0002 /* socket ready for writing */
+#define OPCUA_SOCKET_CLOSE_EVENT     0x0004 /* socket has been closed */
+#define OPCUA_SOCKET_EXCEPT_EVENT    0x0008 /* an exception ocurred on a socket */
+#define OPCUA_SOCKET_TIMEOUT_EVENT   0x0010 /* the connection on a socket timed out */
+#define OPCUA_SOCKET_SHUTDOWN_EVENT  0x0020 /* server shuts down */
+#define OPCUA_SOCKET_CONNECT_EVENT   0x0040 /* the socket has connected to the remote node (client) */
+#define OPCUA_SOCKET_ACCEPT_EVENT    0x0080 /* a remote node has connected to this socket (server) */
+#define OPCUA_SOCKET_NEED_BUFFER_EVENT  0x0100 /* the socketmanager requests a temporary buffer */
+#define OPCUA_SOCKET_FREE_BUFFER_EVENT  0x0200 /* the socketmanager releases the temporary buffer */
+
+/** @brief Events which are set outside the event loop. (external events) */
+#define OPCUA_SOCKET_RENEWLOOP_EVENT 0x0100 /* restarts loop to reinterpret socket list */
+#define OPCUA_SOCKET_USER_EVENT      0x0200 /* user fired an event */
+
+/** @brief SocketManager behaviour control. */
+#define OPCUA_SOCKET_NO_FLAG                    0   /* standard behaviour */
+#define OPCUA_SOCKET_REJECT_ON_NO_THREAD        1   /* thread pooling; reject connection if no worker thread i available */
+#define OPCUA_SOCKET_DONT_CLOSE_ON_EXCEPT       2   /* don't close a socket if an except event occurred */
+#define OPCUA_SOCKET_SPAWN_THREAD_ON_ACCEPT     4   /* assing each accepted socket a new thread */
+
+/** @brief PeerInfo settings */
+#define OPCUA_P_SOCKETGETPEERINFO_V2                OPCUA_CONFIG_YES
+#define OPCUA_P_PEERINFO_MIN_SIZE                   64
+
+/** @brief Toggle SSL support in the socket manager class. */
+#ifdef OPCUA_HAVE_HTTPS
+#define OPCUA_P_SOCKETMANAGER_SUPPORT_SSL           OPCUA_CONFIG_YES
+#else
+#define OPCUA_P_SOCKETMANAGER_SUPPORT_SSL           OPCUA_CONFIG_NO
+#endif
+
+/** @brief How SSL verifies certificates. */
+#define OPCUA_P_SOCKETMANAGER_SSL_VERIFY_OPTION     (SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
+
+/** @brief How SSL negotiates the tls protocol. */
+#define OPCUA_P_SOCKETMANAGER_SSL_PROTOCOL_OPTION   (SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TICKET)
+
+/*============================================================================
+ * The Socket Event Callback
+ *===========================================================================*/
+/** @brief Function prototype for receiving event callbacks from the socket module. */
+typedef OpcUa_StatusCode (*OpcUa_Socket_EventCallback)( OpcUa_Socket   hSocket,
+                                                        OpcUa_UInt32   uintSocketEvent,
+                                                        OpcUa_Void*    pUserData,
+                                                        OpcUa_UInt16   usPortNumber,
+                                                        OpcUa_Boolean  bIsSSL);
+
+
+/*============================================================================
+ * The Certificate Validation Event Callback
+ *===========================================================================*/
+/** @brief Function prototype for receiving event callbacks from the socket module.
+  * pCertificate is the full client certificate including certificate chain
+  * uResult is the Status Code from PKI_ValidateCertificate
+  * returning OpcUa_Bad rejects a valid certificate
+  * returning OpcUa_Good accepts a valid certificate
+  * returnint Opcua_BadContinue accepts an otherwise invalid certificate
+  */
+typedef OpcUa_StatusCode (*OpcUa_Socket_CertificateCallback)(   OpcUa_Socket        hSocket,
+                                                                OpcUa_Void*         pUserData,
+                                                                OpcUa_ByteString*   pCertificate,
+                                                                OpcUa_StatusCode    uResult);
+
+
+/*============================================================================
+ * va_list definitions
+ *===========================================================================*/
+#define varg_list va_list
+
+#define VA_START(ap,v)  va_start(ap, v)
+#define VA_END(ap)      va_end(ap)
+
+
+/***********************************************************************************************/
+
+/** @brief Servicetable exposing the platform layer functionality to the stack implementation. */
+typedef struct S_OpcUa_Port_CallTable OpcUa_Port_CallTable;
+
+struct S_OpcUa_Port_CallTable
+{
+    /**@name CallTable Header */
+    /**@{*/
+
+    /** Size of the platform layer calltable */
+    OpcUa_UInt32 uSize;
+
+    /** Reserved for platform layer internal use. */
+    OpcUa_Void*  pReserved;
+
+    /**@} CallTable Header */
+    /**@name Memory Functions */
+    /**@{*/
+
+    /** @brief Standard malloc functionality.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void*         (OPCUA_DLLCALL* MemAlloc)                 ( OpcUa_UInt32                uSize);
+
+    /** @brief Standard free functionality.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* MemFree)                  ( OpcUa_Void*                 pMemory);
+
+    /** @brief Standard realloc functionality.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void*         (OPCUA_DLLCALL* MemReAlloc)               ( OpcUa_Void*                 pBuffer,
+                                                                    OpcUa_UInt32                nSize);
+
+    /** @brief Standard memcpy functionality but with target and source buffer size for additional checks.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* MemCpy)                   ( OpcUa_Void*                 pBuffer,
+                                                                    OpcUa_UInt32                nSizeInBytes,
+                                                                    OpcUa_Void*                 pSource,
+                                                                    OpcUa_UInt32                nCount);
+
+    /** @brief Standard memset functionality.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void*         (OPCUA_DLLCALL* MemSet)                   ( OpcUa_Void*                 pMemory,
+                                                                    OpcUa_Byte                  uValue,
+                                                                    OpcUa_UInt32                uMemorySize);
+
+    /**@} Memory Functions */
+    /**@name Date and Time Functions */
+    /**@{*/
+
+    /** @brief Returns the current time in the OpcUa_DateTime format.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_DateTime      (OPCUA_DLLCALL* UtcNow)                   ( void);
+
+    /** @brief Returns the current time in the OpcUa_TimeVal format.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* GetTimeOfDay)             ( OpcUa_TimeVal*              pValue);
+
+    /** @brief Converts the given datetime into a string format. The given buffer must have a length of
+     *         at least 25 bytes. The length parameter is used for verification. The format is %04d-%02d-%02dT%02d:%02d:%02d.%03dZ.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* GetStringFromDateTime)    ( OpcUa_DateTime              datetime,
+                                                                    OpcUa_StringA               buffer,
+                                                                    OpcUa_UInt32                length);
+
+    /** @brief Converts a given DateTimeString into the OpcUa_DateTime format. The string format is
+     *         %04d-%02d-%02dT%02d:%02d:%02d.%03dZ
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* GetDateTimeFromString)    ( OpcUa_StringA               DateTimeString,
+                                                                    OpcUa_DateTime*             DateTime);
+
+    /**@} Date and Time Functions */
+    /**@name Mutex Functions */
+    /**@{*/
+
+#if OPCUA_MUTEX_ERROR_CHECKING   /* debug version of mutex */
+    /** @brief Create a recursive mutex and get information about the origin of the call.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* MutexCreate)              ( OpcUa_Mutex*                phNewMutex, char* file, int line);
+
+    /** @brief Delete a mutex and get information about the origin of the call.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* MutexDelete)              ( OpcUa_Mutex*                phMutex,    char* file, int line);
+
+    /** @brief Lock the given mutex and get information about the origin of the call.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* MutexLock)                ( OpcUa_Mutex                 hMutex,     char* file, int line);
+
+    /** @brief Unlock the given mutex and get information about the origin of the call.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* MutexUnlock)              ( OpcUa_Mutex                 hMutex,     char* file, int line);
+
+#else /* OPCUA_MUTEX_ERROR_CHECKING */
+
+    /** @brief Create a recursive mutex.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* MutexCreate)              ( OpcUa_Mutex*                phNewMutex);
+
+    /** @brief Delete a mutex.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* MutexDelete)              ( OpcUa_Mutex*                phMutex);
+
+    /** @brief Lock the given mutex.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* MutexLock)                ( OpcUa_Mutex                 hMutex);
+
+    /** @brief Unlock the given mutex.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* MutexUnlock)              ( OpcUa_Mutex                 hMutex);
+
+#endif /* OPCUA_MUTEX_ERROR_CHECKING */
+
+    /**@} Mutex Functions */
+    /**@name Guid Functions */
+    /**@{*/
+
+    /* Guid */
+    /** @brief Create a guid and store it at the given memory position.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Guid*         (OPCUA_DLLCALL* GuidCreate)               ( OpcUa_Guid*                 pGuid);
+
+    /**@} Guid Functions */
+    /**@name Semaphore Functions */
+    /**@{*/
+
+    /** @brief Create a semaphore object and set its initial and max value.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SemaphoreCreate)          ( OpcUa_Semaphore*            phNewSemaphore,
+                                                                    OpcUa_UInt32                uInitalValue,
+                                                                    OpcUa_UInt32                uMaxRange);
+
+    /** @brief Delete the semaphore.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* SemaphoreDelete)          ( OpcUa_Semaphore*            phSemaphore);
+
+    /** @brief Wait on a semaphore until you can acquire 1.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SemaphoreWait)            ( OpcUa_Semaphore             HSemaphore);
+
+    /** @brief Same as @see SemaphoreWait but with a maximum waiting time of msecTimeout milliseconds before
+     *         OpcUa_GoodNonCriticalTimeout is returned.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SemaphoreTimedWait)       ( OpcUa_Semaphore             hSemaphore,
+                                                                    OpcUa_UInt32                msecTimeout);
+
+    /** @brief Post/Release a semaphore with a count of uReleaseCount.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SemaphorePost)            ( OpcUa_Semaphore             hSemaphore,
+                                                                    OpcUa_UInt32                uReleaseCount);
+
+    /**@} Semaphore Functions */
+    /**@name Thread Functions */
+    /**@{*/
+
+    /** @brief Reserve resources for a system thread object.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* ThreadCreate)             ( OpcUa_RawThread*            pThread);
+
+    /** @brief Free the resources reserved for the system thread object.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* ThreadDelete)             ( OpcUa_RawThread*            pRawThread);
+
+    /** @brief Start the system thread and let it execute the given function with pArguments.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* ThreadStart)              ( OpcUa_RawThread             pThread,
+                                                                    OpcUa_PfnInternalThreadMain pfnStartFunction,
+                                                                    OpcUa_Void*                 pArguments);
+
+    /** @brief Let the calling thread sleep for msecTimeout milliseconds.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* ThreadSleep)              ( OpcUa_UInt32                msecTimeout);
+
+    /** @brief Get an unique id for the calling system thread.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    unsigned long       (OPCUA_DLLCALL* ThreadGetCurrentId)       ( void);
+
+    /**@} Thread Functions */
+    /**@name Trace Functions */
+    /**@{*/
+
+    /** @brief Output the given zero terminated string to the systems tracing device.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* Trace)                    (
+#if OPCUA_TRACE_FILE_LINE_INFO
+                                                                    OpcUa_UInt32 level,
+                                                                    OpcUa_CharA* sFile,
+                                                                    OpcUa_UInt32 line,
+#endif
+                                                                    OpcUa_CharA* sFormat);
+
+    /** @brief Initialize tracing functionality during stack initialization before any call to Trace is made.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* TraceInitialize)          ( void);
+
+    /** @brief Clean up the tracing functionality after stack clean up after the last call to Trace was made.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* TraceClear)               ( void);
+
+    /**@} Trace Functions */
+    /**@name String Functions */
+    /**@{*/
+
+    /** @brief Standard strncpy functionality.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* StrnCpy)                  ( OpcUa_StringA               strDestination,
+                                                                    OpcUa_UInt32                uiDestSize,
+                                                                    OpcUa_StringA               strSource,
+                                                                    OpcUa_UInt32                uiLength);
+
+    /** @brief Standard strncat functionality.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* StrnCat)                  ( OpcUa_StringA               strDestination,
+                                                                    OpcUa_UInt32                uiDestSize,
+                                                                    OpcUa_StringA               strSource,
+                                                                    OpcUa_UInt32                uiLength);
+
+    /** @brief Standard strlen functionality.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Int32         (OPCUA_DLLCALL* StrLen)                   ( OpcUa_StringA               pCString);
+
+    /** @brief Standard strncmp functionality.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Int32         (OPCUA_DLLCALL* StrnCmp)                  ( OpcUa_StringA               string1,
+                                                                    OpcUa_StringA               string2,
+                                                                    OpcUa_UInt32                uiLength);
+
+    /** @brief Standard strnicmp functionality.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Int32         (OPCUA_DLLCALL* StrniCmp)                 ( OpcUa_StringA               string1,
+                                                                    OpcUa_StringA               string2,
+                                                                    OpcUa_UInt32                uiLength);
+
+    /** @brief Standard strvsnprintf functionality.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Int32         (OPCUA_DLLCALL* StrVsnPrintf)             ( OpcUa_StringA               sDest,
+                                                                    OpcUa_UInt32                uCount,
+                                                                    const OpcUa_StringA         sFormat,
+                                                                    varg_list                   argptr)
+                                                                    OPCUA_PRINTF_VALIST(3);
+
+    /**@} String Functions */
+    /**@name Utility Functions */
+    /**@{*/
+
+    /** @brief Implementation of the qsort algorithm.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* qSort)                    ( OpcUa_Void*                 pElements,
+                                                                    OpcUa_UInt32                nElementCount,
+                                                                    OpcUa_UInt32                nElementSize,
+                                                                    OpcUa_PfnCompare*           pfnCompare,
+                                                                    OpcUa_Void*                 pContext);
+
+    /** @brief Implementation of the bsearch algorithm.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void*         (OPCUA_DLLCALL* bSearch)                  ( OpcUa_Void*                 pKey,
+                                                                    OpcUa_Void*                 pElements,
+                                                                    OpcUa_UInt32                nElementCount,
+                                                                    OpcUa_UInt32                nElementSize,
+                                                                    OpcUa_PfnCompare*           pfnCompare,
+                                                                    OpcUa_Void*                 pContext);
+
+    /** @brief Get last error (aka errno);
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_UInt32        (OPCUA_DLLCALL* UtilGetLastError)         ( void);
+
+    /** @brief Get the current millisecond tick count of the system.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_UInt32        (OPCUA_DLLCALL* UtilGetTickCount)         ( void);
+
+    /** @brief Convert the given string containing a number into OpcUa_Int32.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Int32         (OPCUA_DLLCALL* CharToInt)                ( OpcUa_StringA               sValue);
+
+    /**@} Utility Functions */
+    /**@name Network Functions */
+    /**@{*/
+
+    /** @brief Convert the given IPv4 network address into its binary representation.
+     *         No longer required by the stack. Can be ignored and may be removed in future versions.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_UInt32        (OPCUA_DLLCALL* InetAddr)                 ( OpcUa_StringA               sRemoteAddress);
+
+    /** @brief Create a socket manager with the ability to host nSockets sockets and use the given runtime behavior flags.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketManagerCreate)      ( OpcUa_SocketManager*        ppSocketManager,
+                                                                    OpcUa_UInt32                nSockets,
+                                                                    OpcUa_UInt32                uintFlags);
+
+    /** @brief Delete the given socket manager and block until the operation is completed and no more callbacks will be invoked.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* SocketManagerDelete)      ( OpcUa_SocketManager*        pSocketManager);
+
+    /** @brief Request the given socket manager to use one of its sockets as a listen socket for incoming connect requests.
+     *         The given address contains a network address (and port number if required). This function is completed
+     *         synchronously. The given callback will be invoked when client connection requests on the listen socket are accepted.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketManagerCreateServer)( OpcUa_SocketManager         pSocketManager,
+                                                                    OpcUa_StringA               sRemoteAdress,
+                                                                    OpcUa_Boolean               bListenOnAllInterfaces,
+                                                                    OpcUa_Socket_EventCallback  pfnSocketCallBack,
+                                                                    OpcUa_Void*                 pCookie,
+                                                                    OpcUa_Socket*               ppSocket);
+
+    /** @brief Request the given socket manager to use one of its sockets for a client connection to the given address data.
+     *         The created socket handle is returned immediately if the operation could be started without errors. The local
+     *         port number is optional and ignored if 0. Else, the socket manager tries to bind the connection to the local
+     *         port. This function is completed asynchronously by calling pfnSocketCallBack providing pCookie. This callback
+     *         is also called for follow-up events on the socket. If the connection can not be established, the callback is
+     *         called with an exception event.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketManagerCreateClient)( OpcUa_SocketManager         pSocketManager,
+                                                                    OpcUa_StringA               sRemoteAdress,
+                                                                    OpcUa_UInt16                usLocalPort,
+                                                                    OpcUa_Socket_EventCallback  pfnSocketCallBack,
+                                                                    OpcUa_Void*                 pCookie,
+                                                                    OpcUa_Socket*               ppSocket);
+
+    /** @brief Request the given socket manager to use one of its sockets as a listen socket for incoming connect requests.
+     *         The given address contains a network address (and port number if required). This function is completed
+     *         synchronously. The given callback will be invoked when client connection requests on the listen socket are accepted.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketManagerCreateSslServer)( OpcUa_SocketManager              pSocketManager,
+                                                                       OpcUa_StringA                    sRemoteAdress,
+                                                                       OpcUa_Boolean                    bListenOnAllInterfaces,
+                                                                       OpcUa_ByteString*                pServerCertificate,
+                                                                       OpcUa_Key*                       pServerPrivateKey,
+                                                                       OpcUa_Void*                      pPKIConfig,
+                                                                       OpcUa_Socket_EventCallback       pfnSocketCallBack,
+                                                                       OpcUa_Socket_CertificateCallback pfnCertificateCallBack,
+                                                                       OpcUa_Void*                      pCookie,
+                                                                       OpcUa_Socket*                    ppSocket);
+
+    /** @brief Request the given socket manager to use one of its sockets for a client connection to the given address data.
+     *         The created socket handle is returned immediately if the operation could be started without errors. The local
+     *         port number is optional and ignored if 0. Else, the socket manager tries to bind the connection to the local
+     *         port. This function is completed asynchronously by calling pfnSocketCallBack providing pCookie. This callback
+     *         is also called for follow-up events on the socket. If the connection can not be established, the callback is
+     *         called with an exception event.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketManagerCreateSslClient)( OpcUa_SocketManager              pSocketManager,
+                                                                       OpcUa_StringA                    sRemoteAdress,
+                                                                       OpcUa_UInt16                     usLocalPort,
+                                                                       OpcUa_ByteString*                pClientCertificate,
+                                                                       OpcUa_Key*                       pClientPrivateKey,
+                                                                       OpcUa_Void*                      pPKIConfig,
+                                                                       OpcUa_Socket_EventCallback       pfnSocketCallBack,
+                                                                       OpcUa_Socket_CertificateCallback pfnCertificateCallBack,
+                                                                       OpcUa_Void*                      pCookie,
+                                                                       OpcUa_Socket*                    ppSocket);
+
+    /** @brief Raise the given event for the given socket manager or all socket managers hosted by the platform layer.
+     *         If pSocketManager is OpcUa_Null and bAllManager is OpcUa_False, the call is directed to the default socket
+     *         manager in single thread configuration. The only event raised by the stack itself is the OPCUA_SOCKET_SHUTDOWN_EVENT
+     *         when the stack wants a socket manager to stop processing network events.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketManagerSignalEvent) ( OpcUa_SocketManager         pSocketManager,
+                                                                    OpcUa_UInt32                uintEvent,
+                                                                    OpcUa_Boolean               bAllManagers);
+
+    /** @brief Invoke the communication message loop for the given socket manager and block for a maximum of msecTimout seconds.
+     *         Caller can decide whether the loop should be executed once or until the shutdown event is signalled to the loop by
+     *         setting bRunOnce approbriately. The implementation decides whether timer callbacks are also invoked during the call.
+     *         This function is mainly intended to process network and timer events in a single threaded environment. In a multi
+     *         threaded environment, this function is executed in loop by a dedicated thread and not by the application.
+     *         If pSocketManager is OpcUa_Null, the call is directed to the default socket manager in single thread configuration.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketManagerServeLoop)   ( OpcUa_SocketManager         pSocketManager,
+                                                                    OpcUa_UInt32                msecTimeout,
+                                                                    OpcUa_Boolean               bRunOnce);
+
+    /** @brief Copy a maximum of BufferSize bytes from the socket into pBuffer and store the actual number bytes copied in puintBytesRead.
+     *         A *puintBytesRead is interpreted as a shutdown of the inbound direction by the peer.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketRead)               ( OpcUa_Socket                hSocket,
+                                                                    OpcUa_Byte*                 pBuffer,
+                                                                    OpcUa_UInt32                BufferSize,
+                                                                    OpcUa_UInt32*               puintBytesRead);
+
+    /** @brief Write BufferSize bytes from pBuffer to the given Socket and dont return until all data is copied if bBlock is OpcUa_True.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Int32         (OPCUA_DLLCALL* SocketWrite)              ( OpcUa_Socket                hSocket,
+                                                                    OpcUa_Byte*                 pBuffer,
+                                                                    OpcUa_UInt32                BufferSize,
+                                                                    OpcUa_Boolean               bBlock);
+
+    /** @brief Close the given socket handle.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketClose)              ( OpcUa_Socket                hSocket);
+
+    /** @brief Get IPv4 address and port number for the peer connected to the given socket.
+     *         (Ignore call for non IPv4 connections. May get changed in future revisions.)
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketGetPeerInfo)        ( OpcUa_Socket                hSocket,
+                                                                    OpcUa_CharA*                achPeerInfoBuffer,
+                                                                    OpcUa_UInt32                uiPeerInfoBufferSize);
+
+    /** @brief Get the status code for the last error that occurred on the given socket.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketGetLastError)       ( OpcUa_Socket                hSocket);
+
+    /** @brief Set the socket user data on the given socket.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* SocketSetUserData)        ( OpcUa_Socket                hSocket,
+                                                                    OpcUa_Void*                 pvUserData);
+
+    /** @brief Initialize all network resources required by the platform layer. Called during proxystub initialization.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* NetworkInitialize)        ( void);
+
+    /** @brief Clean up and free all network resources. Called during proxystub cleanup procedure.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* NetworkCleanup)           ( void);
+
+    /**@} Network Functions */
+    /**@name Crypto and PKI Functions */
+    /**@{*/
+
+    /** @brief Create a crypto provider based on the given security policy URI.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* CreateCryptoProvider)   (   OpcUa_StringA               Uri,
+                                                                    OpcUa_CryptoProvider*       pProvider);
+
+    /** @brief Delete the given crypto provider.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* DeleteCryptoProvider)   (   OpcUa_CryptoProvider*       pProvider);
+
+    /** @brief Create a PKI Provider based on the given certificate store configuration.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* CreatePKIProvider)      (   OpcUa_Void*                 pCertificateStoreConfig,
+                                                                    OpcUa_PKIProvider*          pProvider);
+
+    /** @brief Delete the given PKI provider.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* DeletePKIProvider)      (   OpcUa_PKIProvider*          pProvider);
+
+
+    /**@} Crypto and PKI Functions*/
+    /**@name Timer Functions */
+    /**@{*/
+
+    /** @brief Create a timer which calls the TimerCallback every msecInterval milliseconds with pvCallbackData.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* TimerCreate)            (   OpcUa_Timer*                phTimer,
+                                                                    OpcUa_UInt32                msecInterval,
+                                                                    OpcUa_P_Timer_Callback*     fTimerCallback,
+                                                                    OpcUa_P_Timer_Callback*     fKillCallback,
+                                                                    OpcUa_Void*                 pvCallbackData);
+
+    /** @brief Delete the given timer and call the KillCallback when it is guaranteed that no more TimerCallbacks occur.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* TimerDelete)            (   OpcUa_Timer*                phTimer);
+
+    /** @brief Called before cleanup to stop all active timers and invoke timer delete callbacks.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* TimersCleanup)            ( void);
+
+    /**@} Timer Functions */
+
+    /** @brief Called to clean up OpenSSL state information in client threads.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* ThreadCleanupOpenSSL)     ( void);
+
+    /** @brief seeds pseudo-random-number-generator of openssl.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_StatusCode    (OPCUA_DLLCALL* OpenSSLSeedPRNG)          ( OpcUa_Byte*                 seed,
+                                                                    OpcUa_Int                   bytes);
+
+    /** @brief destroys secret data values in a cyptographically safe way.
+     *  @ingroup opcua_platformlayer_interface
+     */
+    OpcUa_Void          (OPCUA_DLLCALL* DestroySecretData)        ( OpcUa_Void*                 data,
+                                                                    OpcUa_UInt32                bytes);
+
+}; /* struct S_OpcUa_Port_CallTable */
+
+
+/** @brief Platform layer initialization. */
+OPCUA_EXPORT OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Initialize(OpcUa_Handle* ppCallTable);
+
+/** @brief Platform layer clean up. */
+OPCUA_EXPORT OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Clean(     OpcUa_Handle* ppCallTable);
+
+OPCUA_END_EXTERN_C
+#endif /* _OpcUa__P_Interface_H_ */

--- a/Stack/platforms/vxworks/opcua_p_internal.c
+++ b/Stack/platforms/vxworks/opcua_p_internal.c
@@ -1,0 +1,106 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* System Headers */
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+
+/*============================================================================
+ * Calculate DateTime Difference
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_GetDateTimeDiff( OpcUa_DateTime  a_Value1,
+                                                        OpcUa_DateTime  a_Value2,
+                                                        OpcUa_DateTime* a_pResult)
+{
+    OpcUa_UInt64 ullValue1 = 0;
+    OpcUa_UInt64 ullValue2 = 0;
+    OpcUa_UInt64 ullResult = 0;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pResult);
+
+    a_pResult->dwLowDateTime = (OpcUa_UInt32)0;
+    a_pResult->dwHighDateTime = (OpcUa_UInt32)0;
+
+    ullValue1 = a_Value1.dwHighDateTime;
+    ullValue1 = (ullValue1 << 32) + a_Value1.dwLowDateTime;
+
+    ullValue2 = a_Value2.dwHighDateTime;
+    ullValue2 = (ullValue2 << 32) + a_Value2.dwLowDateTime;
+
+    if(ullValue1 > ullValue2)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    ullResult = ullValue2 - ullValue1;
+
+    a_pResult->dwLowDateTime = (OpcUa_UInt32)(ullResult & 0x00000000FFFFFFFFll);
+    a_pResult->dwHighDateTime = (OpcUa_UInt32)((ullResult & 0xFFFFFFFF00000000ll) >> 32);
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * Calculate DateTime Difference In Seconds (Rounded)
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_GetDateTimeDiffInSeconds32(  OpcUa_DateTime  a_Value1,
+                                                                    OpcUa_DateTime  a_Value2,
+                                                                    OpcUa_UInt32*   a_puResult)
+{
+    OpcUa_UInt64 ullValue1 = 0;
+    OpcUa_UInt64 ullValue2 = 0;
+    OpcUa_UInt64 ullResult = 0;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_puResult);
+
+    *a_puResult = (OpcUa_UInt32)0;
+
+    ullValue1 = a_Value1.dwHighDateTime;
+    ullValue1 = (ullValue1 << 32) + a_Value1.dwLowDateTime;
+
+    ullValue2 = a_Value2.dwHighDateTime;
+    ullValue2 = (ullValue2 << 32) + a_Value2.dwLowDateTime;
+
+    if(ullValue1 > ullValue2)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    ullResult = (OpcUa_UInt64)((ullValue2 - ullValue1 + 5000000) / 10000000);
+
+    if(ullResult > (OpcUa_UInt64)OpcUa_UInt32_Max)
+    {
+        return OpcUa_BadOutOfRange;
+    }
+
+    *a_puResult = (OpcUa_UInt32)(ullResult & 0x00000000FFFFFFFF);
+
+    return OpcUa_Good;
+}

--- a/Stack/platforms/vxworks/opcua_p_internal.h
+++ b/Stack/platforms/vxworks/opcua_p_internal.h
@@ -1,0 +1,139 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* UA platform definitions, base types and configuration */
+#include "opcua_platformdefs.h"
+
+/* proxy stub errorhandling */
+#include <opcua_statuscodes.h>
+#include <opcua_stackstatuscodes.h>
+#include <opcua_errorhandling.h>
+#include <opcua_trace.h>
+
+#include "opcua_p_trace.h"
+
+/* import types for crypto and pki */
+#include <opcua_types.h>
+#include <opcua_crypto.h>
+#include <opcua_pki.h>
+
+/* own */
+#include "opcua_p_interface.h"
+
+/**********************************************************************************/
+/*/  Configuration section.                                                      /*/
+/**********************************************************************************/
+
+/** @brief Maximum wait time for socket module (in Milli sec) at the blocking point. */
+#define OPCUA_SOCKET_MAXLOOPTIME (OpcUa_UInt32)1000 /* reloop after 1 second to be secure against hangs */
+
+/**********************************************************************************/
+/*/  Trace Modules.                                                              /*/
+/**********************************************************************************/
+#define OpcUa_Module_P_OpenSSL 0
+#define OpcUa_Module_P_CryptoFactory 1
+#define OpcUa_Module_P_PKIFactory 2
+
+/**********************************************************************************/
+/*/  Evaluate Security Config.                                                   /*/
+/**********************************************************************************/
+/* determine whether OpenSSL is required and set the compiler switch appropriately */
+/* DON'T CHANGE THIS MANUALLY, just add new supported policies! */
+
+#if OPCUA_SUPPORT_SECURITYPOLICY_BASIC128RSA15 && !defined(OPCUA_REQUIRE_OPENSSL)
+#  define OPCUA_REQUIRE_OPENSSL OPCUA_CONFIG_YES
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_BASIC128RSA15 */
+
+#if OPCUA_SUPPORT_SECURITYPOLICY_BASIC256 && !defined(OPCUA_REQUIRE_OPENSSL)
+#  define OPCUA_REQUIRE_OPENSSL OPCUA_CONFIG_YES
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_BASIC256 */
+
+#if OPCUA_SUPPORT_SECURITYPOLICY_BASIC256SHA256 && !defined(OPCUA_REQUIRE_OPENSSL)
+#  define OPCUA_REQUIRE_OPENSSL OPCUA_CONFIG_YES
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_BASIC256SHA256 */
+
+#if OPCUA_SUPPORT_SECURITYPOLICY_AES128SHA256RSAOAEP && !defined(OPCUA_REQUIRE_OPENSSL)
+#  define OPCUA_REQUIRE_OPENSSL OPCUA_CONFIG_YES
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_AES128SHA256RSAOAEP */
+
+#if OPCUA_SUPPORT_SECURITYPOLICY_AES256SHA256RSAPSS && !defined(OPCUA_REQUIRE_OPENSSL)
+#  define OPCUA_REQUIRE_OPENSSL OPCUA_CONFIG_YES
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_AES256SHA256RSAPSS */
+
+#if OPCUA_SUPPORT_PKI && !defined(OPCUA_REQUIRE_OPENSSL)
+#  define OPCUA_REQUIRE_OPENSSL OPCUA_CONFIG_YES
+#endif /* OPCUA_SUPPORT_PKI */
+
+/* if at all, OPCUA_REQUIRE_OPENSSL is set to OPCUA_CONFIG_YES before this point. */
+#ifndef OPCUA_REQUIRE_OPENSSL
+#define OPCUA_REQUIRE_OPENSSL OPCUA_CONFIG_NO
+#endif /* OPCUA_REQUIRE_OPENSSL */
+
+#if OPCUA_REQUIRE_OPENSSL && !OPCUA_HAVE_OPENSSL
+# error OpenSSL required; globally define OPCUA_HAVE_OPENSSL if OpenSSL is available or disable security!
+#endif
+
+#if defined(OPCUA_HAVE_HTTPS) && !OPCUA_SUPPORT_PKI
+# error PKI support is required for HTTPS; globally define OPCUA_SUPPORT_PKI
+#endif
+
+/**********************************************************************************/
+/*/  Internally used function prototypes.                                        /*/
+/**********************************************************************************/
+
+/**
+ * @brief Subtract Value 2 from Value 1 and store the result in the given location.
+ *
+ * @param a_Value1  [ in] Operand 1
+ * @param a_Value2  [ in] Operand 2
+ * @param a_pResult [out] Pointer to designated result.
+ * @return Statuscode; OpcUa_Good; OpcUa_BadInvalidArgument; OpcUa_BadOutOfRange;
+ */
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_GetDateTimeDiff(
+    OpcUa_DateTime  a_Value1,
+    OpcUa_DateTime  a_Value2,
+    OpcUa_DateTime* a_pResult);
+
+/**
+ * @brief Subtract Value 2 from Value 1 and store the result as rounded number
+ *        of seconds in Result.
+ *
+ * @param a_Value1   [ in] Operand 1
+ * @param a_Value2   [ in] Operand 2
+ * @param a_puResult [out] Pointer to designated result.
+ * @return Statuscode; OpcUa_Good; OpcUa_BadInvalidArgument; OpcUa_BadOutOfRange;
+ */
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_GetDateTimeDiffInSeconds32(
+    OpcUa_DateTime  a_Value1,
+    OpcUa_DateTime  a_Value2,
+    OpcUa_UInt32*   a_puResult);
+
+/**********************************************************************************/
+/*/                                 End Of File.                                 /*/
+/**********************************************************************************/

--- a/Stack/platforms/vxworks/opcua_p_memory.c
+++ b/Stack/platforms/vxworks/opcua_p_memory.c
@@ -1,0 +1,88 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#include <stdlib.h>
+#include <memory.h>
+#include <errno.h>      /* for errornumbers when using save functions */
+
+#include <opcua_p_internal.h>
+#include <opcua_p_memory.h>
+
+
+/*============================================================================
+ * OpcUa_Memory_Alloc
+ *===========================================================================*/
+OpcUa_Void* OPCUA_DLLCALL OpcUa_P_Memory_Alloc(OpcUa_UInt32 nSize)
+{
+    return malloc(nSize);
+}
+
+/*============================================================================
+ * OpcUa_Memory_ReAlloc
+ *===========================================================================*/
+OpcUa_Void* OPCUA_DLLCALL OpcUa_P_Memory_ReAlloc(OpcUa_Void* pBuffer, OpcUa_UInt32 nSize)
+{
+    return realloc(pBuffer, nSize);
+}
+
+/*============================================================================
+ * OpcUa_Memory_Free
+ *===========================================================================*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Memory_Free(OpcUa_Void* pBuffer)
+{
+    free(pBuffer);
+}
+
+/*============================================================================
+ * OpcUa_Memory_MemCpy
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Memory_MemCpy(
+    OpcUa_Void*  pBuffer,
+    OpcUa_UInt32 nSizeInBytes,
+    OpcUa_Void*  pSource,
+    OpcUa_UInt32 nCount)
+{
+    if(     pBuffer == OpcUa_Null
+        ||  pSource == OpcUa_Null)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    if(nSizeInBytes < nCount)
+    {
+        return OpcUa_BadOutOfRange;
+    }
+
+    if(memcpy(pBuffer, pSource, nCount) != pBuffer)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    return OpcUa_Good;
+}

--- a/Stack/platforms/vxworks/opcua_p_memory.h
+++ b/Stack/platforms/vxworks/opcua_p_memory.h
@@ -1,0 +1,66 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_P_Memory_H_
+#define _OpcUa_P_Memory_H_ 1
+
+#include <opcua_platformdefs.h>
+
+OPCUA_BEGIN_EXTERN_C
+
+/**
+ * @see OpcUa_Memory_Alloc
+ */
+OpcUa_Void* OPCUA_DLLCALL OpcUa_P_Memory_Alloc(         OpcUa_UInt32 nSize);
+
+/**
+ * @brief Reallocates a new block of memory
+ *
+ * @param pBuffer [in] The existing memory block.
+ * @param nSize   [in] The size of the block to allocate.
+ */
+OpcUa_Void* OPCUA_DLLCALL OpcUa_P_Memory_ReAlloc(       OpcUa_Void*  pBuffer,
+                                                        OpcUa_UInt32 nSize);
+
+/**
+ * @see OpcUa_Memory_Free
+ */
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Memory_Free(           OpcUa_Void* pvBuffer);
+
+/**
+ * @see OpcUa_Memory_MemCpy
+ */
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Memory_MemCpy(   OpcUa_Void*  pBuffer,
+                                                        OpcUa_UInt32 nSizeInBytes,
+                                                        OpcUa_Void*  pSource,
+                                                        OpcUa_UInt32 nCount);
+
+OPCUA_END_EXTERN_C
+
+#endif /* _OpcUa_P_Memory_H_ */

--- a/Stack/platforms/vxworks/opcua_p_mutex.c
+++ b/Stack/platforms/vxworks/opcua_p_mutex.c
@@ -1,0 +1,123 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright (c) 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+06nov18,lan  use VxWorks native api to implement OPC-UA mutex.
+*/
+
+#include <vxWorks.h>
+#include <semLib.h>
+#include <opcua_platformdefs.h>
+#include <opcua.h>
+
+#include <opcua_mutex.h>
+#include <opcua_p_mutex.h>
+#include <opcua_p_memory.h>
+#include <string.h>
+#include <stdlib.h>
+
+/*============================================================================
+ * Allocate the mutex.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Mutex_Create
+    (
+    OpcUa_Mutex* a_phMutex
+    )
+    {
+    SEM_ID          semid;
+
+    semid = semMCreate (SEM_Q_PRIORITY | SEM_INVERSION_SAFE | SEM_DELETE_SAFE);
+
+    if (semid == SEM_ID_NULL)
+        {
+        return OpcUa_Bad;
+        }
+
+    *a_phMutex = semid;
+
+    return OpcUa_Good;
+    }
+
+/*============================================================================
+ * Clear and free the mutex.
+ *===========================================================================*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Mutex_Delete
+    (
+    OpcUa_Mutex* a_phMutex
+    )
+    {
+    SEM_ID          semid;
+
+    if (a_phMutex == OpcUa_Null || *a_phMutex == OpcUa_Null)
+        {
+        return;
+        }
+
+    semid = (SEM_ID) *a_phMutex;
+
+    (void) semDelete (semid);
+    *a_phMutex = OpcUa_Null;
+    }
+
+/*============================================================================
+ * Lock the mutex.
+ *===========================================================================*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Mutex_Lock
+    (
+    OpcUa_Mutex hMutex
+    )
+    {
+    SEM_ID          semid;
+
+    if (hMutex != OpcUa_Null)
+        {
+        semid = (SEM_ID) hMutex;
+        (void) semTake (semid, WAIT_FOREVER);
+        }
+    }
+
+/*============================================================================
+ * Unlock the mutex.
+ *===========================================================================*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Mutex_Unlock
+    (
+    OpcUa_Mutex hMutex
+    )
+    {
+    SEM_ID          semid;
+    if (hMutex != OpcUa_Null)
+        {
+        semid = (SEM_ID) hMutex;
+        (void) semGive (semid);
+        }
+    }

--- a/Stack/platforms/vxworks/opcua_p_mutex.h
+++ b/Stack/platforms/vxworks/opcua_p_mutex.h
@@ -1,0 +1,52 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#if OPCUA_MUTEX_ERROR_CHECKING
+    #define OpcUa_P_Mutex_Create(xMutex)  OpcUa_P_Mutex_CreateImp( xMutex, __FILE__, __LINE__)
+    #define OpcUa_P_Mutex_Delete(xMutex)  OpcUa_P_Mutex_DeleteImp( xMutex, __FILE__, __LINE__)
+    #define OpcUa_P_Mutex_Lock(xMutex)    OpcUa_P_Mutex_LockImp(   xMutex, __FILE__, __LINE__)
+    #define OpcUa_P_Mutex_Unlock(xMutex)  OpcUa_P_Mutex_UnlockImp( xMutex, __FILE__, __LINE__)
+#else /* OPCUA_MUTEX_ERROR_CHECKING */
+    #define OpcUa_P_Mutex_Create(xMutex)  OpcUa_P_Mutex_CreateImp( xMutex)
+    #define OpcUa_P_Mutex_Delete(xMutex)  OpcUa_P_Mutex_DeleteImp( xMutex)
+    #define OpcUa_P_Mutex_Lock(xMutex)    OpcUa_P_Mutex_LockImp(   xMutex)
+    #define OpcUa_P_Mutex_Unlock(xMutex)  OpcUa_P_Mutex_UnlockImp( xMutex)
+#endif /* OPCUA_MUTEX_ERROR_CHECKING */
+
+#if OPCUA_MUTEX_ERROR_CHECKING
+    OpcUa_StatusCode    OPCUA_DLLCALL OpcUa_P_Mutex_CreateImp(   OpcUa_Mutex*    phMutex, char* file, int line);
+    OpcUa_Void          OPCUA_DLLCALL OpcUa_P_Mutex_DeleteImp(   OpcUa_Mutex*    phMutex, char* file, int line);
+    OpcUa_Void          OPCUA_DLLCALL OpcUa_P_Mutex_LockImp(     OpcUa_Mutex     hMutex,  char* file, int line);
+    OpcUa_Void          OPCUA_DLLCALL OpcUa_P_Mutex_UnlockImp(   OpcUa_Mutex     hMutex,  char* file, int line);
+#else
+    OpcUa_StatusCode    OPCUA_DLLCALL OpcUa_P_Mutex_CreateImp(   OpcUa_Mutex*    phMutex);
+    OpcUa_Void          OPCUA_DLLCALL OpcUa_P_Mutex_DeleteImp(   OpcUa_Mutex*    phMutex);
+    OpcUa_Void          OPCUA_DLLCALL OpcUa_P_Mutex_LockImp(     OpcUa_Mutex     hMutex);
+    OpcUa_Void          OPCUA_DLLCALL OpcUa_P_Mutex_UnlockImp(   OpcUa_Mutex     hMutex);
+#endif

--- a/Stack/platforms/vxworks/opcua_p_openssl.c
+++ b/Stack/platforms/vxworks/opcua_p_openssl.c
@@ -1,0 +1,1128 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_memory.h>
+#include <opcua_p_cryptofactory.h>
+#include <opcua_p_mutex.h>
+#include <opcua_p_thread.h>
+
+#if OPCUA_REQUIRE_OPENSSL
+
+/* System Headers */
+#include <openssl/rsa.h>
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <openssl/err.h>
+
+#if OPCUA_P_SOCKETMANAGER_SUPPORT_SSL
+#include <openssl/ssl.h>
+#endif /* OPCUA_P_SOCKETMANAGER_SUPPORT_SSL */
+
+/* own headers */
+#include <opcua_p_openssl.h>
+
+/*============================================================================
+ * OpcUa_P_ByteString_Clear
+ *===========================================================================*/
+static
+OpcUa_Void OpcUa_P_ByteString_Clear(OpcUa_ByteString* a_pValue)
+{
+    if(a_pValue == OpcUa_Null)
+    {
+        return;
+    }
+
+    a_pValue->Length = -1;
+
+    if(a_pValue->Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(a_pValue->Data);
+        a_pValue->Data = OpcUa_Null;
+    }
+}
+
+/*============================================================================
+ * OpcUa_Key_Clear
+ *===========================================================================*/
+static
+OpcUa_Void OpcUa_P_Key_Clear(OpcUa_Key* a_pKey)
+{
+    OpcUa_P_ByteString_Clear(&a_pKey->Key);
+    a_pKey->Type = 0;
+}
+
+/*============================================================================
+ * simple locking for OpenSSL
+ *===========================================================================*/
+#if OPCUA_USE_SYNCHRONISATION
+static OpcUa_Mutex OpenSSL_Mutex;
+static void OpcUa_P_OpenSSL_Lock(int mode, int type, const char *file, int line)
+{
+    OpcUa_ReferenceParameter(type);
+    OpcUa_ReferenceParameter(file);
+    OpcUa_ReferenceParameter(line);
+    if(mode & CRYPTO_LOCK)
+    {
+        OpcUa_P_Mutex_Lock(OpenSSL_Mutex);
+    }
+    if(mode & CRYPTO_UNLOCK)
+    {
+        OpcUa_P_Mutex_Unlock(OpenSSL_Mutex);
+    }
+}
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_Initialize
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize(OpcUa_Void)
+{
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_StatusCode uStatus = OpcUa_P_Mutex_Create(&OpenSSL_Mutex);
+    OpcUa_ReturnErrorIfBad(uStatus);
+    CRYPTO_set_id_callback(OpcUa_P_Thread_GetCurrentThreadId);
+    CRYPTO_set_locking_callback(OpcUa_P_OpenSSL_Lock);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+    OpenSSL_add_all_algorithms();
+#if OPCUA_P_SOCKETMANAGER_SUPPORT_SSL
+    SSL_library_init();
+    SSL_load_error_strings();
+#endif /* OPCUA_P_SOCKETMANAGER_SUPPORT_SSL */
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_Cleanup
+ *===========================================================================*/
+OpcUa_Void OpcUa_P_OpenSSL_Cleanup(OpcUa_Void)
+{
+#if OPCUA_P_SOCKETMANAGER_SUPPORT_SSL
+#if OPENSSL_VERSION_NUMBER >= 0x1000200fL && !defined(OPENSSL_NO_COMP)
+    SSL_COMP_free_compression_methods();
+#endif
+#endif /* OPCUA_P_SOCKETMANAGER_SUPPORT_SSL */
+    EVP_cleanup();
+    CRYPTO_cleanup_all_ex_data();
+    ERR_remove_state(0);
+    ERR_free_strings();
+#if OPCUA_USE_SYNCHRONISATION
+    CRYPTO_set_id_callback(OpcUa_Null);
+    CRYPTO_set_locking_callback(OpcUa_Null);
+    OpcUa_P_Mutex_Delete(&OpenSSL_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_Thread_Cleanup()
+ *===========================================================================*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_OpenSSL_Thread_Cleanup(OpcUa_Void)
+{
+    ERR_remove_state(0);
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+    OPENSSL_thread_stop();
+#endif
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_DestroySecretData()
+ *===========================================================================*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_OpenSSL_DestroySecretData(OpcUa_Void*  data,
+                                                           OpcUa_UInt32 bytes)
+{
+    OPENSSL_cleanse(data, bytes);
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_AES_128_CBC_Encrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_128_CBC_Encrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32            a_plainTextLen, /* message length = outputlength */
+    OpcUa_Key*              a_key,
+    OpcUa_Byte*             a_pInitalVector,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "AES_128_CBC_Encrypt");
+
+    if(a_key->Key.Length == 16) /* check 128 bit key (16*8) */
+    {
+        uStatus = OpcUa_P_OpenSSL_AES_CBC_Encrypt(
+                                                a_pProvider,
+                                                a_pPlainText,
+                                                a_plainTextLen,
+                                                a_key,
+                                                a_pInitalVector,
+                                                a_pCipherText,
+                                                a_pCipherTextLen);
+    }
+    else
+    {
+        uStatus = OpcUa_Bad;
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_AES_128_CBC_Decrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_128_CBC_Decrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32            a_cipherTextLen, /* cipher length */
+    OpcUa_Key*              a_key,
+    OpcUa_Byte*             a_pInitalVector,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "AES_128_CBC_Decrypt");
+
+    if(a_key->Key.Length == 16) /* check 128 bit key (16*8) */
+    {
+        uStatus = OpcUa_P_OpenSSL_AES_CBC_Decrypt(
+                                                a_pProvider,
+                                                a_pCipherText,
+                                                a_cipherTextLen,
+                                                a_key,
+                                                a_pInitalVector,
+                                                a_pPlainText,
+                                                a_pCipherTextLen);
+    }
+    else
+    {
+        uStatus = OpcUa_Bad;
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_AES_128_CBC_Encrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_256_CBC_Encrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32            a_plainTextLen, /* message length = outputlength */
+    OpcUa_Key*              a_key,
+    OpcUa_Byte*             a_pInitalVector,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "AES_256_CBC_Encrypt");
+
+    if(a_key->Key.Length == 32) /* check 256 bit key (32*8) */
+    {
+        uStatus = OpcUa_P_OpenSSL_AES_CBC_Encrypt(
+                                                a_pProvider,
+                                                a_pPlainText,
+                                                a_plainTextLen,
+                                                a_key,
+                                                a_pInitalVector,
+                                                a_pCipherText,
+                                                a_pCipherTextLen);
+    }
+    else
+    {
+        uStatus = OpcUa_Bad;
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_AES_256_CBC_Decrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_256_CBC_Decrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32            a_cipherTextLen, /* cipher length */
+    OpcUa_Key*              a_key,
+    OpcUa_Byte*             a_pInitalVector,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "AES_256_CBC_Decrypt");
+
+    if(a_key->Key.Length == 32) /* check 256 bit key (32*8) */
+    {
+        uStatus = OpcUa_P_OpenSSL_AES_CBC_Decrypt(
+                                                a_pProvider,
+                                                a_pCipherText,
+                                                a_cipherTextLen,
+                                                a_key,
+                                                a_pInitalVector,
+                                                a_pPlainText,
+                                                a_pCipherTextLen);
+    }
+    else
+    {
+        uStatus = OpcUa_Bad;
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_PKCS1_V15_Encrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_Encrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32            a_plainTextLen,
+    OpcUa_Key*              a_publicKey,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_PKCS1_V15_Encrypt");
+
+    uStatus = OpcUa_P_OpenSSL_RSA_Public_Encrypt(   a_pProvider,
+                                                    a_pPlainText,
+                                                    a_plainTextLen,
+                                                    a_publicKey,
+                                                    RSA_PKCS1_PADDING,
+                                                    a_pCipherText,
+                                                    a_pCipherTextLen);
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_PKCS1_V15_Decrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_Decrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32            a_cipherTextLen,
+    OpcUa_Key*              a_privateKey,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32*           a_pPlainTextLen)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_PKCS1_V15_Decrypt");
+
+    uStatus = OpcUa_P_OpenSSL_RSA_Private_Decrypt(
+                                                a_pProvider,
+                                                a_pCipherText,
+                                                a_cipherTextLen,
+                                                a_privateKey,
+                                                RSA_PKCS1_PADDING,
+                                                a_pPlainText,
+                                                a_pPlainTextLen);
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_OAEP_Encrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_OAEP_Encrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32            a_plainTextLen,
+    OpcUa_Key*              a_publicKey,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_OAEP_Encrypt");
+
+    uStatus = OpcUa_P_OpenSSL_RSA_Public_Encrypt(
+                                                a_pProvider,
+                                                a_pPlainText,
+                                                a_plainTextLen,
+                                                a_publicKey,
+                                                RSA_PKCS1_OAEP_PADDING,
+                                                a_pCipherText,
+                                                a_pCipherTextLen);
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_OAEP_Decrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_OAEP_Decrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32            a_cipherTextLen,
+    OpcUa_Key*              a_privateKey,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32*           a_pPlainTextLen)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_OAEP_Decrypt");
+
+    uStatus = OpcUa_P_OpenSSL_RSA_Private_Decrypt(
+                                                a_pProvider,
+                                                a_pCipherText,
+                                                a_cipherTextLen,
+                                                a_privateKey,
+                                                RSA_PKCS1_OAEP_PADDING,
+                                                a_pPlainText,
+                                                a_pPlainTextLen);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_OAEP_SHA256_Encrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_OAEP_SHA256_Encrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32            a_plainTextLen,
+    OpcUa_Key*              a_publicKey,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_OAEP_SHA256_Encrypt");
+
+    uStatus = OpcUa_P_OpenSSL_RSA_SHA256_Public_Encrypt(
+                                                a_pProvider,
+                                                a_pPlainText,
+                                                a_plainTextLen,
+                                                a_publicKey,
+                                                a_pCipherText,
+                                                a_pCipherTextLen);
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_OAEP_Decrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_OAEP_SHA256_Decrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32            a_cipherTextLen,
+    OpcUa_Key*              a_privateKey,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32*           a_pPlainTextLen)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_OAEP_SHA256_Decrypt");
+
+    uStatus = OpcUa_P_OpenSSL_RSA_SHA256_Private_Decrypt(
+                                                a_pProvider,
+                                                a_pCipherText,
+                                                a_cipherTextLen,
+                                                a_privateKey,
+                                                a_pPlainText,
+                                                a_pPlainTextLen);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_HMAC_SHA1_Sign
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA1_Sign(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Byte*           a_pData,
+    OpcUa_UInt32          a_dataLen,
+    OpcUa_Key*            a_key,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "HMAC_SHA1_Sign");
+
+    uStatus = OpcUa_P_OpenSSL_HMAC_SHA1_Generate(
+                                                a_pProvider,
+                                                a_pData,
+                                                a_dataLen,
+                                                a_key,
+                                                a_pSignature);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_HMAC_SHA1_Verify
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA1_Verify(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Byte*           a_pData,
+    OpcUa_UInt32          a_dataLen,
+    OpcUa_Key*            a_key,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_ByteString mac = OPCUA_BYTESTRING_STATICINITIALIZER;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "HMAC_SHA1_Verify");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature);
+    OpcUa_ReturnErrorIfArgumentNull(a_key);
+    OpcUa_ReturnErrorIfArgumentNull(a_key->Key.Data);
+
+    if(a_key->Key.Length < 1)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(a_pSignature->Length != 20)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if((OpcUa_Int32)a_dataLen < 1)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    uStatus = OpcUa_P_OpenSSL_HMAC_SHA1_Generate(
+                                                a_pProvider,
+                                                a_pData,
+                                                a_dataLen,
+                                                a_key,
+                                                &mac);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    if(mac.Length > 0)
+    {
+        mac.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(mac.Length*sizeof(OpcUa_Byte));
+        OpcUa_GotoErrorIfAllocFailed(mac.Data);
+    }
+    else
+    {
+        uStatus = OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    uStatus = OpcUa_P_OpenSSL_HMAC_SHA1_Generate(
+                                                a_pProvider,
+                                                a_pData,
+                                                a_dataLen,
+                                                a_key,
+                                                &mac);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    if((OpcUa_MemCmp(mac.Data, a_pSignature->Data, mac.Length))==0)
+    {
+        uStatus = OpcUa_Good;
+    }
+    else
+    {
+        uStatus = OpcUa_BadSignatureInvalid;
+    }
+
+    if(mac.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(mac.Data);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(mac.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(mac.Data);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_HMAC_SHA1_Sign
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA256_Sign(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Byte*           a_pData,
+    OpcUa_UInt32          a_dataLen,
+    OpcUa_Key*            a_key,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "HMAC_SHA256_Sign");
+
+    uStatus = OpcUa_P_OpenSSL_HMAC_SHA2_256_Generate(
+                                                    a_pProvider,
+                                                    a_pData,
+                                                    a_dataLen,
+                                                    a_key,
+                                                    a_pSignature);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_HMAC_SHA256_Verify
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA256_Verify(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Byte*           a_pData,
+    OpcUa_UInt32          a_dataLen,
+    OpcUa_Key*            a_key,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_ByteString mac = OPCUA_BYTESTRING_STATICINITIALIZER;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "HMAC_SHA256_Verify");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature);
+
+    if(a_pSignature->Length != 32)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    uStatus = OpcUa_P_OpenSSL_HMAC_SHA2_256_Generate(
+                                                    a_pProvider,
+                                                    a_pData,
+                                                    a_dataLen,
+                                                    a_key,
+                                                    &mac);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    if(mac.Length > 0)
+    {
+        mac.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(mac.Length*sizeof(OpcUa_Byte));
+        OpcUa_GotoErrorIfAllocFailed(mac.Data);
+    }
+    else
+    {
+        uStatus = OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    uStatus = OpcUa_P_OpenSSL_HMAC_SHA2_256_Generate(
+                                                    a_pProvider,
+                                                    a_pData,
+                                                    a_dataLen,
+                                                    a_key,
+                                                    &mac);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    if((OpcUa_MemCmp(mac.Data, a_pSignature->Data, mac.Length))==0)
+    {
+        uStatus = OpcUa_Good;
+    }
+    else
+    {
+        uStatus = OpcUa_BadSignatureInvalid;
+    }
+
+    if(mac.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(mac.Data);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(mac.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(mac.Data);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA1_Sign
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA1_Sign(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_ByteString        a_data,
+    OpcUa_Key*              a_privateKey,
+    OpcUa_ByteString*       a_pSignature)
+{
+    OpcUa_ByteString messageDigest = OPCUA_BYTESTRING_STATICINITIALIZER;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_PKCS1_V15_SHA1_Sign");
+
+    messageDigest.Length = 20; /* 160 bit */
+
+    if(a_data.Data != OpcUa_Null)
+    {
+        messageDigest.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(messageDigest.Length);
+        OpcUa_GotoErrorIfAllocFailed(messageDigest.Data);
+
+        uStatus = OpcUa_P_OpenSSL_SHA1_Generate(    a_pProvider,
+                                                    a_data.Data,
+                                                    a_data.Length,
+                                                    messageDigest.Data);
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    uStatus = OpcUa_P_OpenSSL_RSA_Private_Sign( a_pProvider,
+                                                messageDigest,
+                                                a_privateKey,
+                                                NID_sha1,
+                                                a_pSignature);
+
+    if(messageDigest.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(messageDigest.Data);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(messageDigest.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(messageDigest.Data);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA1_Verify
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA1_Verify(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_data,
+    OpcUa_Key*            a_publicKey,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_ByteString messageDigest = OPCUA_BYTESTRING_STATICINITIALIZER;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_PKCS1_V15_SHA1_Verify");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature);
+
+    messageDigest.Length = 20; /* 160 bit */
+    messageDigest.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(messageDigest.Length*sizeof(OpcUa_Byte));
+    OpcUa_GotoErrorIfAllocFailed(messageDigest.Data);
+
+    uStatus = OpcUa_P_OpenSSL_SHA1_Generate(a_pProvider, a_data.Data, a_data.Length, messageDigest.Data);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    uStatus = OpcUa_P_OpenSSL_RSA_Public_Verify(
+                                                a_pProvider,
+                                                messageDigest,
+                                                a_publicKey,
+                                                NID_sha1,
+                                                a_pSignature);
+
+    OpcUa_P_Memory_Free(messageDigest.Data);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(messageDigest.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(messageDigest.Data);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA256_Sign
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA256_Sign(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_data,
+    OpcUa_Key*            a_privateKey,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_ByteString messageDigest = OPCUA_BYTESTRING_STATICINITIALIZER;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_PKCS1_V15_SHA256_Sign");
+
+    messageDigest.Length = 32; /* 256 bit */
+
+    if(a_data.Data != OpcUa_Null)
+    {
+        messageDigest.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(messageDigest.Length*sizeof(OpcUa_Byte));
+        OpcUa_GotoErrorIfAllocFailed(messageDigest.Data);
+
+        uStatus = OpcUa_P_OpenSSL_SHA2_256_Generate(a_pProvider, a_data.Data, a_data.Length, messageDigest.Data);
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    uStatus = OpcUa_P_OpenSSL_RSA_Private_Sign(
+                                                a_pProvider,
+                                                messageDigest,
+                                                a_privateKey,
+                                                NID_sha256,
+                                                a_pSignature);
+
+    if(messageDigest.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(messageDigest.Data);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(messageDigest.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(messageDigest.Data);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA256_Verify
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA256_Verify(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_data,
+    OpcUa_Key*            a_publicKey,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_ByteString messageDigest = OPCUA_BYTESTRING_STATICINITIALIZER;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_PKCS1_V15_SHA256_Verify");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature);
+
+    messageDigest.Length = 32; /* 256 bit */
+    messageDigest.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(messageDigest.Length*sizeof(OpcUa_Byte));
+    OpcUa_GotoErrorIfAllocFailed(messageDigest.Data);
+
+    uStatus = OpcUa_P_OpenSSL_SHA2_256_Generate(a_pProvider, a_data.Data, a_data.Length, messageDigest.Data);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    uStatus = OpcUa_P_OpenSSL_RSA_Public_Verify(
+                                                a_pProvider,
+                                                messageDigest,
+                                                a_publicKey,
+                                                NID_sha256,
+                                                a_pSignature);
+
+    OpcUa_P_Memory_Free(messageDigest.Data);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(messageDigest.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(messageDigest.Data);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_PSS_SHA256_Sign
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PSS_SHA256_Sign(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_data,
+    OpcUa_Key*            a_privateKey,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_ByteString messageDigest = OPCUA_BYTESTRING_STATICINITIALIZER;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_PSS_SHA256_Sign");
+
+    messageDigest.Length = 32; /* 256 bit */
+
+    if(a_data.Data != OpcUa_Null)
+    {
+        messageDigest.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(messageDigest.Length*sizeof(OpcUa_Byte));
+        OpcUa_GotoErrorIfAllocFailed(messageDigest.Data);
+
+        uStatus = OpcUa_P_OpenSSL_SHA2_256_Generate(a_pProvider, a_data.Data, a_data.Length, messageDigest.Data);
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    uStatus = OpcUa_P_OpenSSL_RSA_PSS_Private_Sign(
+                                                a_pProvider,
+                                                messageDigest,
+                                                a_privateKey,
+                                                a_pSignature);
+
+    if(messageDigest.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(messageDigest.Data);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(messageDigest.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(messageDigest.Data);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_PSS_SHA256_Verify
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PSS_SHA256_Verify(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_data,
+    OpcUa_Key*            a_publicKey,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_ByteString messageDigest = OPCUA_BYTESTRING_STATICINITIALIZER;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_PSS_SHA256_Verify");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature);
+
+    messageDigest.Length = 32; /* 256 bit */
+    messageDigest.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(messageDigest.Length*sizeof(OpcUa_Byte));
+    OpcUa_GotoErrorIfAllocFailed(messageDigest.Data);
+
+    uStatus = OpcUa_P_OpenSSL_SHA2_256_Generate(a_pProvider, a_data.Data, a_data.Length, messageDigest.Data);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    uStatus = OpcUa_P_OpenSSL_RSA_PSS_Public_Verify(
+                                                a_pProvider,
+                                                messageDigest,
+                                                a_publicKey,
+                                                a_pSignature);
+
+    OpcUa_P_Memory_Free(messageDigest.Data);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(messageDigest.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(messageDigest.Data);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_DeriveChannelKeyset
+ *===========================================================================*/
+static
+OpcUa_StatusCode OpcUa_P_OpenSSL_DeriveChannelKeyset(
+    OpcUa_CryptoProvider*   a_pCryptoProvider,
+    OpcUa_ByteString        a_remoteNonce,
+    OpcUa_ByteString        a_localNonce,
+    OpcUa_SecurityKeyset*   a_pKeyset)
+{
+    OpcUa_Key MasterKey;
+    OpcUa_UInt32 uKeyDataSize = 0;
+    OpcUa_Boolean bCalculateSizes = OpcUa_False;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "DeriveChannelKeyset");
+
+    if(a_pKeyset->SigningKey.Key.Data == OpcUa_Null)
+    {
+        a_pKeyset->SigningKey.Key.Length = a_pCryptoProvider->DerivedSignatureKeyLength;
+        bCalculateSizes = OpcUa_True;
+    }
+
+    uKeyDataSize += a_pKeyset->SigningKey.Key.Length;
+
+    if(a_pKeyset->EncryptionKey.Key.Data == OpcUa_Null)
+    {
+        a_pKeyset->EncryptionKey.Key.Length = a_pCryptoProvider->DerivedEncryptionKeyLength;
+        bCalculateSizes = OpcUa_True;
+    }
+
+    uKeyDataSize += a_pKeyset->EncryptionKey.Key.Length;
+
+    if(a_pKeyset->InitializationVector.Key.Data == OpcUa_Null)
+    {
+        a_pKeyset->InitializationVector.Key.Length = 16;
+        bCalculateSizes = OpcUa_True;
+    }
+
+    uKeyDataSize += a_pKeyset->InitializationVector.Key.Length;
+
+    if(bCalculateSizes)
+    {
+        OpcUa_ReturnStatusCode;
+    }
+
+    /************************************************************************************/
+
+    /* preinitialize */
+    MasterKey.Type = 0;
+    /*MasterKey.fpClearHandle = OpcUa_Null;*/
+    MasterKey.Key.Length = -1;
+    MasterKey.Key.Data = OpcUa_Null;
+
+    /* check required nonce length */
+    if(a_remoteNonce.Length < a_pCryptoProvider->SymmetricKeyLength)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadNonceInvalid);
+    }
+
+    if(a_localNonce.Length < a_pCryptoProvider->SymmetricKeyLength)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadNonceInvalid);
+    }
+
+    /* create the client master key */
+    uStatus = a_pCryptoProvider->DeriveKey( a_pCryptoProvider,
+                                            a_remoteNonce,
+                                            a_localNonce,
+                                            uKeyDataSize,
+                                            &MasterKey);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    if(MasterKey.Key.Length <= 0)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadUnexpectedError);
+    }
+
+    /* MasterKey */
+    MasterKey.Key.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(MasterKey.Key.Length*sizeof(OpcUa_Byte));
+    OpcUa_GotoErrorIfAllocFailed(MasterKey.Key.Data);
+    uStatus = a_pCryptoProvider->DeriveKey( a_pCryptoProvider,
+                                            a_remoteNonce,
+                                            a_localNonce,
+                                            uKeyDataSize,
+                                            &MasterKey);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    /* SigningKey */
+    uStatus = OpcUa_P_Memory_MemCpy(a_pKeyset->SigningKey.Key.Data,
+                                    a_pKeyset->SigningKey.Key.Length,
+                                    MasterKey.Key.Data,
+                                    a_pKeyset->SigningKey.Key.Length);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    /* EncryptingKey */
+    uStatus = OpcUa_P_Memory_MemCpy(a_pKeyset->EncryptionKey.Key.Data,
+                                    a_pKeyset->EncryptionKey.Key.Length,
+                                    MasterKey.Key.Data + a_pKeyset->SigningKey.Key.Length,
+                                    a_pKeyset->EncryptionKey.Key.Length);
+
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    /* InitializationVector */
+    OpcUa_P_Memory_MemCpy(  a_pKeyset->InitializationVector.Key.Data,
+                            a_pKeyset->InitializationVector.Key.Length,
+                            MasterKey.Key.Data + a_pKeyset->SigningKey.Key.Length + a_pKeyset->EncryptionKey.Key.Length,
+                            a_pKeyset->InitializationVector.Key.Length);
+
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    /* cleanup */
+    OpcUa_P_OpenSSL_DestroySecretData(MasterKey.Key.Data, MasterKey.Key.Length);
+    OpcUa_P_Key_Clear(&MasterKey);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    OpcUa_P_Key_Clear(&MasterKey);
+    OpcUa_P_Key_Clear(&a_pKeyset->SigningKey);
+    OpcUa_P_Key_Clear(&a_pKeyset->EncryptionKey);
+    OpcUa_P_Key_Clear(&a_pKeyset->InitializationVector);
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_DeriveChannelKeysets
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_DeriveChannelKeysets(
+    OpcUa_CryptoProvider*   a_pCryptoProvider,
+    OpcUa_ByteString        a_clientNonce,
+    OpcUa_ByteString        a_serverNonce,
+    OpcUa_Int32             a_keySize,
+    OpcUa_SecurityKeyset*   a_pClientKeyset,
+    OpcUa_SecurityKeyset*   a_pServerKeyset)
+{
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "DeriveChannelKeysets");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pCryptoProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_clientNonce.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_serverNonce.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pClientKeyset);
+    OpcUa_ReturnErrorIfArgumentNull(a_pServerKeyset);
+
+    OpcUa_ReferenceParameter(a_keySize);
+
+    uStatus = OpcUa_P_OpenSSL_DeriveChannelKeyset(
+        a_pCryptoProvider,
+        a_serverNonce,
+        a_clientNonce,
+        a_pClientKeyset);
+
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    uStatus = OpcUa_P_OpenSSL_DeriveChannelKeyset(
+        a_pCryptoProvider,
+        a_clientNonce,
+        a_serverNonce,
+        a_pServerKeyset);
+
+    OpcUa_GotoErrorIfBad(uStatus);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_GenerateAsymmetricKeyPair
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_GenerateAsymmetricKeyPair(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_UInt              a_type,
+    OpcUa_UInt32            a_bits,
+    OpcUa_Key*              a_pPublicKey,
+    OpcUa_Key*              a_pPrivateKey)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "GenerateAsymmetricKeyPair");
+
+    if(a_type == OpcUa_Crypto_Rsa_Id)
+    {
+        uStatus = OpcUa_P_OpenSSL_RSA_GenerateKeys(a_pProvider, a_bits, a_pPublicKey, a_pPrivateKey);
+    }
+    else
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+#endif /* OPCUA_REQUIRE_OPENSSL */

--- a/Stack/platforms/vxworks/opcua_p_openssl.h
+++ b/Stack/platforms/vxworks/opcua_p_openssl.h
@@ -1,0 +1,1195 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_P_OpenSSL_H_
+#define _OpcUa_P_OpenSSL_H_ 1
+
+OPCUA_BEGIN_EXTERN_C
+
+/**
+  @brief Initializes the OpenSSL library.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_Initialize(void);
+
+/**
+  @brief cleans up the OpenSSL library.
+*/
+OpcUa_Void OpcUa_P_OpenSSL_Cleanup(void);
+
+/**
+  @brief cleans up the OpenSSL library.
+*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_OpenSSL_Thread_Cleanup(void);
+
+/**
+  @brief seeds pseudo-random-number-generator of openssl.
+*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_OpenSSL_SeedPRNG( OpcUa_Byte* seed,
+                                                         OpcUa_Int   bytes);
+
+/**
+  @brief destroys secret data values in a cyptographically safe way.
+*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_OpenSSL_DestroySecretData(OpcUa_Void*  data,
+                                                           OpcUa_UInt32 bytes);
+
+/**
+  @brief Encrypts data using Advanced Encryption Standard (AES) with the Cipher Block Chaining (CBC) mode.
+
+   keylen = blocksize => 128
+   message length = outputlength
+
+  @param pProvider              [in]  Provider handle.
+  @param pPlainText             [in]  Plain text to encrypt.
+  @param plainTextLen           [in]  The length of the plain text in bytes.
+  @param key                    [in]  The encryption/decryption key.
+  @param pInitalVector          [in]  The initial vector.
+
+  @param pCipherText            [out] The encrypted text.
+  @param pCipherTextLen         [out] The length of the encrypted text
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_128_CBC_Encrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32            plainTextLen, /* message length = outputlength */
+    OpcUa_Key*              key,
+    OpcUa_Byte*             pInitalVector,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief Decrypts encrypted data using Advanced Encryption Standard (AES) with the Cipher Block Chaining (CBC) mode.
+
+  keylen = blocksize => 128
+  synchronous!
+
+  @param pProvider              [in]  Provider handle.
+  @param pCipherText            [in]  Cipher text to decrypt.
+  @param cipherTextLen          [in]  The length of the cipher text in bytes.
+  @param key                    [in]  The encryption/decryption key.
+  @param pInitalVector          [in]  The initial vector.
+
+  @param pPlainText             [out] The decrypted text.
+  @param pPlainTextLen          [out] The length of the decrypted text
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_128_CBC_Decrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32            cipherTextLen, /* cipher length */
+    OpcUa_Key*              key,
+    OpcUa_Byte*             pInitalVector,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32*           pPlainTextLen);
+
+/**
+  @brief Encrypts data using Advanced Encryption Standard (AES) with the Cipher Block Chaining (CBC) mode.
+
+   keylen = blocksize => 256
+   message length = outputlength
+
+  @param pProvider              [in]  Provider handle.
+  @param pPlainText             [in]  Plain text to encrypt.
+  @param plainTextLen           [in]  The length of the plain text in bytes.
+  @param key                    [in]  The encryption/decryption key.
+  @param pInitalVector          [in]  The initial vector.
+
+  @param pCipherText            [out] The encrypted text.
+  @param pCipherTextLen         [out] The length of the encrypted text
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_256_CBC_Encrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32            plainTextLen, /* message length = outputlength */
+    OpcUa_Key*              key,
+    OpcUa_Byte*             pInitalVector,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief Decrypts encrypted data using Advanced Encryption Standard (AES) with the Cipher Block Chaining (CBC) mode.
+
+  keylen = blocksize => 128
+  synchronous!
+
+  @param pProvider              [in]  Provider handle.
+  @param pCipherText            [in]  Cipher text to decrypt.
+  @param cipherTextLen          [in]  The length of the cipher text in bytes.
+  @param key                    [in]  The encryption/decryption key.
+  @param pInitalVector          [in]  The initial vector.
+
+  @param pPlainText             [out] The decrypted text.
+  @param pPlainTextLen          [out] The length of the decrypted text
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_256_CBC_Decrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32            cipherTextLen, /* cipher length */
+    OpcUa_Key*              key,
+    OpcUa_Byte*             pInitalVector,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief Encrypts data using (RSA)<NAME> with the public key of the appropriate key pair.
+
+  RSA_PKCS1_PADDING
+  synchronous!
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param pPlainText        [in]  The plain text to encrypt.
+  @param plainTextLen      [in]  The length of the plain text to encrypt.
+  @param publicKey         [in]  The public key used to encrypt the plain text.
+
+  @param pCipherText       [out] The encrypted text.
+  @param pCipherTextLen    [out] The length of the encrypted text.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_Encrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32            plainTextLen,
+    OpcUa_Key*              publicKey,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief Decrypts encrypted data using <NAME>(RSA) with the private key of the appropriate key pair.
+
+  RSA_PKCS1_PADDING
+  synchonous!
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param pCipherText       [in]  The cipher text to decrypt.
+  @param cipherTextLen     [in]  The length of the cipher text to decrypt.
+  @param privateKey        [in]  The private key used to decrypt the plain text.
+
+  @param pPlainText        [out] The decrypted text.
+  @param pPlainTextLen     [out] The length of the decrypted text.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_Decrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32            cipherTextLen,
+    OpcUa_Key*              privateKey,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32*           pPlainTextLen);
+
+/**
+  @brief Encrypts data using (RSA)<NAME> with the public key of the appropriate key pair.
+
+  RSA_PKCS1_OAEP_PADDING
+  synchronous!
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param pPlainText        [in]  The plain text to encrypt.
+  @param plainTextLen      [in]  The length of the plain text to encrypt.
+  @param publicKey         [in]  The public key used to encrypt the plain text.
+
+  @param pCipherText       [out] The encrypted text.
+  @param pCipherTextLen    [out] The length of the encrypted text.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_OAEP_Encrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32            plainTextLen,
+    OpcUa_Key*              publicKey,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief Decrypts encrypted data using <NAME>(RSA) with the private key of the appropriate key pair.
+
+  RSA_PKCS1_OAEP_PADDING
+  synchonous!
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param pCipherText       [in]  The cipher text to decrypt.
+  @param cipherTextLen     [in]  The length of the cipher text to decrypt.
+  @param privateKey        [in]  The private key used to decrypt the plain text.
+
+  @param pPlainText        [out] The decrypted text.
+  @param pPlainTextLen     [out] The length of the decrypted text.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_OAEP_Decrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32            cipherTextLen,
+    OpcUa_Key*              privateKey,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32*           pPlainTextLen);
+
+/**
+  @brief Encrypts data using (RSA)<NAME> with the public key of the appropriate key pair.
+
+  RSA_PKCS1_OAEP_PADDING
+  synchronous!
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param pPlainText        [in]  The plain text to encrypt.
+  @param plainTextLen      [in]  The length of the plain text to encrypt.
+  @param publicKey         [in]  The public key used to encrypt the plain text.
+
+  @param pCipherText       [out] The encrypted text.
+  @param pCipherTextLen    [out] The length of the encrypted text.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_OAEP_SHA256_Encrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32            plainTextLen,
+    OpcUa_Key*              publicKey,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief Decrypts encrypted data using <NAME>(RSA) with the private key of the appropriate key pair.
+
+  RSA_PKCS1_OAEP_PADDING
+  synchonous!
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param pCipherText       [in]  The cipher text to decrypt.
+  @param cipherTextLen     [in]  The length of the cipher text to decrypt.
+  @param privateKey        [in]  The private key used to decrypt the plain text.
+
+  @param pPlainText        [out] The decrypted text.
+  @param pPlainTextLen     [out] The length of the decrypted text.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_OAEP_SHA256_Decrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32            cipherTextLen,
+    OpcUa_Key*              privateKey,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32*           pPlainTextLen);
+
+/**
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the MAC generation.
+  @param dataLen          [in]  The length data for the MAC generation.
+  @param key              [in]  The key for the MAC generation.
+
+  @param pSignature       [out] The resulting signature (MAC).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA1_Sign(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Byte*           pData,
+    OpcUa_UInt32          dataLen,
+    OpcUa_Key*            key,
+    OpcUa_ByteString*     pSignature);
+
+/**
+  @param pProvider              [in]  The crypto provider handle.
+  @param pData                  [in]  The data for the MAC generation.
+  @param dataLen                [in]  The length data for the MAC generation.
+  @param key                    [in]  The key for the MAC generation.
+  @param pSignature             [in]  The resulting signature (MAC).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA1_Verify(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Byte*           pData,
+    OpcUa_UInt32          dataLen,
+    OpcUa_Key*            key,
+    OpcUa_ByteString*     pSignature);
+
+/**
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the MAC generation.
+  @param dataLen          [in]  The length data for the MAC generation.
+  @param key              [in]  The key for the MAC generation.
+
+  @param pSignature       [out] The resulting signature (MAC).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA256_Sign(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Byte*           pData,
+    OpcUa_UInt32          dataLen,
+    OpcUa_Key*            key,
+    OpcUa_ByteString*     pSignature);
+
+/**
+  @param pProvider              [in]  The crypto provider handle.
+  @param pData                  [in]  The data for the MAC generation.
+  @param dataLen                [in]  The length data for the MAC generation.
+  @param key                    [in]  The key for the MAC generation.
+  @param pSignature             [in]  The resulting signature (MAC).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA256_Verify(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Byte*           pData,
+    OpcUa_UInt32          dataLen,
+    OpcUa_Key*            key,
+    OpcUa_ByteString*     pSignature);
+
+/**@brief Signs data using <NAME>(RSA) with the private key of the appropriate key pair.
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param data              [in]  The data to sign.
+  @param privateKey        [in]  The private key used to sign the data.
+
+  @param pSignature        [out] The signature of the data.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA1_Sign(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            privateKey,
+    OpcUa_ByteString*     pSignature);      /* minimum length = key length */
+
+/**
+  @brief Verifies signed data using <NAME>(RSA) with the public key of the appropriate key pair.
+
+  @param pProvider                  [in]  The crypto provider handle.
+  @param data                       [in]  The data that was signed.
+  @param publicKey                  [in]  The public key used to verify the signature.
+  @param pSignature                 [in]  The signature of the data that should be verified.
+ */
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA1_Verify(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            publicKey,
+    OpcUa_ByteString*     pSignature);
+
+/**@brief Signs data using <NAME>(RSA) with the private key of the appropriate key pair.
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param data              [in]  The data to sign.
+  @param privateKey        [in]  The private key used to sign the data.
+
+  @param pSignature        [out] The signature of the data.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA256_Sign(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            privateKey,
+    OpcUa_ByteString*     pSignature);      /* minimum length = key length */
+
+/**
+  @brief Verifies signed data using <NAME>(RSA) with the public key of the appropriate key pair.
+
+  @param pProvider                  [in]  The crypto provider handle.
+  @param data                       [in]  The data that was signed.
+  @param publicKey                  [in]  The public key used to verify the signature.
+  @param pSignature                 [in]  The signature of the data that should be verified.
+ */
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PSS_SHA256_Verify(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            publicKey,
+    OpcUa_ByteString*     pSignature);
+
+/**@brief Signs data using <NAME>(RSA) with the private key of the appropriate key pair.
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param data              [in]  The data to sign.
+  @param privateKey        [in]  The private key used to sign the data.
+
+  @param pSignature        [out] The signature of the data.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PSS_SHA256_Sign(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            privateKey,
+    OpcUa_ByteString*     pSignature);      /* minimum length = key length */
+
+/**
+  @brief Verifies signed data using <NAME>(RSA) with the public key of the appropriate key pair.
+
+  @param pProvider                  [in]  The crypto provider handle.
+  @param data                       [in]  The data that was signed.
+  @param publicKey                  [in]  The public key used to verify the signature.
+  @param pSignature                 [in]  The signature of the data that should be verified.
+ */
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PKCS1_V15_SHA256_Verify(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            publicKey,
+    OpcUa_ByteString*     pSignature);
+
+/**
+  @brief
+
+  if keyLen > 0 then an encryption key, signing key and a IV of the given length is generated for client and server.
+  if keyLen == 0 then nothing will be generated.
+  if keyLen < 0 then default setting from the CryptoProvider is used.
+
+ */
+OpcUa_StatusCode OpcUa_P_OpenSSL_DeriveChannelKeysets(
+    OpcUa_CryptoProvider*           pCryptoProvider,
+    OpcUa_ByteString                clientNonce,
+    OpcUa_ByteString                serverNonce,
+    OpcUa_Int32                     keySize,
+    OpcUa_SecurityKeyset*           pClientKeyset,
+    OpcUa_SecurityKeyset*           pServerKeyset);
+
+/**
+  @brief
+ */
+OpcUa_StatusCode OpcUa_P_OpenSSL_GenerateAsymmetricKeyPair(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_UInt              type,
+    OpcUa_UInt32            bytes,
+    OpcUa_Key*              pPublicKey,
+    OpcUa_Key*              pPrivateKey);
+
+/*** CERTIFICATES ***/
+
+/**
+  @brief Creates a new X509 selfsigned certificate object.
+
+  @param pProvider                [in]  The crypto provider handle.
+  @param validToInSec             [in]  The validation end time information.
+  @param pNameEntries             [in]  Name entries for the certificate.
+  @param nameEntriesCount         [in]  The count of name entries located at the address in pNameEntries.
+  @param pSubjectPublicKey        [in]  The subject's public key.
+  @param pExtensions              [in]  The extensions for the desired certificate.
+  @param extensionsCount          [in]  The count of extension at the address in pExtensions.
+  @param signatureHashAlgorithm   [in]  The hash algorithm for calculating the signature.
+  @param pIssuerPrivateKey        [in]  The private key of the certificate authority.
+
+  @param pCertificate             [out] The new self-signed certificate.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_X509_SelfSigned_Custom_Create(
+    OpcUa_CryptoProvider*       pProvider,
+    OpcUa_Int32                 serialNumber,
+    OpcUa_UInt32                validToInSec,
+    OpcUa_Crypto_NameEntry*     pNameEntries,
+    OpcUa_UInt                  nameEntriesCount,  /* will be used for issuer and subject thus it's selfigned cert */
+    OpcUa_Key                   pSubjectPublicKey, /* EVP_PKEY* - type defines also public key algorithm */
+    OpcUa_Crypto_Extension*     pExtensions,
+    OpcUa_UInt                  extensionsCount,
+    OpcUa_UInt                  signatureHashAlgorithm, /* EVP_sha1(),... */
+    OpcUa_Key                   pIssuerPrivateKey, /* EVP_PKEY* - type defines also signature algorithm */
+    OpcUa_ByteString*           pCertificate);     /* DER encoded byte string */
+/**
+  @brief Gets the public key from a given certificate.
+
+  @param pProvider               [in]  A pointer to a crypto provider.
+  @param pCertificate            [in]  A pointer to a DER encoded ByteString representation of the certificate.
+  @param password                [in]  Password for certificate. Only used when certificate is password protected. (Not used in current implementation)
+
+  @param pPublicKey              [out] The read out public key of the certificate.
+*/
+
+OpcUa_StatusCode OpcUa_P_OpenSSL_X509_GetPublicKey(
+    OpcUa_CryptoProvider*       pProvider,
+    OpcUa_ByteString*           pCertificate,
+    OpcUa_StringA               password,
+    OpcUa_Key*                  pPublicKey);
+
+/**
+  @brief Gets the signature from a given certificate.
+
+  @param pProvider                [in]  A pointer to a crypto provider.
+  @param certificate              [in]  The passed in certificate.
+
+  @param pSignature               [out] The read out signature of the certificate.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_X509_GetSignature(
+    OpcUa_CryptoProvider*       pProvider,
+    OpcUa_ByteString*           pCertificate,
+    OpcUa_Signature*            pSignature);
+
+/**
+  @brief Gets the thumbprint of a given certificate.
+
+  @param pProvider              [in]  A pointer to a crypto provider.
+  @param pCertificate           [in]  The passed in certificate.
+
+  @param pCertificateThumprint  [out] The SHA-1 thumbprint of the certificate.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_X509_GetCertificateThumbprint(
+    OpcUa_CryptoProvider*       pProvider,
+    OpcUa_ByteString*           pCertificate,
+    OpcUa_ByteString*           pCertificateThumprint);
+
+/*** NO SECURITY PROTOTYPES ***/
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_CreateCertificate(
+    OpcUa_CryptoProvider*       pProvider,
+    OpcUa_Int32                 serialNumber,
+    OpcUa_UInt32                validToInSec,
+    OpcUa_Crypto_NameEntry*     pNameEntries,
+    OpcUa_UInt                  nameEntriesCount,
+    OpcUa_Key                   pSubjectPublicKey,
+    OpcUa_Crypto_Extension*     pExtensions,
+    OpcUa_UInt                  extensionsCount,
+    OpcUa_UInt                  signatureHashAlgorithm,
+    OpcUa_Key                   pIssuerPrivateKey,
+    OpcUa_ByteString*           pCertificate);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GetPublicKeyFromCert(
+    OpcUa_CryptoProvider*       pProvider,
+    OpcUa_ByteString*           pCertificate,
+    OpcUa_StringA               password,
+    OpcUa_Key*                  pPublicKey);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GetSignatureFromCert(
+    OpcUa_CryptoProvider*       pProvider,
+    OpcUa_ByteString*           pCertificate,
+    OpcUa_Signature*            pSignature);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GenerateAsymmetricKeyPair(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_UInt              type,
+    OpcUa_UInt32            bytes,
+    OpcUa_Key*              pPublicKey,
+    OpcUa_Key*              pPrivateKey);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_DeriveChannelKeysets(
+    struct _OpcUa_CryptoProvider*   pCryptoProvider,
+    OpcUa_ByteString                clientNonce,
+    OpcUa_ByteString                serverNonce,
+    OpcUa_Int32                     keySize,
+    struct _OpcUa_SecurityKeyset*   pClientKeyset,
+    struct _OpcUa_SecurityKeyset*   pServerKeyset);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_DeriveKey(OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      secret,
+    OpcUa_ByteString      seed,
+    OpcUa_Int32           keyLen,
+    OpcUa_Key*            pKey);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GenerateKey(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Int32           keyLen,
+    OpcUa_Key*            pKey);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_SymmetricEncrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32            plainTextLen,
+    OpcUa_Key*              key,
+    OpcUa_Byte*             pInitalVector,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_SymmetricDecrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32            cipherTextLen,
+    OpcUa_Key*              key,
+    OpcUa_Byte*             pInitalVector,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_SymmetricSign(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Byte*           pData,
+    OpcUa_UInt32          dataLen,
+    OpcUa_Key*            key,
+    OpcUa_ByteString*     ppSignature);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_SymmetricVerify(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Byte*           pData,
+    OpcUa_UInt32          dataLen,
+    OpcUa_Key*            key,
+    OpcUa_ByteString*     pSignature);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_AsymmetricEncrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32            plainTextLen,
+    OpcUa_Key*              publicKey,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_AsymmetricDecrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32            cipherTextLen,
+    OpcUa_Key*              privateKey,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32*           pPlainTextLen);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_AsymmetricSign(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            privateKey,
+    OpcUa_ByteString*     pSignature);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_AsymmetricVerify(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            publicKey,
+    OpcUa_ByteString*     pSignature);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GetCertificateThumbprint(
+    OpcUa_CryptoProvider*       a_pProvider,
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_ByteString*           a_pCertificateThumbprint);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GetAsymmetricKeyLength(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Key               publicKey,
+    OpcUa_UInt32*           pKeyLen);
+
+/*** AES SYMMETRIC ENCRYPTION ***/
+
+/**
+  @brief Encrypts data using Advanced Encryption Standard (AES) with the Cipher Block Chaining (CBC) mode.
+
+   keylen = blocksize => fixed sizes of 128 = 10 rounds, 192 = 12 rounds, 256 = 14 rounds
+   message length = outputlength
+
+  @param pProvider              [in]  Provider handle.
+  @param pPlainText             [in]  Plain text to encrypt.
+  @param plainTextLen           [in]  The length of the plain text in bytes. (message length = outputlength)
+  @param key                    [in]  The encryption/decryption key.
+  @param pInitalVector          [in]  The initial vector.
+
+  @param pCipherText            [out] The encrypted text.
+  @param pCipherTextLen         [out] The length of the encrypted text
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_CBC_Encrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32            plainTextLen,
+    OpcUa_Key*              key,
+    OpcUa_Byte*             pInitalVector,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief Decrypts encrypted data using Advanced Encryption Standard (AES) with the Cipher Block Chaining (CBC) mode.
+
+  If PlainText is null, then the cipherTextLen is returned in pPlainTextLen, since this is the maximum output size after decryption.
+
+  synchronous!
+
+  @param pProvider              [in]  Provider handle.
+  @param pPlainText             [in]  Plain text to encrypt.
+  @param plainTextLen           [in]  The length of the plain text in bytes. (message length = outputlength)
+  @param key                    [in]  The encryption/decryption key.
+  @param pInitalVector          [in]  The initial vector.
+
+  @param pPlainText             [out] The plaintext.
+  @param pPlainTextLen          [out] The length of the plaintext
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_CBC_Decrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32            cipherTextLen,
+    OpcUa_Key*              key,
+    OpcUa_Byte*             pInitalVector,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32*           pPlainTextLen);
+
+
+/*** RSA ASYMMETRIC ENCRYPTION ***/
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_GenerateKeys(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_UInt32            bytes,
+    OpcUa_Key*              pPublicKey,
+    OpcUa_Key*              pPrivateKey);
+
+/**
+  @brief
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_Public_GetKeyLength(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Key               publicKey,
+    OpcUa_UInt32*           pKeyLen);
+
+/**
+  @brief Encrypts data using (RSA)<NAME> with the public key of the appropriate key pair.
+
+  synchronous!
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param pPlainText        [in]  The plain text to encrypt.
+  @param plainTextLen      [in]  The length of the plain text to encrypt.
+  @param publicKey         [in]  The public key used to encrypt the plain text.
+  @param padding           [in]  The paddin scheme used for filling empty bytes after encryption.
+
+  @param pCipherText       [out] The encrypted text.
+  @param pCipherTextLen    [out] The length of the encrypted text.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_Public_Encrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32            plainTextLen,
+    OpcUa_Key*              publicKey,
+    OpcUa_Int16             padding,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief Decrypts encrypted data using <NAME>(RSA) with the private key of the appropriate key pair.
+
+  synchonous!
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param pCipherText       [in]  The cipher text to decrypt.
+  @param cipherTextLen     [in]  The length of the cipher text to decrypt.
+  @param privateKey        [in]  The private key used to decrypt the plain text.
+  @param padding           [in]  The paddin scheme used for filling empty bytes after encryption.
+
+  @param pPlainText        [out] The decrypted text.
+  @param pPlainTextLen     [out] The length of the decrypted text.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_Private_Decrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32            cipherTextLen,
+    OpcUa_Key*              privateKey,
+    OpcUa_Int16             padding,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32*           pPlainTextLen);
+
+
+/*** RSA ASYMMETRIC SIGNATURE ***/
+
+/**
+  @brief Signs data using <NAME>(RSA) with the private key of the appropriate key pair.
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param data              [in]  The data to sign.
+  @param privateKey        [in]  The private key used to sign the data.
+  @param padding           [in]  The signature algorithm used (e.g. NID_sha1).
+
+  @param pSignature        [out] The signature of the data.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_Private_Sign(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            privateKey,
+    OpcUa_Int16           padding,
+    OpcUa_ByteString*     pSignature);
+
+/**
+  @brief Verifies signed data using <NAME>(RSA) with the public key of the appropriate key pair.
+
+  @param pProvider                  [in]  The crypto provider handle.
+  @param data                       [in]  The data that was signed.
+  @param publicKey                  [in]  The public key used to verify the signature.
+  @param padding                    [in]  The signature algorithm used (e.g. NID_sha1).
+  @param pSignature                 [in]  The signature of the data that should be verified.
+ */
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_Public_Verify(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            publicKey,
+    OpcUa_Int16           padding,
+    OpcUa_ByteString*     pSignature);
+
+/**
+  @brief Encrypts data using (RSA)<NAME> with the public key of the appropriate key pair.
+
+  synchronous!
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param pPlainText        [in]  The plain text to encrypt.
+  @param plainTextLen      [in]  The length of the plain text to encrypt.
+  @param publicKey         [in]  The public key used to encrypt the plain text.
+
+  @param pCipherText       [out] The encrypted text.
+  @param pCipherTextLen    [out] The length of the encrypted text.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_SHA256_Public_Encrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32            plainTextLen,
+    OpcUa_Key*              publicKey,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32*           pCipherTextLen);
+
+/**
+  @brief Decrypts encrypted data using <NAME>(RSA) with the private key of the appropriate key pair.
+
+  synchonous!
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param pCipherText       [in]  The cipher text to decrypt.
+  @param cipherTextLen     [in]  The length of the cipher text to decrypt.
+  @param privateKey        [in]  The private key used to decrypt the plain text.
+
+  @param pPlainText        [out] The decrypted text.
+  @param pPlainTextLen     [out] The length of the decrypted text.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_SHA256_Private_Decrypt(
+    OpcUa_CryptoProvider*   pProvider,
+    OpcUa_Byte*             pCipherText,
+    OpcUa_UInt32            cipherTextLen,
+    OpcUa_Key*              privateKey,
+    OpcUa_Byte*             pPlainText,
+    OpcUa_UInt32*           pPlainTextLen);
+
+/**
+  @brief Signs data using <NAME>(RSA) with the private key of the appropriate key pair.
+
+  @param pProvider         [in]  The crypto provider handle.
+  @param data              [in]  The data to sign.
+  @param privateKey        [in]  The private key used to sign the data.
+
+  @param pSignature        [out] The signature of the data.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PSS_Private_Sign(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            privateKey,
+    OpcUa_ByteString*     pSignature);
+
+/**
+  @brief Verifies signed data using <NAME>(RSA) with the public key of the appropriate key pair.
+
+  @param pProvider                  [in]  The crypto provider handle.
+  @param data                       [in]  The data that was signed.
+  @param publicKey                  [in]  The public key used to verify the signature.
+  @param pSignature                 [in]  The signature of the data that should be verified.
+ */
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PSS_Public_Verify(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      data,
+    OpcUa_Key*            publicKey,
+    OpcUa_ByteString*     pSignature);
+
+/**
+  @brief Generates a session key using secret input data.
+
+    if keyLen > 0 then random data of the given length is generated.
+    if keyLen == 0 then nothing will be generated.
+    if keyLen < 0 then default setting from the CryptoProvider is used.
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param secret           [in]  The secret information to create a random key. (clientnonce | servernonce, servernonce | clientnonce)
+  @param seed             [in]  The seed to create a random key. (seed)
+  @param keyLen           [in]  The desired length of the random key. (output len)
+
+  @param pKey             [out] The derived random key.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_Random_Key_Derive(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      secret,
+    OpcUa_ByteString      seed,
+    OpcUa_Int32           keyLen,
+    OpcUa_Key*            pKey);
+
+/**
+  @brief Generates a session key using secret input data. Use PSHA256.
+
+    if keyLen > 0 then random data of the given length is generated.
+    if keyLen == 0 then nothing will be generated.
+    if keyLen < 0 then default setting from the CryptoProvider is used.
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param secret           [in]  The secret information to create a random key. (clientnonce | servernonce, servernonce | clientnonce)
+  @param seed             [in]  The seed to create a random key. (seed)
+  @param keyLen           [in]  The desired length of the random key. (output len)
+
+  @param pKey             [out] The derived random key.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_Random_Key_PSHA256_Derive(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_ByteString      secret,
+    OpcUa_ByteString      seed,
+    OpcUa_Int32           keyLen,
+    OpcUa_Key*            pKey);
+
+/**
+  @brief Adds random data to the destination buffer..
+
+    if keyLen > 0 then random data of the given length is generated.
+    if keyLen == 0 then nothing will be generated.
+    if keyLen < 0 then default setting from the CryptoProvider is used.
+
+    if there are no default settings then an error is returned.
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param keyLen           [in]  The desired length of the random key.
+
+  @param pKey             [out] The generated random key.
+ */
+OpcUa_StatusCode OpcUa_P_OpenSSL_Random_Key_Generate(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Int32           keyLen,
+    OpcUa_Key*            pKey);
+
+
+/*** MESSAGE DIGEST ***/
+
+/**
+  @brief Generates a 20 Bytes message digest of the given input buffer.
+
+  SHA-1: 160 Bits output
+
+  synchronous!
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the hash generation.
+  @param dataLen          [in]  The length of the data for the hash generation.
+
+  @param pMessageDigest   [out] The resulting message digest (hash).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_SHA1_Generate(
+    OpcUa_CryptoProvider*         pProvider,
+    OpcUa_Byte*                   pData,
+    OpcUa_UInt32                  dataLen,
+    OpcUa_Byte*                   pMessageDigest);
+
+/**
+  @brief Generates variant bytes message digest of the given input buffer.
+
+  SHA-2: 224 Bits output
+
+  synchronous!
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the hash generation.
+  @param dataLen          [in]  The length data for the hash generation.
+
+  @param pMessageDigest   [out] The resulting message digest (hash).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_SHA2_224_Generate(
+    OpcUa_CryptoProvider*         pProvider,
+    OpcUa_Byte*                   pData,
+    OpcUa_UInt32                  dataLen,
+    OpcUa_Byte*                   pMessageDigest);
+
+/**
+  @brief Generates variant bytes message digest of the given input buffer.
+
+  SHA-2: 256 Bits output
+
+  synchronous!
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the hash generation.
+  @param dataLen          [in]  The length data for the hash generation.
+
+  @param pMessageDigest   [out] The resulting message digest (hash).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_SHA2_256_Generate(
+    OpcUa_CryptoProvider*         pProvider,
+    OpcUa_Byte*                   pData,
+    OpcUa_UInt32                  dataLen,
+    OpcUa_Byte*                   pMessageDigest);
+
+/**
+  @brief Generates variant bytes message digest of the given input buffer.
+
+  SHA-2: 384 Bits output
+
+  synchronous!
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the hash generation.
+  @param dataLen          [in]  The length data for the hash generation.
+
+  @param pMessageDigest   [out] The resulting message digest (hash).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_SHA2_384_Generate(
+    OpcUa_CryptoProvider*         pProvider,
+    OpcUa_Byte*                   pData,
+    OpcUa_UInt32                  dataLen,
+    OpcUa_Byte*                   pMessageDigest);
+
+/**
+  @brief Generates variant bytes message digest of the given input buffer.
+
+  SHA-2: 512 Bits output
+
+  synchronous!
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the hash generation.
+  @param dataLen          [in]  The length data for the hash generation.
+
+  @param pMessageDigest   [out] The resulting message digest (hash).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_SHA2_512_Generate(
+    OpcUa_CryptoProvider*         pProvider,
+    OpcUa_Byte*                   pData,
+    OpcUa_UInt32                  dataLen,
+    OpcUa_Byte*                   pMessageDigest);
+
+
+/*** MESSAGE AUTHENTICATION CODE ***/
+
+/**
+  @brief Generates s 20 Bytes Message Authentication Code (MAC) of the given input buffer and a secret key.
+
+  HMAC-SHA-1: 160 Bits output
+
+  synchronous!
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the MAC generation.
+  @param dataLen          [in]  The length data for the MAC generation.
+  @param key              [in]  The key for the MAC generation.
+
+  @param pMac             [out] The resulting messsage authentication code (MAC).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA1_Generate(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Byte*           pData,
+    OpcUa_UInt32          dataLen,
+    OpcUa_Key*            key,
+    OpcUa_ByteString*     pMac);
+
+/**
+  @brief Generates s variant Bytes Message Authentication Code (MAC) of the given input buffer and a secret key.
+
+  HMAC-SHA-2: 224 Bits output
+
+  synchronous!
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the MAC generation.
+  @param dataLen          [in]  The length data for the MAC generation.
+  @param key              [in]  The key for the MAC generation.
+
+  @param pMac             [out] The resulting messsage authentication code (MAC).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA2_224_Generate(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Byte*           pData,
+    OpcUa_UInt32          dataLen,
+    OpcUa_Key*            key,
+    OpcUa_ByteString*     pMac);
+
+/**
+  @brief Generates s variant Bytes Message Authentication Code (MAC) of the given input buffer and a secret key.
+
+  HMAC-SHA-2: 256 Bits output
+
+  synchronous!
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the MAC generation.
+  @param dataLen          [in]  The length data for the MAC generation.
+  @param key              [in]  The key for the MAC generation.
+
+  @param pMac             [out] The resulting messsage authentication code (MAC).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA2_256_Generate(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Byte*           pData,
+    OpcUa_UInt32          dataLen,
+    OpcUa_Key*            key,
+    OpcUa_ByteString*     pMac);
+
+/**
+  @brief Generates s variant Bytes Message Authentication Code (MAC) of the given input buffer and a secret key.
+
+  HMAC-SHA-2: 384 Bits output
+
+  synchronous!
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the MAC generation.
+  @param dataLen          [in]  The length data for the MAC generation.
+  @param key              [in]  The key for the MAC generation.
+
+  @param pMac             [out] The resulting messsage authentication code (MAC).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA2_384_Generate(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Byte*           pData,
+    OpcUa_UInt32          dataLen,
+    OpcUa_Key*            key,
+    OpcUa_ByteString*     pMac);
+
+/**
+  @brief Generates s variant Bytes Message Authentication Code (MAC) of the given input buffer and a secret key.
+
+  HMAC-SHA-2: 512 Bits output
+
+  synchronous!
+
+  @param pProvider        [in]  The crypto provider handle.
+  @param pData            [in]  The data for the MAC generation.
+  @param dataLen          [in]  The length data for the MAC generation.
+  @param key              [in]  The key for the MAC generation.
+
+  @param pMac             [out] The resulting messsage authentication code (MAC).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA2_512_Generate(
+    OpcUa_CryptoProvider* pProvider,
+    OpcUa_Byte*           pData,
+    OpcUa_UInt32          dataLen,
+    OpcUa_Key*            key,
+    OpcUa_ByteString*     pMac);
+
+
+OPCUA_END_EXTERN_C
+
+#endif /* _OpcUa_Crypto_OpenSsl_H_ */

--- a/Stack/platforms/vxworks/opcua_p_openssl_aes.c
+++ b/Stack/platforms/vxworks/opcua_p_openssl_aes.c
@@ -1,0 +1,171 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_memory.h>
+
+#if OPCUA_REQUIRE_OPENSSL
+
+/* System Headers */
+#include <memory.h>
+#include <openssl/aes.h>
+
+/* own headers */
+#include <opcua_p_openssl.h>
+
+/*** AES SYMMETRIC ENCRYPTION ***/
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_AES_CBC_Encrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_CBC_Encrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32            a_plainTextLen,
+    OpcUa_Key*              a_key,
+    OpcUa_Byte*             a_pInitalVector,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    AES_KEY         key;
+
+    OpcUa_Byte      pInitalVector[16];
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "AES_CBC_Encrypt");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pPlainText);
+    OpcUa_ReturnErrorIfArgumentNull(a_key);
+    OpcUa_ReturnErrorIfArgumentNull(a_key->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pInitalVector);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCipherTextLen);
+
+    if(a_plainTextLen % 16 != 0)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    *a_pCipherTextLen = a_plainTextLen;
+
+    /* if just the output length is needed for the caller of this function */
+    if(a_pCipherText == OpcUa_Null)
+    {
+        OpcUa_ReturnStatusCode;
+    }
+
+    /* we have to pass the key length in bits instead of bytes */
+    if(AES_set_encrypt_key(a_key->Key.Data, a_key->Key.Length * 8, &key) < 0)
+    {
+        uStatus = OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* copy the IV because the AES_cbc_encrypt function overwrites it. */
+    OpcUa_P_Memory_MemCpy(pInitalVector, 16, a_pInitalVector, 16);
+
+    /* encrypt data */
+    AES_cbc_encrypt(    a_pPlainText,
+                        a_pCipherText,
+                        a_plainTextLen,
+                        &key,
+                        pInitalVector,
+                        AES_ENCRYPT);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_AES_CBC_decrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_AES_CBC_Decrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32            a_cipherTextLen,
+    OpcUa_Key*              a_key,
+    OpcUa_Byte*             a_pInitalVector,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32*           a_pPlainTextLen)
+{
+    AES_KEY         key;
+    OpcUa_Byte      pInitalVector[16];
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "AES_CBC_Decrypt");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pCipherText);
+    OpcUa_ReturnErrorIfArgumentNull(a_key);
+    OpcUa_ReturnErrorIfArgumentNull(a_key->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pInitalVector);
+    OpcUa_ReturnErrorIfArgumentNull(a_pPlainTextLen);
+
+    if(a_cipherTextLen % 16 != 0)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    *a_pPlainTextLen = a_cipherTextLen;
+
+    /* if just the output length is needed for the caller of this function */
+    if(a_pPlainText == OpcUa_Null)
+    {
+        OpcUa_ReturnStatusCode;
+    }
+
+    /* we have to pass the key length in bits instead of bytes */
+    if(AES_set_decrypt_key(a_key->Key.Data, a_key->Key.Length * 8, &key) < 0)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+    /* copy the IV because the AES_cbc_encrypt function overwrites it. */
+    OpcUa_P_Memory_MemCpy(pInitalVector, 16, a_pInitalVector, 16);
+
+    /* decrypt ciphertext */
+    AES_cbc_encrypt(    a_pCipherText,
+                        a_pPlainText,
+                        a_cipherTextLen,
+                        &key,
+                        pInitalVector,
+                        AES_DECRYPT);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+OpcUa_FinishErrorHandling;
+}
+
+#endif /* OPCUA_REQUIRE_OPENSSL */

--- a/Stack/platforms/vxworks/opcua_p_openssl_hmac_sha.c
+++ b/Stack/platforms/vxworks/opcua_p_openssl_hmac_sha.c
@@ -1,0 +1,228 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_memory.h>
+
+#if OPCUA_REQUIRE_OPENSSL
+/* System Headers */
+#include <openssl/hmac.h>
+
+
+/* own headers */
+#include <opcua_p_openssl.h>
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_HMAC_SHA1_Generate
+ *===========================================================================*/
+/* HMAC-SHA-1: 160 Bits output */
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA1_Generate(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Byte*           a_pData,
+    OpcUa_UInt32          a_dataLen,
+    OpcUa_Key*            a_key,
+    OpcUa_ByteString*     a_pMac)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "HMAC_SHA1_Generate");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pData);
+    OpcUa_ReturnErrorIfArgumentNull(a_key);
+    OpcUa_ReturnErrorIfArgumentNull(a_key->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pMac);
+
+    if(a_pMac->Data == OpcUa_Null)
+    {
+        a_pMac->Length = 20;
+        OpcUa_ReturnStatusCode;
+    }
+
+    if(HMAC(EVP_sha1(),a_key->Key.Data,a_key->Key.Length,a_pData,a_dataLen,a_pMac->Data,(unsigned int*)&(a_pMac->Length)) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_HMAC_SHA2_224_Generate
+ *===========================================================================*/
+/* HMAC-SHA-2: 224 Bits output */
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA2_224_Generate(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Byte*           a_pData,
+    OpcUa_UInt32          a_dataLen,
+    OpcUa_Key*            a_key,
+    OpcUa_ByteString*     a_pMac)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "HMAC_SHA224_Generate");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pData);
+    OpcUa_ReturnErrorIfArgumentNull(a_key);
+    OpcUa_ReturnErrorIfArgumentNull(a_key->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pMac);
+
+    if(a_pMac->Data == OpcUa_Null)
+    {
+        a_pMac->Length = 28;
+        OpcUa_ReturnStatusCode;
+    }
+
+    if(HMAC(EVP_sha224(),a_key->Key.Data,a_key->Key.Length,a_pData,a_dataLen,a_pMac->Data,(unsigned int*)&(a_pMac->Length)) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_HMAC_SHA2_256_Generate
+ *===========================================================================*/
+/* HMAC-SHA-2: 256 Bits output */
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA2_256_Generate(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Byte*           a_pData,
+    OpcUa_UInt32          a_dataLen,
+    OpcUa_Key*            a_key,
+    OpcUa_ByteString*     a_pMac)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "HMAC_SHA256_Generate");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pData);
+    OpcUa_ReturnErrorIfArgumentNull(a_key);
+    OpcUa_ReturnErrorIfArgumentNull(a_key->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pMac);
+
+    if(a_pMac->Data == OpcUa_Null)
+    {
+        a_pMac->Length = 32;
+        OpcUa_ReturnStatusCode;
+    }
+
+    if(HMAC(EVP_sha256(),a_key->Key.Data,a_key->Key.Length,a_pData,a_dataLen,a_pMac->Data,(unsigned int*)&(a_pMac->Length)) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_HMAC_SHA2_384_Generate
+ *===========================================================================*/
+/* HMAC-SHA-2: 384 Bits output */
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA2_384_Generate(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Byte*           a_pData,
+    OpcUa_UInt32          a_dataLen,
+    OpcUa_Key*            a_key,
+    OpcUa_ByteString*     a_pMac)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "HMAC_SHA384_Generate");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pData);
+    OpcUa_ReturnErrorIfArgumentNull(a_key);
+    OpcUa_ReturnErrorIfArgumentNull(a_key->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pMac);
+
+    if(a_pMac->Data == OpcUa_Null)
+    {
+        a_pMac->Length = 48;
+        OpcUa_ReturnStatusCode;
+    }
+
+    if(HMAC(EVP_sha384(),a_key->Key.Data,a_key->Key.Length,a_pData,a_dataLen,a_pMac->Data,(unsigned int*)&(a_pMac->Length)) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_HMAC_SHA2_512_Generate
+ *===========================================================================*/
+/* HMAC-SHA-2: 512 Bits output */
+OpcUa_StatusCode OpcUa_P_OpenSSL_HMAC_SHA2_512_Generate(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Byte*           a_pData,
+    OpcUa_UInt32          a_dataLen,
+    OpcUa_Key*            a_key,
+    OpcUa_ByteString*     a_pMac)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "HMAC_SHA512_Generate");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pData);
+    OpcUa_ReturnErrorIfArgumentNull(a_key);
+    OpcUa_ReturnErrorIfArgumentNull(a_key->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pMac);
+
+    if(a_pMac->Data == OpcUa_Null)
+    {
+        a_pMac->Length = 64;
+        OpcUa_ReturnStatusCode;
+    }
+
+    if(HMAC(EVP_sha512(),a_key->Key.Data,a_key->Key.Length,a_pData,a_dataLen,a_pMac->Data,(unsigned int*)&(a_pMac->Length)) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+OpcUa_FinishErrorHandling;
+}
+
+#endif /* OPCUA_REQUIRE_OPENSSL */

--- a/Stack/platforms/vxworks/opcua_p_openssl_nosecurity.c
+++ b/Stack/platforms/vxworks/opcua_p_openssl_nosecurity.c
@@ -1,0 +1,363 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* System Headers */
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+
+/* own headers */
+#include <opcua_p_openssl.h>
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_CreateCertificate
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_CreateCertificate(
+    OpcUa_CryptoProvider*       a_pProvider,
+    OpcUa_Int32                 a_serialNumber,
+    OpcUa_UInt32                a_validToInSec,
+    OpcUa_Crypto_NameEntry*     a_pNameEntries,
+    OpcUa_UInt                  a_nameEntriesCount,
+    OpcUa_Key                   a_pSubjectPublicKey,
+    OpcUa_Crypto_Extension*     a_pExtensions,
+    OpcUa_UInt                  a_extensionsCount,
+    OpcUa_UInt                  a_signatureHashAlgorithm,
+    OpcUa_Key                   a_pIssuerPrivateKey,
+    OpcUa_ByteString*           a_pCertificate)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_serialNumber);
+    OpcUa_ReferenceParameter(a_validToInSec);
+    OpcUa_ReferenceParameter(a_pNameEntries);
+    OpcUa_ReferenceParameter(a_nameEntriesCount);
+    OpcUa_ReferenceParameter(a_pSubjectPublicKey);
+    OpcUa_ReferenceParameter(a_pExtensions);
+    OpcUa_ReferenceParameter(a_extensionsCount);
+    OpcUa_ReferenceParameter(a_signatureHashAlgorithm);
+    OpcUa_ReferenceParameter(a_pIssuerPrivateKey);
+    OpcUa_ReferenceParameter(a_pCertificate);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_GetPublicKeyFromCert
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GetPublicKeyFromCert(
+    OpcUa_CryptoProvider*       a_pProvider,
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_StringA               a_password,
+    OpcUa_Key*                  a_pPublicKey)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pCertificate);
+    OpcUa_ReferenceParameter(a_password);
+    OpcUa_ReferenceParameter(a_pPublicKey);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_GetSignatureFromCert
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GetSignatureFromCert(
+    OpcUa_CryptoProvider*       a_pProvider,
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_Signature*            a_pSignature)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pCertificate);
+    OpcUa_ReferenceParameter(a_pSignature);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_GenerateAsymmetricKeyPair
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GenerateAsymmetricKeyPair(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_UInt              a_type,
+    OpcUa_UInt32            a_bits,
+    OpcUa_Key*              a_pPublicKey,
+    OpcUa_Key*              a_pPrivateKey)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_type);
+    OpcUa_ReferenceParameter(a_bits);
+    OpcUa_ReferenceParameter(a_pPublicKey);
+    OpcUa_ReferenceParameter(a_pPrivateKey);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_DeriveChannelKeysets
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_DeriveChannelKeysets(
+    OpcUa_CryptoProvider*           a_pCryptoProvider,
+    OpcUa_ByteString                a_clientNonce,
+    OpcUa_ByteString                a_serverNonce,
+    OpcUa_Int32                     a_keySize,
+    OpcUa_SecurityKeyset*           a_pClientKeyset,
+    OpcUa_SecurityKeyset*           a_pServerKeyset)
+{
+    OpcUa_ReferenceParameter(a_pCryptoProvider);
+    OpcUa_ReferenceParameter(a_clientNonce);
+    OpcUa_ReferenceParameter(a_serverNonce);
+    OpcUa_ReferenceParameter(a_keySize);
+    OpcUa_ReferenceParameter(a_pClientKeyset);
+    OpcUa_ReferenceParameter(a_pServerKeyset);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_DeriveKey
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_DeriveKey(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_secret,
+    OpcUa_ByteString      a_seed,
+    OpcUa_Int32           a_keyLen,
+    OpcUa_Key*            a_pKey)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_secret);
+    OpcUa_ReferenceParameter(a_seed);
+    OpcUa_ReferenceParameter(a_keyLen);
+    OpcUa_ReferenceParameter(a_pKey);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_GenerateKey
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GenerateKey(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Int32           a_keyLen,
+    OpcUa_Key*            a_pKey)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_keyLen);
+    OpcUa_ReferenceParameter(a_pKey);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_SymmetricEncrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_SymmetricEncrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32            a_plainTextLen,
+    OpcUa_Key*              a_key,
+    OpcUa_Byte*             a_pInitalVector,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pPlainText);
+    OpcUa_ReferenceParameter(a_plainTextLen);
+    OpcUa_ReferenceParameter(a_key);
+    OpcUa_ReferenceParameter(a_pInitalVector);
+    OpcUa_ReferenceParameter(a_pCipherText);
+    OpcUa_ReferenceParameter(a_pCipherTextLen);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_SymmetricDecrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_SymmetricDecrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32            a_cipherTextLen,
+    OpcUa_Key*              a_key,
+    OpcUa_Byte*             a_pInitalVector,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pCipherText);
+    OpcUa_ReferenceParameter(a_cipherTextLen);
+    OpcUa_ReferenceParameter(a_key);
+    OpcUa_ReferenceParameter(a_pInitalVector);
+    OpcUa_ReferenceParameter(a_pPlainText);
+    OpcUa_ReferenceParameter(a_pCipherTextLen);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_SymmetricSign
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_SymmetricSign(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Byte*           a_pData,
+    OpcUa_UInt32          a_dataLen,
+    OpcUa_Key*            a_key,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pData);
+    OpcUa_ReferenceParameter(a_dataLen);
+    OpcUa_ReferenceParameter(a_key);
+    OpcUa_ReferenceParameter(a_pSignature);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_SymmetricVerify
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_SymmetricVerify(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Byte*           a_pData,
+    OpcUa_UInt32          a_dataLen,
+    OpcUa_Key*            a_key,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pData);
+    OpcUa_ReferenceParameter(a_dataLen);
+    OpcUa_ReferenceParameter(a_key);
+    OpcUa_ReferenceParameter(a_pSignature);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_AsymmetricEncrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_AsymmetricEncrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32            a_plainTextLen,
+    OpcUa_Key*              a_publicKey,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pPlainText);
+    OpcUa_ReferenceParameter(a_plainTextLen);
+    OpcUa_ReferenceParameter(a_publicKey);
+    OpcUa_ReferenceParameter(a_pCipherText);
+    OpcUa_ReferenceParameter(a_pCipherTextLen);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_AsymmetricEncrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_AsymmetricDecrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32            a_cipherTextLen,
+    OpcUa_Key*              a_privateKey,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32*           a_pPlainTextLen)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pCipherText);
+    OpcUa_ReferenceParameter(a_cipherTextLen);
+    OpcUa_ReferenceParameter(a_privateKey);
+    OpcUa_ReferenceParameter(a_pPlainText);
+    OpcUa_ReferenceParameter(a_pPlainTextLen);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_AsymmetricSign
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_AsymmetricSign(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_data,
+    OpcUa_Key*            a_privateKey,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_data);
+    OpcUa_ReferenceParameter(a_privateKey);
+    OpcUa_ReferenceParameter(a_pSignature);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_AsymmetricVerify
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_AsymmetricVerify(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_data,
+    OpcUa_Key*            a_publicKey,
+    OpcUa_ByteString*     a_pSignature)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_data);
+    OpcUa_ReferenceParameter(a_publicKey);
+    OpcUa_ReferenceParameter(a_pSignature);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_GetCertificateThumbprint
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GetCertificateThumbprint(
+    OpcUa_CryptoProvider*       a_pProvider,
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_ByteString*           a_pCertificateThumbprint)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pCertificate);
+    OpcUa_ReferenceParameter(a_pCertificateThumbprint);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_Crypto_NoSecurity_GetAsymmetricKeyLength
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Crypto_NoSecurity_GetAsymmetricKeyLength(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Key               a_publicKey,
+    OpcUa_UInt32*           a_pKeyLen)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_publicKey);
+    OpcUa_ReferenceParameter(a_pKeyLen);
+
+    return OpcUa_BadNotSupported;
+}

--- a/Stack/platforms/vxworks/opcua_p_openssl_pki.c
+++ b/Stack/platforms/vxworks/opcua_p_openssl_pki.c
@@ -1,0 +1,1300 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright (c) 2018 Wind River Systems, Inc. */
+ 	 		 
+/*
+modification history
+--------------------
+07sep18,lan  port to vxWorks.
+*/
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_memory.h>
+#include <opcua_p_string.h>
+
+#if OPCUA_REQUIRE_OPENSSL
+
+
+/* System Headers */
+#include <openssl/pem.h>
+#include <openssl/bio.h>
+#include <openssl/x509_vfy.h>
+#include <openssl/x509v3.h>
+#include <openssl/pkcs12.h>
+#include <sys/types.h>
+#include <dirent.h>
+
+#include "opcua_vxworks_dirent.h"
+
+/* own headers */
+#include <opcua_p_openssl_pki.h>
+
+#define MAX_PATH 512
+
+/* This functions filters out all hidden files and
+ * files that don't have *.der extension.
+ */
+static int certificate_filter_der(const struct dirent *entry)
+{
+    char *pszFind;
+
+    /* ignore hidden files */
+    if (entry->d_name[0] == '.') return 0;
+
+    /* check file extension */
+    pszFind = strrchr(entry->d_name, '.');
+    if (pszFind == 0) return 0;
+    pszFind++;
+    if (OpcUa_P_String_strnicmp(pszFind, "der", (OpcUa_UInt32)-1) == 0)
+        return 1;
+
+    return 0;
+}
+
+/** Certificate filter function for scandir.
+ * This functions filters out all hidden files and
+ * files that don't have *.crl extension.
+ */
+static int certificate_filter_crl(const struct dirent *entry)
+{
+    char *pszFind;
+
+    /* ignore hidden files */
+    if (entry->d_name[0] == '.') return 0;
+
+    /* check file extension */
+    pszFind = strrchr(entry->d_name, '.');
+    if (pszFind == 0) return 0;
+    pszFind++;
+    if (OpcUa_P_String_strnicmp(pszFind, "crl", (OpcUa_UInt32)-1) == 0)
+        return 1;
+
+    return 0;
+}
+
+static
+OpcUa_StatusCode OpcUa_P_OpenSSL_BuildFullPath( /*  in */ char*         a_pPath,
+                                                /*  in */ char*         a_pFileName,
+                                                /*  in */ unsigned int  a_uiFullPathBufferLength,
+                                                /* out */ char*         a_pFullPath)
+{
+    unsigned int uiPathLength;
+    unsigned int uiFileLength;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pPath);
+    OpcUa_ReturnErrorIfArgumentNull(a_pFileName);
+    OpcUa_ReturnErrorIfArgumentNull(a_pFullPath);
+
+    uiPathLength = (unsigned int)strlen(a_pPath);
+    uiFileLength = (unsigned int)strlen(a_pFileName);
+
+    if((uiPathLength + uiFileLength + 2) > a_uiFullPathBufferLength)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    strcpy(a_pFullPath, a_pPath);
+    strcat(a_pFullPath, "/");
+    strcat(a_pFullPath, a_pFileName);
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * verify_callback
+ *===========================================================================*/
+static OpcUa_Int OpcUa_P_OpenSSL_CertificateStore_Verify_Callback(int a_ok, X509_STORE_CTX* a_pStore)
+{
+    OpcUa_P_OpenSSL_CertificateStore_Config*    pCertificateStoreCfg;
+
+    pCertificateStoreCfg = X509_STORE_CTX_get_app_data(a_pStore);
+    if(a_ok == 0)
+    {
+        /* certificate not ok */
+        char    buf[256];
+        X509*   err_cert;
+        int     err;
+        int     depth;
+
+        err_cert = X509_STORE_CTX_get_current_cert(a_pStore);
+        err      = X509_STORE_CTX_get_error(a_pStore);
+        depth    = X509_STORE_CTX_get_error_depth(a_pStore);
+
+        X509_NAME_oneline(X509_get_subject_name(err_cert), buf, 256);
+        OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "\nverify error:\n\tnum=%d:%s\n\tdepth=%d\n\t%s\n", err, X509_verify_cert_error_string(err), depth, buf);
+
+        X509_NAME_oneline(X509_get_issuer_name(err_cert), buf, 256);
+        OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "\tissuer=%s\n", buf);
+
+        switch (err)
+        {
+            case X509_V_ERR_UNABLE_TO_GET_CRL:
+                if (pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_SUPPRESS_CRL_NOT_FOUND_ERROR)
+                    a_ok = 1;
+                break;
+
+            case X509_V_ERR_CRL_NOT_YET_VALID:
+            case X509_V_ERR_CRL_HAS_EXPIRED:
+                if (pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_SUPPRESS_CRL_VALIDITY_PERIOD_CHECK)
+                    a_ok = 1;
+                break;
+
+            case X509_V_ERR_CERT_NOT_YET_VALID:
+            case X509_V_ERR_CERT_HAS_EXPIRED:
+                if (pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_SUPPRESS_CERT_VALIDITY_PERIOD_CHECK)
+                    a_ok = 1;
+                break;
+        }
+    }
+
+    return a_ok;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_CertificateStore_Open
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_OpenCertificateStore(
+    OpcUa_PKIProvider*          a_pProvider,
+    OpcUa_Void**                a_ppCertificateStore)           /* type depends on store implementation */
+{
+    OpcUa_P_OpenSSL_CertificateStore_Config*    pCertificateStoreCfg;
+    X509_STORE*         pStore;
+    X509_LOOKUP*        pLookup;
+    char                CertFile[MAX_PATH];
+    struct dirent **dirlist = NULL;
+    int numCertificates = 0, i;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "PKI_OpenCertificateStore");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider->Handle);
+    OpcUa_ReturnErrorIfArgumentNull(a_ppCertificateStore);
+
+    *a_ppCertificateStore = OpcUa_Null;
+
+    pCertificateStoreCfg = (OpcUa_P_OpenSSL_CertificateStore_Config*)a_pProvider->Handle;
+
+    if(!(*a_ppCertificateStore = pStore = X509_STORE_new()))
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+    X509_STORE_set_verify_cb_func(pStore, OpcUa_P_OpenSSL_CertificateStore_Verify_Callback);
+
+    if(pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_USE_DEFAULT_CERT_CRL_LOOKUP_METHOD)
+    {
+        if(X509_STORE_set_default_paths(pStore) != 1)
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "error at X509_STORE_set_default_paths!\n");
+            OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+        }
+    }
+
+    if(!(pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_DONT_ADD_TRUST_LIST_TO_ROOT_CERTIFICATES))
+    {
+        if(pCertificateStoreCfg->CertificateTrustListLocation == OpcUa_Null || pCertificateStoreCfg->CertificateTrustListLocation[0] == '\0')
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+        }
+
+        /* how to search for certificate & CRLs */
+        if(!(pLookup = X509_STORE_add_lookup(pStore, X509_LOOKUP_file())))
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+        }
+
+        /* how to search for certificate & CRLs */
+        numCertificates = scandir(pCertificateStoreCfg->CertificateTrustListLocation, &dirlist, certificate_filter_der, alphasort);
+        for (i=0; i<numCertificates; i++)
+        {
+            uStatus = OpcUa_P_OpenSSL_BuildFullPath(pCertificateStoreCfg->CertificateTrustListLocation, dirlist[i]->d_name, MAX_PATH, CertFile);
+            OpcUa_GotoErrorIfBad(uStatus);
+
+            /* add CACertificate lookup */
+            if(X509_LOOKUP_load_file(pLookup, CertFile, X509_FILETYPE_ASN1) != 1) /*DER encoded*/
+            {
+                OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "error at X509_LOOKUP_load_file: skipping %s\n", CertFile);
+            }
+        }
+        for (i=0; i<numCertificates; i++)
+        {
+            free(dirlist[i]);
+        }
+        free(dirlist);
+        dirlist = NULL;
+    }
+
+    if(pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_ADD_UNTRUSTED_LIST_TO_ROOT_CERTIFICATES)
+    {
+        if(pCertificateStoreCfg->CertificateUntrustedListLocation == OpcUa_Null || pCertificateStoreCfg->CertificateUntrustedListLocation[0] == '\0')
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+        }
+
+        if(pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_UNTRUSTED_LIST_IS_INDEX)
+        {
+            /* how to search for certificate */
+            if(!(pLookup = X509_STORE_add_lookup(pStore, X509_LOOKUP_hash_dir())))
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+            }
+
+            /* add hash lookup */
+            if(X509_LOOKUP_add_dir(pLookup, pCertificateStoreCfg->CertificateUntrustedListLocation, X509_FILETYPE_ASN1) != 1) /*DER encoded*/
+            {
+                OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "error at X509_LOOKUP_add_dir!\n");
+                OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+            }
+        }
+        else
+        {
+            /* how to search for certificate & CRLs */
+            if(!(pLookup = X509_STORE_add_lookup(pStore, X509_LOOKUP_file())))
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+            }
+
+            numCertificates = scandir(pCertificateStoreCfg->CertificateUntrustedListLocation, &dirlist, certificate_filter_der, alphasort);
+            for (i=0; i<numCertificates; i++)
+            {
+                uStatus = OpcUa_P_OpenSSL_BuildFullPath(pCertificateStoreCfg->CertificateUntrustedListLocation, dirlist[i]->d_name, MAX_PATH, CertFile);
+                OpcUa_GotoErrorIfBad(uStatus);
+
+                /* add CACertificate lookup */
+                if(X509_LOOKUP_load_file(pLookup, CertFile, X509_FILETYPE_ASN1) != 1) /*DER encoded*/
+                {
+                    OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "error at X509_LOOKUP_load_file: skipping %s\n", CertFile);
+                }
+            }
+            for (i=0; i<numCertificates; i++)
+            {
+                free(dirlist[i]);
+            }
+            free(dirlist);
+            dirlist = NULL;
+        }
+    }
+
+    if(pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_CHECK_REVOCATION_ALL)
+    {
+        if(pCertificateStoreCfg->CertificateRevocationListLocation == OpcUa_Null || pCertificateStoreCfg->CertificateRevocationListLocation[0] == '\0')
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+        }
+
+        if(pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_REVOCATION_LIST_IS_INDEX)
+        {
+            /* how to search for certificate & CRLs */
+            if(!(pLookup = X509_STORE_add_lookup(pStore, X509_LOOKUP_hash_dir())))
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+            }
+
+            /* add CRL lookup */
+            if(X509_LOOKUP_add_dir(pLookup, pCertificateStoreCfg->CertificateRevocationListLocation, X509_FILETYPE_PEM) != 1) /*PEM encoded*/
+            {
+                OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "error at X509_LOOKUP_add_dir!\n");
+                OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+            }
+        }
+        else if(pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_REVOCATION_LIST_IS_CONCATENATED_PEM_FILE)
+        {
+            /* how to search for certificate & CRLs */
+            if(!(pLookup = X509_STORE_add_lookup(pStore, X509_LOOKUP_file())))
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+            }
+
+            /* add CRL lookup */
+            if(X509_load_crl_file(pLookup, pCertificateStoreCfg->CertificateRevocationListLocation, X509_FILETYPE_PEM) != 1) /*PEM encoded*/
+            {
+                OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "error at X509_load_crl_file!\n");
+            }
+        }
+        else
+        {
+            /* how to search for certificate & CRLs */
+            if(!(pLookup = X509_STORE_add_lookup(pStore, X509_LOOKUP_file())))
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+            }
+
+            numCertificates = scandir(pCertificateStoreCfg->CertificateRevocationListLocation, &dirlist, certificate_filter_crl, alphasort);
+            for (i=0; i<numCertificates; i++)
+            {
+                uStatus = OpcUa_P_OpenSSL_BuildFullPath(pCertificateStoreCfg->CertificateRevocationListLocation, dirlist[i]->d_name, MAX_PATH, CertFile);
+                OpcUa_GotoErrorIfBad(uStatus);
+
+                if(X509_load_crl_file(pLookup, CertFile, X509_FILETYPE_PEM) != 1) /*PEM encoded*/
+                {
+                    OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "error at X509_load_crl_file: skipping %s\n", CertFile);
+                }
+            }
+            for (i=0; i<numCertificates; i++)
+            {
+                free(dirlist[i]);
+            }
+            free(dirlist);
+            dirlist = NULL;
+        }
+
+        if((pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_CHECK_REVOCATION_ALL) == OPCUA_P_PKI_OPENSSL_CHECK_REVOCATION_ALL)
+        {
+            /* set the flags of the store so that CRLs are consulted */
+            if(X509_STORE_set_flags(pStore, X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL) != 1)
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+            }
+        }
+        else if(pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_CHECK_REVOCATION_ONLY_LEAF)
+        {
+            /* set the flags of the store so that CRLs are consulted */
+            if(X509_STORE_set_flags(pStore, X509_V_FLAG_CRL_CHECK) != 1)
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+            }
+        }
+    }
+
+    if(pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_CHECK_SELF_SIGNED_SIGNATURE)
+    {
+        /* set the flags of the store so that CRLs are consulted */
+        if(X509_STORE_set_flags(pStore, X509_V_FLAG_CHECK_SS_SIGNATURE) != 1)
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+        }
+    }
+
+    if(pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_ALLOW_PROXY_CERTIFICATES)
+    {
+        /* set the flags of the store so that CRLs are consulted */
+        if(X509_STORE_set_flags(pStore, X509_V_FLAG_ALLOW_PROXY_CERTS) != 1)
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+        }
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(dirlist != NULL)
+    {
+        for (i=0; i<numCertificates; i++)
+        {
+            free(dirlist[i]);
+        }
+        free(dirlist);
+    }
+
+    if(*a_ppCertificateStore != OpcUa_Null)
+    {
+        X509_STORE_free((X509_STORE*)*a_ppCertificateStore);
+        *a_ppCertificateStore = OpcUa_Null;
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_CertificateStore_Close
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_CloseCertificateStore(
+    OpcUa_PKIProvider*          a_pProvider,
+    OpcUa_Void**                a_ppCertificateStore) /* type depends on store implementation */
+{
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "PKI_CloseCertificateStore");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    if(*a_ppCertificateStore != OpcUa_Null)
+    {
+        X509_STORE_free((X509_STORE*)*a_ppCertificateStore);
+        *a_ppCertificateStore = OpcUa_Null;
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PKI_ValidateCertificate
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_ValidateCertificate(
+    OpcUa_PKIProvider*          a_pProvider,
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_Void*                 a_pCertificateStore,
+    OpcUa_Int*                  a_pValidationCode /* Validation return codes from OpenSSL */
+    )
+{
+    OpcUa_P_OpenSSL_CertificateStore_Config*    pCertificateStoreCfg;
+
+    const unsigned char* p;
+
+    X509*               pX509Certificate        = OpcUa_Null;
+    STACK_OF(X509)*     pX509Chain              = OpcUa_Null;
+    X509_STORE_CTX*     verify_ctx              = OpcUa_Null;    /* holds data used during verification process */
+    char                CertFile[MAX_PATH];
+    struct dirent **dirlist = NULL;
+    int numCertificates = 0, i;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "PKI_ValidateCertificate");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider->Handle);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificate);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificateStore);
+    OpcUa_ReturnErrorIfArgumentNull(a_pValidationCode);
+
+    pCertificateStoreCfg = (OpcUa_P_OpenSSL_CertificateStore_Config*)a_pProvider->Handle;
+
+    /* convert DER encoded bytestring certificate to openssl X509 certificate */
+    p = a_pCertificate->Data;
+    if(!(pX509Certificate = d2i_X509((X509**)OpcUa_Null, &p, a_pCertificate->Length)))
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+    while(p < a_pCertificate->Data + a_pCertificate->Length)
+    {
+        X509* pX509AddCertificate;
+        if(!(pX509AddCertificate = d2i_X509((X509**)OpcUa_Null, &p, a_pCertificate->Data + a_pCertificate->Length - p)))
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+        }
+        if(pX509Chain == NULL)
+        {
+            pX509Chain = sk_X509_new_null();
+            OpcUa_GotoErrorIfAllocFailed(pX509Chain);
+        }
+        if(!sk_X509_push(pX509Chain, pX509AddCertificate))
+        {
+            X509_free(pX509AddCertificate);
+            OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+        }
+    }
+
+    /* create verification context and initialize it */
+    if(!(verify_ctx = X509_STORE_CTX_new()))
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+#if (OPENSSL_VERSION_NUMBER > 0x00907000L)
+    if(X509_STORE_CTX_init(verify_ctx, (X509_STORE*)a_pCertificateStore, pX509Certificate, pX509Chain) != 1)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+#else
+    X509_STORE_CTX_init(verify_ctx, (X509_STORE*)a_pCertificateStore, pX509Certificate, pX509Chain);
+#endif
+
+    if(X509_STORE_CTX_set_app_data(verify_ctx, pCertificateStoreCfg) != 1)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+    if((pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_CHECK_REVOCATION_ALL) == OPCUA_P_PKI_OPENSSL_CHECK_REVOCATION_ALL_EXCEPT_SELF_SIGNED
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+        && !X509_STORE_CTX_get_check_issued(verify_ctx) (verify_ctx, pX509Certificate, pX509Certificate))
+#else
+        && !verify_ctx->check_issued(verify_ctx, pX509Certificate, pX509Certificate))
+#endif
+    {
+        /* set the flags of the store so that CRLs are consulted */
+        X509_STORE_CTX_set_flags(verify_ctx, X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL);
+    }
+
+    /* verify the certificate */
+    *a_pValidationCode = X509_V_OK;
+    if(X509_verify_cert(verify_ctx) <= 0)
+    {
+        *a_pValidationCode = X509_STORE_CTX_get_error(verify_ctx);
+        switch(X509_STORE_CTX_get_error(verify_ctx))
+        {
+        case X509_V_ERR_CERT_HAS_EXPIRED:
+        case X509_V_ERR_CERT_NOT_YET_VALID:
+        case X509_V_ERR_CRL_NOT_YET_VALID:
+        case X509_V_ERR_CRL_HAS_EXPIRED:
+        case X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD:
+        case X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD:
+        case X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD:
+        case X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD:
+            {
+                uStatus = OpcUa_BadCertificateTimeInvalid;
+                break;
+            }
+        case X509_V_ERR_CERT_REVOKED:
+            {
+                uStatus = OpcUa_BadCertificateRevoked;
+                break;
+            }
+        case X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT:
+        case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY:
+        case X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT:
+            {
+                uStatus = OpcUa_BadCertificateUntrusted;
+                break;
+            }
+        case X509_V_ERR_CERT_SIGNATURE_FAILURE:
+            {
+                uStatus = OpcUa_BadSecurityChecksFailed;
+                break;
+            }
+        default:
+            {
+                uStatus = OpcUa_BadCertificateInvalid;
+            }
+        }
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_REQUIRE_CHAIN_CERTIFICATE_IN_TRUST_LIST)
+    {
+        FILE*            pCertificateFile;
+        X509*            pTrustCert;
+        STACK_OF(X509)*  chain;
+        int              trusted, n;
+
+        chain = X509_STORE_CTX_get_chain(verify_ctx);
+        trusted = 0;
+        if(pCertificateStoreCfg->CertificateTrustListLocation == NULL || pCertificateStoreCfg->CertificateTrustListLocation[0] == '\0')
+        {
+            uStatus = OpcUa_Bad;
+            OpcUa_GotoErrorIfBad(uStatus);
+        }
+
+        numCertificates = scandir(pCertificateStoreCfg->CertificateTrustListLocation, &dirlist, certificate_filter_der, alphasort);
+        for (i=0; i<numCertificates; i++)
+        {
+            uStatus = OpcUa_P_OpenSSL_BuildFullPath(pCertificateStoreCfg->CertificateTrustListLocation, dirlist[i]->d_name, MAX_PATH, CertFile);
+            OpcUa_GotoErrorIfBad(uStatus);
+
+            /* read DER certificates */
+            pCertificateFile = fopen(CertFile, "r");
+            if(pCertificateFile == OpcUa_Null)
+            {
+                continue; /* ignore access errors */
+            }
+
+            pTrustCert = d2i_X509_fp(pCertificateFile, (X509**)OpcUa_Null);
+            fclose(pCertificateFile);
+            if(pTrustCert == OpcUa_Null)
+            {
+                continue; /* ignore parse errors */
+            }
+
+            for(n = 0; n < sk_X509_num(chain); n++)
+            {
+                if (X509_cmp(sk_X509_value(chain, n), pTrustCert) == 0)
+                    break;
+            }
+
+            X509_free(pTrustCert);
+            if(n < sk_X509_num(chain))
+            {
+                trusted = 1;
+                break;
+            }
+        }
+        for (i=0; i<numCertificates; i++)
+        {
+            free(dirlist[i]);
+        }
+        free(dirlist);
+        dirlist = NULL;
+
+        if(!trusted)
+        {
+            uStatus = OpcUa_BadCertificateUntrusted;
+            OpcUa_GotoErrorIfBad(uStatus);
+        }
+    }
+
+    X509_STORE_CTX_free(verify_ctx);
+    X509_free(pX509Certificate);
+    if(pX509Chain != OpcUa_Null)
+    {
+        sk_X509_pop_free(pX509Chain, X509_free);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(dirlist != NULL)
+    {
+        for (i=0; i<numCertificates; i++)
+        {
+            free(dirlist[i]);
+        }
+        free(dirlist);
+    }
+
+    if(verify_ctx != OpcUa_Null)
+    {
+        X509_STORE_CTX_free(verify_ctx);
+    }
+
+    if(pX509Certificate != OpcUa_Null)
+    {
+        X509_free(pX509Certificate);
+    }
+
+    if(pX509Chain != OpcUa_Null)
+    {
+        sk_X509_pop_free(pX509Chain, X509_free);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PKI_SaveCertificate
+ *===========================================================================*/
+/*
+    ToDo:   Create Access to OpenSSL certificate store
+            => Only API to In-Memory-Store is available for version 0.9.8x
+            => Wait until Directory- and/or File-Store is available
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_SaveCertificate(
+    OpcUa_PKIProvider*          a_pProvider,
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_Void*                 a_pCertificateStore,
+    OpcUa_Void*                 a_pSaveHandle)      /* Index or number within store/destination filepath */
+{
+    X509*                                       pX509Certificate        = OpcUa_Null;
+    FILE*                                       pCertificateFile        = OpcUa_Null;
+
+    const unsigned char*                        p;
+
+    OpcUa_UInt32                                i;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "PKI_SaveCertificate");
+
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider->Handle);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificate);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificateStore);
+    OpcUa_ReturnErrorIfArgumentNull(a_pSaveHandle);
+
+    /* save DER certificate */
+    pCertificateFile = fopen((const char*)a_pSaveHandle, "w");
+
+    /* check for valid file handle */
+    OpcUa_GotoErrorIfTrue((pCertificateFile == OpcUa_Null), OpcUa_BadInvalidArgument);
+
+    /* convert openssl X509 certificate to DER encoded bytestring certificate */
+    p = a_pCertificate->Data;
+    while (p < a_pCertificate->Data + a_pCertificate->Length)
+    {
+        if(!(pX509Certificate = d2i_X509((X509**)OpcUa_Null, &p, a_pCertificate->Data + a_pCertificate->Length - p)))
+        {
+            fclose(pCertificateFile);
+            uStatus = OpcUa_Bad;
+            OpcUa_GotoErrorIfBad(uStatus);
+        }
+
+        i = i2d_X509_fp(pCertificateFile, pX509Certificate);
+
+        if(i < 1)
+        {
+            fclose(pCertificateFile);
+            uStatus =  OpcUa_Bad;
+            OpcUa_GotoErrorIfBad(uStatus);
+        }
+
+        X509_free(pX509Certificate);
+        pX509Certificate = OpcUa_Null;
+    }
+
+    if(fclose(pCertificateFile) != 0)
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if (pX509Certificate != OpcUa_Null)
+    {
+        X509_free(pX509Certificate);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_CertificateStore_Certificate_Load
+ *===========================================================================*/
+/*
+    ToDo:   Create Access to OpenSSL certificate store
+            => Only API to In-Memory-Store is available for version 0.9.8x
+            => Wait until Directory- and/or File-Store is available
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_LoadCertificate(
+    OpcUa_PKIProvider*          a_pProvider,
+    OpcUa_Void*                 a_pLoadHandle,
+    OpcUa_Void*                 a_pCertificateStore,
+    OpcUa_ByteString*           a_pCertificate)
+{
+    OpcUa_Byte*     buf                 = OpcUa_Null;
+    OpcUa_Byte*     p                   = OpcUa_Null;
+    FILE*           pCertificateFile    = OpcUa_Null;
+    X509*           pTmpCert            = OpcUa_Null;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "PKI_LoadCertificate");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider->Handle);
+    OpcUa_ReturnErrorIfArgumentNull(a_pLoadHandle);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificateStore);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificate);
+
+    /* read DER certificates */
+    pCertificateFile = fopen((const char*)a_pLoadHandle, "r");
+
+    /* check for valid file handle */
+    OpcUa_GotoErrorIfTrue((pCertificateFile == OpcUa_Null), OpcUa_BadInvalidArgument);
+
+    if(!(pTmpCert = d2i_X509_fp(pCertificateFile, (X509**)OpcUa_Null)))
+    {
+        uStatus = OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    a_pCertificate->Length = i2d_X509(pTmpCert, NULL);
+    buf = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pCertificate->Length);
+    OpcUa_GotoErrorIfAllocFailed(buf);
+    p = buf;
+    for (;;)
+    {
+        i2d_X509(pTmpCert, &p);
+        X509_free(pTmpCert);
+        if(!(pTmpCert = d2i_X509_fp(pCertificateFile, (X509**)OpcUa_Null)))
+        {
+            break;
+        }
+        p = OpcUa_P_Memory_ReAlloc(buf, a_pCertificate->Length + i2d_X509(pTmpCert, NULL));
+        OpcUa_GotoErrorIfAllocFailed(p);
+        buf = p;
+        p = buf + a_pCertificate->Length;
+        a_pCertificate->Length += i2d_X509(pTmpCert, NULL);
+    }
+
+    if(fclose(pCertificateFile) != 0)
+    {
+        pCertificateFile = OpcUa_Null;
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    a_pCertificate->Data = buf;
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pCertificateFile != OpcUa_Null)
+    {
+        fclose(pCertificateFile);
+    }
+
+    if(pTmpCert != OpcUa_Null)
+    {
+        X509_free(pTmpCert);
+    }
+
+    if(buf != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(buf);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PKI_LoadPrivateKeyFromFile
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_LoadPrivateKeyFromFile(
+    OpcUa_StringA           a_privateKeyFile,
+    OpcUa_P_FileFormat      a_fileFormat,
+    OpcUa_StringA           a_password,         /* optional: just needed encrypted PEM */
+    OpcUa_UInt              a_keyType,
+    OpcUa_Key*              a_pPrivateKey)
+{
+    BIO*            pPrivateKeyFile     = OpcUa_Null;
+    RSA*            pRsaPrivateKey      = OpcUa_Null;
+    EVP_PKEY*       pEvpKey             = OpcUa_Null;
+    unsigned char*  pData;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "PKI_LoadPrivateKeyFromFile");
+
+    /* check parameters */
+    OpcUa_ReturnErrorIfArgumentNull(a_privateKeyFile);
+    OpcUa_ReturnErrorIfArgumentNull(a_pPrivateKey);
+
+    if(a_fileFormat == OpcUa_Crypto_Encoding_Invalid)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    /* open file */
+    pPrivateKeyFile = BIO_new_file((const char*)a_privateKeyFile, "r");
+    OpcUa_ReturnErrorIfArgumentNull(pPrivateKeyFile);
+
+    /* read and convert file */
+    switch(a_fileFormat)
+    {
+    case OpcUa_Crypto_Encoding_PEM:
+        {
+            /* read from file */
+            pEvpKey = PEM_read_bio_PrivateKey(  pPrivateKeyFile,    /* file                 */
+                                                NULL,               /* key struct           */
+                                                0,                  /* password callback    */
+                                                a_password);        /* default passphrase or arbitrary handle */
+            break;
+        }
+    case OpcUa_Crypto_Encoding_PKCS12:
+        {
+            int i;
+
+            /* read from file. */
+            PKCS12* pPkcs12 = d2i_PKCS12_bio(pPrivateKeyFile, NULL);
+
+            if(pPkcs12 == NULL)
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+            }
+
+            /* parse the certificate. */
+            if(a_keyType == OpcUa_Crypto_KeyType_Asymmetric)
+            {
+                X509 *pCert;
+                STACK_OF(X509) *pCA = sk_X509_new_null();
+                OpcUa_GotoErrorIfNull(pCA, OpcUa_Bad);
+                i = PKCS12_parse(pPkcs12, a_password, &pEvpKey, &pCert, &pCA);
+                PKCS12_free(pPkcs12);
+
+                if(i <= 0 || pCert == NULL)
+                {
+                    sk_X509_pop_free(pCA, X509_free);
+                    OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+                }
+
+                a_pPrivateKey->Key.Length = i2d_X509(pCert, NULL);
+                for(i = 0; i < sk_X509_num(pCA); i++)
+                {
+                    a_pPrivateKey->Key.Length += i2d_X509(sk_X509_value(pCA, i), NULL);
+                }
+
+                a_pPrivateKey->Key.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pPrivateKey->Key.Length);
+                if(a_pPrivateKey->Key.Data == OpcUa_Null)
+                {
+                    sk_X509_pop_free(pCA, X509_free);
+                    X509_free(pCert);
+                    OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+                }
+
+                pData = a_pPrivateKey->Key.Data;
+                i2d_X509(pCert, &pData);
+                for(i = 0; i < sk_X509_num(pCA); i++)
+                {
+                    i2d_X509(sk_X509_value(pCA, i), &pData);
+                }
+
+                a_pPrivateKey->Type = OpcUa_Crypto_KeyType_Asymmetric;
+
+                sk_X509_pop_free(pCA, X509_free);
+                X509_free(pCert);
+                EVP_PKEY_free(pEvpKey);
+                BIO_free(pPrivateKeyFile);
+                OpcUa_ReturnStatusCode;
+            }
+
+            i = PKCS12_parse(pPkcs12, a_password, &pEvpKey, NULL, NULL);
+            PKCS12_free(pPkcs12);
+
+            if(i <= 0)
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+            }
+            break;
+        }
+    case OpcUa_Crypto_Encoding_DER:
+        {
+            switch(a_keyType)
+            {
+            case OpcUa_Crypto_KeyType_Rsa_Private:
+                pRsaPrivateKey = d2i_RSAPrivateKey_bio(pPrivateKeyFile, OpcUa_Null);
+                break;
+
+            default:
+                uStatus = OpcUa_BadNotSupported;
+                OpcUa_GotoError;
+            }
+            break;
+        }
+    default:
+        {
+            uStatus = OpcUa_BadNotSupported;
+            OpcUa_GotoError;
+        }
+    }
+
+    if(pEvpKey != NULL)
+    {
+        /* convert to intermediary openssl struct */
+        switch(a_keyType)
+        {
+        case OpcUa_Crypto_KeyType_Any:
+        case OpcUa_Crypto_KeyType_Rsa_Private:
+            pRsaPrivateKey = EVP_PKEY_get1_RSA(pEvpKey);
+            break;
+
+        default:
+            uStatus = OpcUa_BadNotSupported;
+            OpcUa_GotoError;
+        }
+
+        EVP_PKEY_free(pEvpKey);
+        pEvpKey = NULL;
+    }
+
+    if(pRsaPrivateKey != NULL)
+    {
+        /* get required length */
+        a_pPrivateKey->Key.Length = i2d_RSAPrivateKey(pRsaPrivateKey, OpcUa_Null);
+        OpcUa_GotoErrorIfTrue((a_pPrivateKey->Key.Length <= 0), OpcUa_Bad);
+
+        /* allocate target buffer */
+        a_pPrivateKey->Key.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pPrivateKey->Key.Length);
+        OpcUa_GotoErrorIfAllocFailed(a_pPrivateKey->Key.Data);
+
+        /* do real conversion */
+        pData = a_pPrivateKey->Key.Data;
+        a_pPrivateKey->Key.Length = i2d_RSAPrivateKey(pRsaPrivateKey, &pData);
+        OpcUa_GotoErrorIfTrue((a_pPrivateKey->Key.Length <= 0), OpcUa_Bad);
+
+        a_pPrivateKey->Type = OpcUa_Crypto_KeyType_Rsa_Private;
+
+        RSA_free(pRsaPrivateKey);
+    }
+    else
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+    BIO_free(pPrivateKeyFile);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pEvpKey)
+    {
+        EVP_PKEY_free(pEvpKey);
+    }
+
+    if(a_pPrivateKey != OpcUa_Null)
+    {
+        if(a_pPrivateKey->Key.Data != OpcUa_Null)
+        {
+            OpcUa_P_Memory_Free(a_pPrivateKey->Key.Data);
+            a_pPrivateKey->Key.Data = OpcUa_Null;
+            a_pPrivateKey->Key.Length = -1;
+        }
+    }
+
+    if(pPrivateKeyFile != NULL)
+    {
+        BIO_free(pPrivateKeyFile);
+    }
+
+    if(pRsaPrivateKey != NULL)
+    {
+        RSA_free(pRsaPrivateKey);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/**
+  @brief Extracts data from a certificate.
+
+  @param pCertificate          [in] The certificate to examine.
+  @param pIssuer               [out, optional] The issuer name of the certificate.
+  @param pSubject              [out, optional] The subject name of the certificate.
+  @param pSubjectUri           [out, optional] The subject's URI of the certificate.
+  @param pSubjectIP            [out, optional] The subject's IP of the certificate.
+  @param pSubjectDNS           [out, optional] The subject's DNS name of the certificate.
+  @param pCertThumbprint       [out, optional] The thumbprint of the certificate.
+  @param pSubjectHash          [out, optional] The hash code of the certificate.
+  @param pCertRawLength        [out, optional] The length of the DER encoded data.
+                               can be smaller than the total length of pCertificate in case of chain certificate or garbage follow.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_ExtractCertificateData(
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_ByteString*           a_pIssuer,
+    OpcUa_ByteString*           a_pSubject,
+    OpcUa_ByteString*           a_pSubjectUri,
+    OpcUa_ByteString*           a_pSubjectIP,
+    OpcUa_ByteString*           a_pSubjectDNS,
+    OpcUa_ByteString*           a_pCertThumbprint,
+    OpcUa_UInt32*               a_pSubjectHash,
+    OpcUa_UInt32*               a_pCertRawLength)
+{
+    X509*                       pX509Cert = OpcUa_Null;
+    char*                       pName = OpcUa_Null;
+    GENERAL_NAMES*              pNames = OpcUa_Null;
+    const unsigned char*        p;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "PKI_ExtractCertificateData");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificate);
+
+    if(a_pIssuer != OpcUa_Null)
+    {
+        a_pIssuer->Data = OpcUa_Null;
+        a_pIssuer->Length = -1;
+    }
+
+    if(a_pSubject != OpcUa_Null)
+    {
+        a_pSubject->Data = OpcUa_Null;
+        a_pSubject->Length = -1;
+    }
+
+    if(a_pSubjectUri != OpcUa_Null)
+    {
+        a_pSubjectUri->Data = OpcUa_Null;
+        a_pSubjectUri->Length = -1;
+    }
+
+    if(a_pSubjectIP != OpcUa_Null)
+    {
+        a_pSubjectIP->Data = OpcUa_Null;
+        a_pSubjectIP->Length = -1;
+    }
+
+    if(a_pSubjectDNS != OpcUa_Null)
+    {
+        a_pSubjectDNS->Data = OpcUa_Null;
+        a_pSubjectDNS->Length = -1;
+    }
+
+    if(a_pCertThumbprint != OpcUa_Null)
+    {
+        a_pCertThumbprint->Data = OpcUa_Null;
+        a_pCertThumbprint->Length = -1;
+    }
+
+    if(a_pSubjectHash != OpcUa_Null)
+    {
+        *a_pSubjectHash = 0;
+    }
+
+    if(a_pCertRawLength != OpcUa_Null)
+    {
+        *a_pCertRawLength = 0;
+    }
+
+    /* convert openssl X509 certificate to DER encoded bytestring certificate */
+    p = a_pCertificate->Data;
+    if(!(pX509Cert = d2i_X509((X509**)OpcUa_Null, &p, a_pCertificate->Length)))
+    {
+        uStatus = OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(a_pIssuer != OpcUa_Null)
+    {
+        pName = X509_NAME_oneline(X509_get_issuer_name(pX509Cert), NULL, 0);
+        OpcUa_GotoErrorIfAllocFailed(pName);
+        a_pIssuer->Length = strlen(pName)+1;
+        a_pIssuer->Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pIssuer->Length*sizeof(OpcUa_Byte));
+        OpcUa_GotoErrorIfAllocFailed(a_pIssuer->Data);
+        uStatus = OpcUa_P_Memory_MemCpy(a_pIssuer->Data, a_pIssuer->Length, pName, a_pIssuer->Length);
+        OpcUa_GotoErrorIfBad(uStatus);
+        OPENSSL_free(pName);
+        pName = OpcUa_Null;
+    }
+
+    if(a_pSubject != OpcUa_Null)
+    {
+        pName = X509_NAME_oneline(X509_get_subject_name(pX509Cert), NULL, 0);
+        OpcUa_GotoErrorIfAllocFailed(pName);
+        a_pSubject->Length = strlen(pName)+1;
+        a_pSubject->Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pSubject->Length*sizeof(OpcUa_Byte));
+        OpcUa_GotoErrorIfAllocFailed(a_pSubject->Data);
+        uStatus = OpcUa_P_Memory_MemCpy(a_pSubject->Data, a_pSubject->Length, pName, a_pSubject->Length);
+        OpcUa_GotoErrorIfBad(uStatus);
+        OPENSSL_free(pName);
+        pName = OpcUa_Null;
+    }
+
+    if(a_pSubjectUri != OpcUa_Null || a_pSubjectIP != OpcUa_Null || a_pSubjectDNS != OpcUa_Null)
+    {
+        pNames = X509_get_ext_d2i(pX509Cert, NID_subject_alt_name, OpcUa_Null, OpcUa_Null);
+        if (pNames != OpcUa_Null)
+        {
+            int num;
+            for (num = 0; num < sk_GENERAL_NAME_num(pNames); num++)
+            {
+                GENERAL_NAME *value = sk_GENERAL_NAME_value(pNames, num);
+                switch (value->type)
+                {
+                case GEN_URI:
+                    if (a_pSubjectUri != OpcUa_Null && a_pSubjectUri->Data == OpcUa_Null)
+                    {
+                        a_pSubjectUri->Length = value->d.ia5->length+1;
+                        a_pSubjectUri->Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pSubjectUri->Length*sizeof(OpcUa_Byte));
+                        OpcUa_GotoErrorIfAllocFailed(a_pSubjectUri->Data);
+                        uStatus = OpcUa_P_Memory_MemCpy(a_pSubjectUri->Data, a_pSubjectUri->Length, value->d.ia5->data, a_pSubjectUri->Length);
+                        OpcUa_GotoErrorIfBad(uStatus);
+                    }
+                break;
+
+                case GEN_IPADD:
+                    if (a_pSubjectIP != OpcUa_Null && a_pSubjectIP->Data == OpcUa_Null)
+                    {
+                        a_pSubjectIP->Length = value->d.ip->length;
+                        a_pSubjectIP->Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pSubjectIP->Length*sizeof(OpcUa_Byte));
+                        OpcUa_GotoErrorIfAllocFailed(a_pSubjectIP->Data);
+                        uStatus = OpcUa_P_Memory_MemCpy(a_pSubjectIP->Data, a_pSubjectIP->Length, value->d.ip->data, a_pSubjectIP->Length);
+                        OpcUa_GotoErrorIfBad(uStatus);
+                    }
+                break;
+
+                case GEN_DNS:
+                    if (a_pSubjectDNS != OpcUa_Null && a_pSubjectDNS->Data == OpcUa_Null)
+                    {
+                        a_pSubjectDNS->Length = value->d.ia5->length+1;
+                        a_pSubjectDNS->Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pSubjectDNS->Length*sizeof(OpcUa_Byte));
+                        OpcUa_GotoErrorIfAllocFailed(a_pSubjectDNS->Data);
+                        uStatus = OpcUa_P_Memory_MemCpy(a_pSubjectDNS->Data, a_pSubjectDNS->Length, value->d.ia5->data, a_pSubjectDNS->Length);
+                        OpcUa_GotoErrorIfBad(uStatus);
+                    }
+                break;
+                }
+            }
+            sk_GENERAL_NAME_pop_free(pNames, GENERAL_NAME_free);
+            pNames = OpcUa_Null;
+        }
+    }
+
+    if(a_pCertThumbprint != OpcUa_Null)
+    {
+        a_pCertThumbprint->Length = SHA_DIGEST_LENGTH;
+        a_pCertThumbprint->Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pCertThumbprint->Length*sizeof(OpcUa_Byte));
+        OpcUa_GotoErrorIfAllocFailed(a_pCertThumbprint->Data);
+        if(X509_digest(pX509Cert, EVP_sha1(), a_pCertThumbprint->Data, NULL) <= 0)
+        {
+            uStatus = OpcUa_Bad;
+            OpcUa_GotoErrorIfBad(uStatus);
+        }
+    }
+
+    if(a_pSubjectHash != OpcUa_Null)
+    {
+        *a_pSubjectHash = X509_NAME_hash(X509_get_subject_name(pX509Cert));
+    }
+
+    if(a_pCertRawLength != OpcUa_Null)
+    {
+        *a_pCertRawLength = (OpcUa_UInt32)(p - a_pCertificate->Data);
+    }
+
+    X509_free(pX509Cert);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(a_pIssuer != OpcUa_Null && a_pIssuer->Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(a_pIssuer->Data);
+        a_pIssuer->Data = OpcUa_Null;
+        a_pIssuer->Length = -1;
+    }
+
+    if(a_pSubject != OpcUa_Null && a_pSubject->Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(a_pSubject->Data);
+        a_pSubject->Data = OpcUa_Null;
+        a_pSubject->Length = -1;
+    }
+
+    if(a_pSubjectUri != OpcUa_Null && a_pSubjectUri->Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(a_pSubjectUri->Data);
+        a_pSubjectUri->Data = OpcUa_Null;
+        a_pSubjectUri->Length = -1;
+    }
+
+    if(a_pSubjectIP != OpcUa_Null && a_pSubjectIP->Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(a_pSubjectIP->Data);
+        a_pSubjectIP->Data = OpcUa_Null;
+        a_pSubjectIP->Length = -1;
+    }
+
+    if(a_pSubjectDNS != OpcUa_Null && a_pSubjectDNS->Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(a_pSubjectDNS->Data);
+        a_pSubjectDNS->Data = OpcUa_Null;
+        a_pSubjectDNS->Length = -1;
+    }
+
+    if(a_pCertThumbprint != OpcUa_Null && a_pCertThumbprint->Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(a_pCertThumbprint->Data);
+        a_pCertThumbprint->Data = OpcUa_Null;
+        a_pCertThumbprint->Length = -1;
+    }
+
+    if (pName != OpcUa_Null)
+    {
+        OPENSSL_free(pName);
+    }
+
+    if (pNames != OpcUa_Null)
+    {
+        sk_GENERAL_NAME_pop_free(pNames, GENERAL_NAME_free);
+    }
+
+    if(pX509Cert != OpcUa_Null)
+    {
+        X509_free(pX509Cert);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+#endif /* OPCUA_REQUIRE_OPENSSL */

--- a/Stack/platforms/vxworks/opcua_p_openssl_pki.h
+++ b/Stack/platforms/vxworks/opcua_p_openssl_pki.h
@@ -1,0 +1,273 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_P_OpenSSL_PKI_H_
+#define _OpcUa_P_OpenSSL_PKI_H_ 1
+
+OPCUA_BEGIN_EXTERN_C
+
+/**
+  @brief Creates a certificate store object.
+
+  @param pProvider                  [in]  The crypto provider handle.
+
+  @param ppCertificateStore         [out] The handle to the certificate store. Type depends on store implementation.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_OpenCertificateStore(
+    OpcUa_PKIProvider*          pProvider,
+    OpcUa_Void**                ppCertificateStore);
+
+/**
+  @brief frees a certificate store object.
+
+  @param pProvider             [in]  The crypto provider handle.
+  @param ppCertificateStore    [in] The certificate store object. Type depends on store implementation.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_CloseCertificateStore(
+    OpcUa_PKIProvider*       pProvider,
+    OpcUa_Void**             ppCertificateStore);
+
+/**
+  @brief Validates a given X509 certificate object.
+
+   Validation:
+   - Subject/Issuer
+   - Path
+   - Certificate Revocation List (CRL)
+   - Certificate Trust List (CTL)
+
+  @param pProvider                [in]  The crypto provider handle.
+  @param pCertificate             [in]  The certificate that should be validated.
+  @param pCertificateStore        [in]  The certificate store that validates the passed in certificate.
+
+  @param pValidationCode          [out] The validation code, that gives information about the validation result. Validation return codes from OpenSSL are used.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_ValidateCertificate(
+    OpcUa_PKIProvider*          pProvider,
+    OpcUa_ByteString*           pCertificate,
+    OpcUa_Void*                 pCertificateStore,
+    OpcUa_Int*                  pValidationCode);
+
+/**
+  @brief imports a given certificate into given certificate store.
+
+  @param pProvider                [in]  The crypto provider handle.
+  @param pCertificateStore        [in]  The certificate store that should store the passed in certificate.
+  @param pCertificate             [in]  The certificate that should be stored in the certificate store.
+  @param pSaveHandle              [in]  The index that indicates the store location of the certificate within the certificate store.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_SaveCertificate(
+    OpcUa_PKIProvider*          pProvider,
+    OpcUa_ByteString*           pCertificate,
+    OpcUa_Void*                 pCertificateStore,
+    OpcUa_Void*                 pSaveHandle);
+
+/**
+  @brief exports a certain certificate from a given certificate store.
+
+  @param pProvider                [in]  The crypto provider handle.
+  @param pLoadHandle              [in]  The index that indicates the store location of the certificate within the certificate store.
+  @param ppCertificateStore       [in]  The certificate store that contains the desired certificate.
+
+  @param pCertificate             [out] The exported certificate.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_LoadCertificate(
+    OpcUa_PKIProvider*          pProvider,
+    OpcUa_Void*                 pLoadHandle,
+    OpcUa_Void*                 pCertificateStore,
+    OpcUa_ByteString*           pCertificate);
+
+/**
+  @brief loads a private key object, usually from an encrypted file.
+
+  Note: fileFormat == OpcUa_Crypto_Encoding_DER needs a keyType != OpcUa_Crypto_KeyType_Any
+        e.g. OpcUa_Crypto_KeyType_Rsa_Private.
+        Other formats can use keyType == OpcUa_Crypto_KeyType_Any as a wildcard.
+
+  @param privateKeyFile           [in]  The file name.
+  @param fileFormat               [in]  The file format.
+  @param password                 [in]  The encryption password.
+  @param keyType                  [in]  The expected key type.
+
+  @param pPrivateKey              [out] The private key (in DER format).
+  */
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_LoadPrivateKeyFromFile(
+    OpcUa_StringA           privateKeyFile,
+    OpcUa_P_FileFormat      fileFormat,
+    OpcUa_StringA           password,
+    OpcUa_UInt              keyType,
+    OpcUa_Key*              pPrivateKey);
+
+/**
+  @brief Extracts data from a certificate.
+
+  @param pCertificate          [in] The certificate to examine.
+  @param pIssuer               [out, optional] The issuer name of the certificate.
+  @param pSubject              [out, optional] The subject name of the certificate.
+  @param pSubjectUri           [out, optional] The subject's URI of the certificate.
+  @param pSubjectIP            [out, optional] The subject's IP of the certificate.
+  @param pSubjectDNS           [out, optional] The subject's DNS name of the certificate.
+  @param pCertThumbprint       [out, optional] The thumbprint of the certificate.
+  @param pSubjectHash          [out, optional] The hash code of the certificate.
+  @param pCertRawLength        [out, optional] The length of the DER encoded data.
+                               can be smaller than the total length of pCertificate in case of chain certificate or garbage follow.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_ExtractCertificateData(
+    OpcUa_ByteString*           pCertificate,
+    OpcUa_ByteString*           pIssuer,
+    OpcUa_ByteString*           pSubject,
+    OpcUa_ByteString*           pSubjectUri,
+    OpcUa_ByteString*           pSubjectIP,
+    OpcUa_ByteString*           pSubjectDNS,
+    OpcUa_ByteString*           pCertThumbprint,
+    OpcUa_UInt32*               pSubjectHash,
+    OpcUa_UInt32*               pCertRawLength);
+
+/* NoSecurity functions */
+
+/**
+  @brief Creates a certificate store object.
+
+  @param pProvider                  [in]  The crypto provider handle.
+
+  @param ppCertificateStore         [out] The handle to the certificate store. Type depends on store implementation.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_OpenCertificateStore(
+    OpcUa_PKIProvider*          pProvider,
+    OpcUa_Void**                ppCertificateStore);
+
+/**
+  @brief frees a certificate store object.
+
+  @param pProvider             [in]  The crypto provider handle.
+  @param ppCertificateStore    [in] The certificate store object. Type depends on store implementation.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_CloseCertificateStore(
+    OpcUa_PKIProvider*          pProvider,
+    OpcUa_Void**                ppCertificateStore);
+
+/**
+  @brief Validates a given X509 certificate object.
+
+   Validation:
+   - Subject/Issuer
+   - Path
+   - Certificate Revocation List (CRL)
+   - Certificate Trust List (CTL)
+
+  @param pProvider                [in]  The crypto provider handle.
+  @param pCertificate             [in]  The certificate that should be validated.
+  @param pCertificateStore        [in]  The certificate store that validates the passed in certificate.
+
+  @param pValidationCode          [out] The validation code, that gives information about the validation result. Validation return codes from OpenSSL are used.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_ValidateCertificate(
+    OpcUa_PKIProvider*          pProvider,
+    OpcUa_ByteString*           pCertificate,
+    OpcUa_Void*                 pCertificateStore,
+    OpcUa_Int*                  pValidationCode /* Validation return codes from OpenSSL */);
+
+/**
+  @brief imports a given certificate into given certificate store.
+
+  @param pProvider                [in]  The crypto provider handle.
+  @param pCertificateStore        [in]  The certificate store that should store the passed in certificate.
+  @param pCertificate             [in]  The certificate that should be stored in the certificate store.
+  @param pSaveHandle              [in]  The index that indicates the store location of the certificate within the certificate store.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_SaveCertificate(
+    OpcUa_PKIProvider*          pProvider,
+    OpcUa_ByteString*           pCertificate,
+    OpcUa_Void*                 pCertificateStore,
+    OpcUa_Void*                 pSaveHandle);
+
+/**
+  @brief exports a certain certificate from a given certificate store.
+
+  @param pProvider                [in]  The crypto provider handle.
+  @param pLoadHandle              [in]  The index that indicates the store location of the certificate within the certificate store.
+  @param ppCertificateStore       [in]  The certificate store that contains the desired certificate.
+
+  @param pCertificate             [out] The exported certificate.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_LoadCertificate(
+    OpcUa_PKIProvider*          pProvider,
+    OpcUa_Void*                 pLoadHandle,
+    OpcUa_Void*                 pCertificateStore,
+    OpcUa_ByteString*           pCertificate);
+
+/**
+  @brief loads a private key object, usually from an encrypted file.
+
+  Note: fileFormat == OpcUa_Crypto_Encoding_DER needs a keyType != OpcUa_Crypto_KeyType_Any
+        e.g. OpcUa_Crypto_KeyType_Rsa_Private.
+        Other formats can use keyType == OpcUa_Crypto_KeyType_Any as a wildcard.
+
+  @param privateKeyFile           [in]  The file name.
+  @param fileFormat               [in]  The file format.
+  @param password                 [in]  The encryption password.
+  @param keyType                  [in]  The expected key type.
+
+  @param pPrivateKey              [out] The private key (in DER format).
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_LoadPrivateKeyFromFile(
+    OpcUa_StringA               privateKeyFile,
+    OpcUa_P_FileFormat          fileFormat,
+    OpcUa_StringA               password,
+    OpcUa_UInt                  keyType,
+    OpcUa_Key*                  pPrivateKey);
+
+/**
+  @brief Extracts data from a certificate store object.
+
+  @param pCertificate          [in] The certificate to examine.
+  @param pIssuer               [out, optional] The issuer name of the certificate.
+  @param pSubject              [out, optional] The subject name of the certificate.
+  @param pSubjectUri           [out, optional] The subject's URI of the certificate.
+  @param pSubjectIP            [out, optional] The subject's IP of the certificate.
+  @param pSubjectDNS           [out, optional] The subject's DNS name of the certificate.
+  @param pCertThumbprint       [out, optional] The thumbprint of the certificate.
+  @param pSubjectHash          [out, optional] The hash code of the certificate.
+  @param pCertRawLength        [out, optional] The length of the DER encoded data.
+                               can be smaller than the total length of pCertificate in case of chain certificate or garbage follow.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_ExtractCertificateData(
+    OpcUa_ByteString*           pCertificate,
+    OpcUa_ByteString*           pIssuer,
+    OpcUa_ByteString*           pSubject,
+    OpcUa_ByteString*           pSubjectUri,
+    OpcUa_ByteString*           pSubjectIP,
+    OpcUa_ByteString*           pSubjectDNS,
+    OpcUa_ByteString*           pCertThumbprint,
+    OpcUa_UInt32*               pSubjectHash,
+    OpcUa_UInt32*               pCertRawLength);
+
+OPCUA_END_EXTERN_C
+
+#endif /* _OpcUa_Crypto_OpenSsl_H_ */

--- a/Stack/platforms/vxworks/opcua_p_openssl_pki_nosecurity.c
+++ b/Stack/platforms/vxworks/opcua_p_openssl_pki_nosecurity.c
@@ -1,0 +1,158 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+
+/* own headers */
+#include <opcua_p_openssl_pki.h>
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_CertificateStore_Open
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_OpenCertificateStore(
+    OpcUa_PKIProvider*          a_pProvider,
+    OpcUa_Void**                a_ppCertificateStore)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_ppCertificateStore);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PKI_NoSecurity_CloseCertificateStore
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_CloseCertificateStore(
+    OpcUa_PKIProvider*          a_pProvider,
+    OpcUa_Void**                a_ppCertificateStore)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_ppCertificateStore);
+
+    return OpcUa_BadNotSupported;
+}
+
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PKI_ValidateCertificate
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_ValidateCertificate(
+    OpcUa_PKIProvider*          a_pProvider,
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_Void*                 a_pCertificateStore,
+    OpcUa_Int*                  a_pValidationCode)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pCertificateStore);
+    OpcUa_ReferenceParameter(a_pCertificate);
+    OpcUa_ReferenceParameter(a_pValidationCode);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PKI_NoSecurity_SaveCertificate
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_SaveCertificate(
+    OpcUa_PKIProvider*          a_pProvider,
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_Void*                 a_pCertificateStore,
+    OpcUa_Void*                 a_pSaveHandle)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pCertificateStore);
+    OpcUa_ReferenceParameter(a_pCertificate);
+    OpcUa_ReferenceParameter(a_pSaveHandle);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PKI_NoSecurity_LoadCertificate
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_LoadCertificate(
+    OpcUa_PKIProvider*          a_pProvider,
+    OpcUa_Void*                 a_pLoadHandle,
+    OpcUa_Void*                 a_pCertificateStore,
+    OpcUa_ByteString*           a_pCertificate)
+{
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pCertificateStore);
+    OpcUa_ReferenceParameter(a_pCertificate);
+    OpcUa_ReferenceParameter(a_pLoadHandle);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PKI_NoSecurity_LoadCertificate
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_LoadPrivateKeyFromFile(
+    OpcUa_StringA               a_privateKeyFile,
+    OpcUa_P_FileFormat          a_fileFormat,
+    OpcUa_StringA               a_password,
+    OpcUa_UInt                  a_keyType,
+    OpcUa_Key*                  a_pPrivateKey)
+{
+    OpcUa_ReferenceParameter(a_privateKeyFile);
+    OpcUa_ReferenceParameter(a_fileFormat);
+    OpcUa_ReferenceParameter(a_password);
+    OpcUa_ReferenceParameter(a_keyType);
+    OpcUa_ReferenceParameter(a_pPrivateKey);
+
+    return OpcUa_BadNotSupported;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PKI_NoSecurity_ExtractCertificateData
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PKI_NoSecurity_ExtractCertificateData(
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_ByteString*           a_pIssuer,
+    OpcUa_ByteString*           a_pSubject,
+    OpcUa_ByteString*           a_pSubjectUri,
+    OpcUa_ByteString*           a_pSubjectIP,
+    OpcUa_ByteString*           a_pSubjectDNS,
+    OpcUa_ByteString*           a_pCertThumbprint,
+    OpcUa_UInt32*               a_pSubjectHash,
+    OpcUa_UInt32*               a_pCertRawLength)
+{
+    OpcUa_ReferenceParameter(a_pCertificate);
+    OpcUa_ReferenceParameter(a_pIssuer);
+    OpcUa_ReferenceParameter(a_pSubject);
+    OpcUa_ReferenceParameter(a_pSubjectUri);
+    OpcUa_ReferenceParameter(a_pSubjectIP);
+    OpcUa_ReferenceParameter(a_pSubjectDNS);
+    OpcUa_ReferenceParameter(a_pCertThumbprint);
+    OpcUa_ReferenceParameter(a_pSubjectHash);
+    OpcUa_ReferenceParameter(a_pCertRawLength);
+
+    return OpcUa_BadNotSupported;
+}

--- a/Stack/platforms/vxworks/opcua_p_openssl_random.c
+++ b/Stack/platforms/vxworks/opcua_p_openssl_random.c
@@ -1,0 +1,597 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_memory.h>
+#include <opcua_p_cryptofactory.h>
+
+#if OPCUA_REQUIRE_OPENSSL
+
+/* System Headers */
+#include <openssl/rand.h>
+#include <openssl/hmac.h>
+
+/* own headers */
+#include <opcua_p_openssl.h>
+
+#define MAX_DERIVED_OUTPUT_LEN  512
+#define MAX_GENERATED_OUTPUT_LEN  1024
+
+/* offset macros */
+#define OpcUa_P_OpenSSL_PSHA1_SEED(ctx)   ((ctx)->A+20)
+#define OpcUa_P_OpenSSL_PSHA1_SECRET(ctx) ((ctx)->A+20+(ctx)->seed_len)
+
+/** P_SHA1 Context */
+struct OpcUa_P_OpenSSL_PSHA1_Ctx_
+{
+    OpcUa_Int secret_len;
+    OpcUa_Int seed_len;
+    OpcUa_Byte A[20]; /* 20 bytes of SHA1 output */
+    /* pseudo elements:
+     * char seed[seed_len];
+     * char secret[secret_len];
+     */
+};
+
+typedef struct OpcUa_P_OpenSSL_PSHA1_Ctx_ OpcUa_P_OpenSSL_PSHA1_Ctx;
+
+/**
+  @brief Initializes the pseudo-random function.
+
+  -  returns a PRF context.
+
+  internal!
+
+  @param pSecret          [in]  The secret information for the PRF to create a PRF context.
+  @param secretLen        [in]  The length of the secret information for the PRF to create a PRF context.
+  @param pSeed            [in]  The seed to create the PRF context.
+  @param secretLen        [in]  The length seed to create the PRF context.
+*/
+OpcUa_P_OpenSSL_PSHA1_Ctx* OpcUa_P_OpenSSL_PSHA1_Context_Create(
+    OpcUa_Byte*         pSecret,
+    OpcUa_UInt32        secretLen,
+    OpcUa_Byte*         pSeed,
+    OpcUa_Int32         seedLen);
+
+/**
+  @brief Add bytes of random data to the destination buffer.
+
+  internal!
+
+  @param pPsha1Context     [in]  The PRF context.
+
+  @param pHash             [out] The destination buffer.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PSHA1_Hash_Generate(
+    OpcUa_P_OpenSSL_PSHA1_Ctx* pPsha1Context,
+    OpcUa_Byte*              pHash);
+
+/* offset macros */
+#define OpcUa_P_OpenSSL_PSHA256_SEED(ctx)   ((ctx)->A+32)
+#define OpcUa_P_OpenSSL_PSHA256_SECRET(ctx) ((ctx)->A+32+(ctx)->seed_len)
+
+/** P_SHA256 Context */
+struct OpcUa_P_OpenSSL_PSHA256_Ctx_
+{
+    OpcUa_Int secret_len;
+    OpcUa_Int seed_len;
+    OpcUa_Byte A[32]; /* 32 bytes of SHA256 output */
+    /* pseudo elements:
+     * char seed[seed_len];
+     * char secret[secret_len];
+     */
+};
+
+typedef struct OpcUa_P_OpenSSL_PSHA256_Ctx_ OpcUa_P_OpenSSL_PSHA256_Ctx;
+
+/**
+  @brief Initializes the pseudo-random function.
+
+  -  returns a PRF context.
+
+  internal!
+
+  @param pSecret          [in]  The secret information for the PRF to create a PRF context.
+  @param secretLen        [in]  The length of the secret information for the PRF to create a PRF context.
+  @param pSeed            [in]  The seed to create the PRF context.
+  @param secretLen        [in]  The length seed to create the PRF context.
+*/
+OpcUa_P_OpenSSL_PSHA256_Ctx* OpcUa_P_OpenSSL_PSHA256_Context_Create(
+    OpcUa_Byte*         pSecret,
+    OpcUa_UInt32        secretLen,
+    OpcUa_Byte*         pSeed,
+    OpcUa_Int32         seedLen);
+
+/**
+  @brief Add bytes of random data to the destination buffer.
+
+  internal!
+
+  @param pPsha1Context     [in]  The PRF context.
+
+  @param pHash             [out] The destination buffer.
+*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_PSHA256_Hash_Generate(
+    OpcUa_P_OpenSSL_PSHA256_Ctx* pPsha256Context,
+    OpcUa_Byte*              pHash);
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_SeedPRNG
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_OpenSSL_SeedPRNG( OpcUa_Byte* seed,
+                                                         OpcUa_Int   bytes)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "SeedPRNG");
+
+    RAND_seed(seed, bytes);
+
+OpcUa_ReturnStatusCode;
+
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PSHA1_Context_Create
+ *===========================================================================*/
+/** Implements P_SHA1 according to RFC 2246, section 5
+* using OpenSSL HMAC function.
+* P_SHA1_init creates a P_SHA1 context and initializes it with secret and seed.
+* Use OpcUa_OpcUa_P_Memory_Free to clear the context.
+* A(1) is calculated to use with OpcUa_P_OpenSSL_P_SHA1_update.
+* @see OpcUa_P_OpenSSL_P_SHA1_update
+*/
+
+/* internal function */
+OpcUa_P_OpenSSL_PSHA1_Ctx* OpcUa_P_OpenSSL_PSHA1_Context_Create(
+    OpcUa_Byte*     a_pSecret,
+    OpcUa_UInt32    a_secretLen,
+    OpcUa_Byte*     a_pSeed,
+    OpcUa_Int32     a_seedLen)
+{
+    OpcUa_P_OpenSSL_PSHA1_Ctx*  pCtx;
+    OpcUa_Int                   size;
+
+    if(a_pSecret == OpcUa_Null || a_pSeed == OpcUa_Null)
+        return OpcUa_Null;
+
+    pCtx = OpcUa_Null;
+    size = sizeof(OpcUa_P_OpenSSL_PSHA1_Ctx) + a_secretLen + a_seedLen;
+
+    pCtx = (OpcUa_P_OpenSSL_PSHA1_Ctx*) OpcUa_P_Memory_Alloc(size);
+
+    if(pCtx == OpcUa_Null)
+        return OpcUa_Null;
+
+    pCtx->secret_len = a_secretLen;
+    pCtx->seed_len = a_seedLen;
+
+    OpcUa_P_Memory_MemCpy(OpcUa_P_OpenSSL_PSHA1_SECRET(pCtx), a_secretLen, a_pSecret, a_secretLen);
+    OpcUa_P_Memory_MemCpy(OpcUa_P_OpenSSL_PSHA1_SEED(pCtx), a_seedLen, a_pSeed, a_seedLen);
+
+    /* A(0) = seed */
+    /* A(i) = HMAC_SHA1(secret, A(i-1)) */
+    /* Calculate A(1) = HMAC_SHA1(secret, seed) */
+    if(HMAC(EVP_sha1(), a_pSecret, a_secretLen, a_pSeed, a_seedLen, pCtx->A, OpcUa_Null) == OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(pCtx);
+        return OpcUa_Null;
+    }
+
+    return pCtx;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PSHA1_Hash_Generate
+ *===========================================================================*/
+/** Implements P_SHA1 according to RFC 2246, section 5
+* using OpenSSL HMAC function.
+* P_SHA1_update calculates P_SHA1(n) and writes it to pDst.
+* Call this function as often as you need to get the desired size of data.
+* A(n+1) is caculated for the next run.
+* @see OpcUa_P_OpenSSL_P_SHA1_init
+*/
+
+/* internal function */
+OpcUa_StatusCode OpcUa_P_OpenSSL_PSHA1_Hash_Generate(
+    OpcUa_P_OpenSSL_PSHA1_Ctx* a_pPsha1Context,
+    OpcUa_Byte*              a_pHash)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "PSHA1_Hash_Generate");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pPsha1Context);
+    OpcUa_ReturnErrorIfArgumentNull(a_pHash);
+
+    /* Calculate P_SHA1(n) = HMAC_SHA1(secret, A(n)+seed) */
+    if(HMAC(EVP_sha1(), OpcUa_P_OpenSSL_PSHA1_SECRET(a_pPsha1Context), a_pPsha1Context->secret_len,
+                     a_pPsha1Context->A, sizeof(a_pPsha1Context->A) + a_pPsha1Context->seed_len,
+                     a_pHash, OpcUa_Null) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+    /* Calculate A(n) = HMAC_SHA1(secret, A(n-1)) */
+    if(HMAC(EVP_sha1(), OpcUa_P_OpenSSL_PSHA1_SECRET(a_pPsha1Context), a_pPsha1Context->secret_len,
+                     a_pPsha1Context->A, sizeof(a_pPsha1Context->A),
+                     a_pPsha1Context->A, OpcUa_Null) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_Random_Key_Derive
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_Random_Key_Derive(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_secret, /* clientnonce | servernonce, servernonce | clientnonce */
+    OpcUa_ByteString      a_seed,
+    OpcUa_Int32           a_keyLen, /* output len */
+    OpcUa_Key*            a_pKey)
+{
+    OpcUa_P_OpenSSL_PSHA1_Ctx*  pCtx            = OpcUa_Null;
+    OpcUa_Byte*                 pBuffer         = OpcUa_Null;
+
+    OpcUa_Int                   bufferlength;
+    OpcUa_Int                   i;
+    OpcUa_Int                   iterations;
+
+    OpcUa_Int32                 keyLen          = 0;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "Random_Key_Derive");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_secret.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_seed.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pKey);
+
+    keyLen = a_keyLen;
+
+    if(keyLen < 0)
+    {
+        if(a_pProvider->SymmetricKeyLength > 0)
+        {
+            keyLen = a_pProvider->SymmetricKeyLength;
+        }
+        else
+        {
+            uStatus = OpcUa_BadInvalidArgument;
+            OpcUa_GotoErrorIfBad(uStatus);
+        }
+    }
+    else if(keyLen > MAX_DERIVED_OUTPUT_LEN)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(a_pKey->Key.Data == OpcUa_Null)
+    {
+        a_pKey->Key.Length = keyLen;
+        OpcUa_ReturnStatusCode;
+    }
+
+    a_pKey->Type = OpcUa_Crypto_KeyType_Random;
+
+    /** start creating key **/
+
+    iterations = keyLen/20 + (keyLen%20?1:0);
+    bufferlength = iterations*20;
+
+    pBuffer = (OpcUa_Byte *)OpcUa_P_Memory_Alloc(bufferlength * sizeof(OpcUa_Byte));
+    OpcUa_GotoErrorIfAllocFailed(pBuffer);
+
+    pCtx = OpcUa_P_OpenSSL_PSHA1_Context_Create(a_secret.Data, a_secret.Length, a_seed.Data, a_seed.Length);
+    OpcUa_GotoErrorIfAllocFailed(pCtx);
+
+    for(i=0; i<iterations; i++)
+    {
+        /* SHA1 produces 20 Bytes of output for every iteration */
+        uStatus = OpcUa_P_OpenSSL_PSHA1_Hash_Generate(pCtx, pBuffer + (i*20));
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    uStatus = OpcUa_P_Memory_MemCpy(a_pKey->Key.Data, a_pKey->Key.Length, pBuffer, keyLen);
+
+    OpcUa_P_Memory_Free(pCtx);
+
+    OpcUa_P_Memory_Free(pBuffer);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pCtx != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(pCtx);
+    }
+
+    if(pBuffer != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(pBuffer);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_Random_Key_Generate
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_Random_Key_Generate(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_Int32           a_keyLen,
+    OpcUa_Key*            a_pKey)
+{
+    OpcUa_Int32                 keyLen  = 0;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "Random_Key_Generate");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_pKey);
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    keyLen = a_keyLen;
+
+    if(keyLen < 0)
+    {
+        if(a_pProvider->SymmetricKeyLength > 0)
+        {
+            keyLen = a_pProvider->SymmetricKeyLength;
+        }
+        else
+        {
+            uStatus = OpcUa_BadInvalidArgument;
+            OpcUa_GotoErrorIfBad(uStatus);
+        }
+    }
+    else if(keyLen > MAX_GENERATED_OUTPUT_LEN)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    a_pKey->Key.Length = keyLen;
+    a_pKey->Type = OpcUa_Crypto_KeyType_Random;
+
+    if(a_pKey->Key.Data == OpcUa_Null)
+    {
+        OpcUa_ReturnStatusCode;
+    }
+
+    if(RAND_bytes(a_pKey->Key.Data, a_pKey->Key.Length) <= 0)
+    {
+        uStatus = OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PSHA256_Context_Create
+ *===========================================================================*/
+/** Implements P_SHA256 according to RFC 2246, section 5
+* using OpenSSL HMAC function.
+* P_SHA256_init creates a P_SHA256 context and initializes it with secret and seed.
+* Use OpcUa_OpcUa_P_Memory_Free to clear the context.
+* A(1) is calculated to use with OpcUa_P_OpenSSL_P_SHA256_update.
+* @see OpcUa_P_OpenSSL_P_SHA256_update
+*/
+
+/* internal function */
+OpcUa_P_OpenSSL_PSHA256_Ctx* OpcUa_P_OpenSSL_PSHA256_Context_Create(
+    OpcUa_Byte*     a_pSecret,
+    OpcUa_UInt32    a_secretLen,
+    OpcUa_Byte*     a_pSeed,
+    OpcUa_Int32     a_seedLen)
+{
+    OpcUa_P_OpenSSL_PSHA256_Ctx*  pCtx;
+    OpcUa_Int                   size;
+
+    if(a_pSecret == OpcUa_Null || a_pSeed == OpcUa_Null)
+        return OpcUa_Null;
+
+    pCtx = OpcUa_Null;
+    size = sizeof(OpcUa_P_OpenSSL_PSHA256_Ctx) + a_secretLen + a_seedLen;
+
+    pCtx = (OpcUa_P_OpenSSL_PSHA256_Ctx*) OpcUa_P_Memory_Alloc(size);
+
+    if(pCtx == OpcUa_Null)
+        return OpcUa_Null;
+
+    pCtx->secret_len = a_secretLen;
+    pCtx->seed_len = a_seedLen;
+
+    OpcUa_P_Memory_MemCpy(OpcUa_P_OpenSSL_PSHA256_SECRET(pCtx), a_secretLen, a_pSecret, a_secretLen);
+    OpcUa_P_Memory_MemCpy(OpcUa_P_OpenSSL_PSHA256_SEED(pCtx), a_seedLen, a_pSeed, a_seedLen);
+
+    /* A(0) = seed */
+    /* A(i) = HMAC_SHA256(secret, A(i-1)) */
+    /* Calculate A(1) = HMAC_SHA256(secret, seed) */
+    if(HMAC(EVP_sha256(), a_pSecret, a_secretLen, a_pSeed, a_seedLen, pCtx->A, OpcUa_Null) == OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(pCtx);
+        return OpcUa_Null;
+    }
+
+    return pCtx;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_PSHA256_Hash_Generate
+ *===========================================================================*/
+/** Implements P_SHA256 according to RFC 2246, section 5
+* using OpenSSL HMAC function.
+* P_SHA256_update calculates P_SHA256(n) and writes it to pDst.
+* Call this function as often as you need to get the desired size of data.
+* A(n+1) is caculated for the next run.
+* @see OpcUa_P_OpenSSL_P_SHA256_init
+*/
+
+/* internal function */
+OpcUa_StatusCode OpcUa_P_OpenSSL_PSHA256_Hash_Generate(
+    OpcUa_P_OpenSSL_PSHA256_Ctx* a_pPsha256Context,
+    OpcUa_Byte*              a_pHash)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "PSHA256_Hash_Generate");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pPsha256Context);
+    OpcUa_ReturnErrorIfArgumentNull(a_pHash);
+
+    /* Calculate P_SHA256(n) = HMAC_SHA256(secret, A(n)+seed) */
+    if(HMAC(EVP_sha256(), OpcUa_P_OpenSSL_PSHA256_SECRET(a_pPsha256Context), a_pPsha256Context->secret_len,
+                     a_pPsha256Context->A, sizeof(a_pPsha256Context->A) + a_pPsha256Context->seed_len,
+                     a_pHash, OpcUa_Null) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+    /* Calculate A(n) = HMAC_SHA256(secret, A(n-1)) */
+    if(HMAC(EVP_sha256(), OpcUa_P_OpenSSL_PSHA256_SECRET(a_pPsha256Context), a_pPsha256Context->secret_len,
+                     a_pPsha256Context->A, sizeof(a_pPsha256Context->A),
+                     a_pPsha256Context->A, OpcUa_Null) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_Random_Key_PSHA256_Derive
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_Random_Key_PSHA256_Derive(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_secret, /* clientnonce | servernonce, servernonce | clientnonce */
+    OpcUa_ByteString      a_seed,
+    OpcUa_Int32           a_keyLen, /* output len */
+    OpcUa_Key*            a_pKey)
+{
+    OpcUa_P_OpenSSL_PSHA256_Ctx*pCtx            = OpcUa_Null;
+    OpcUa_Byte*                 pBuffer         = OpcUa_Null;
+
+    OpcUa_Int                   bufferlength;
+    OpcUa_Int                   i;
+    OpcUa_Int                   iterations;
+
+    OpcUa_Int32                 keyLen          = 0;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "Random_Key_PSHA256_Derive");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_secret.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_seed.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pKey);
+
+    keyLen = a_keyLen;
+
+    if(keyLen < 0)
+    {
+        if(a_pProvider->SymmetricKeyLength > 0)
+        {
+            keyLen = a_pProvider->SymmetricKeyLength;
+        }
+        else
+        {
+            uStatus = OpcUa_BadInvalidArgument;
+            OpcUa_GotoErrorIfBad(uStatus);
+        }
+    }
+    else if(keyLen > MAX_DERIVED_OUTPUT_LEN)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(a_pKey->Key.Data == OpcUa_Null)
+    {
+        a_pKey->Key.Length = keyLen;
+        OpcUa_ReturnStatusCode;
+    }
+
+    a_pKey->Type = OpcUa_Crypto_KeyType_Random;
+
+    /** start creating key **/
+
+    iterations = keyLen/32 + (keyLen%32?1:0);
+    bufferlength = iterations*32;
+
+    pBuffer = (OpcUa_Byte *)OpcUa_P_Memory_Alloc(bufferlength * sizeof(OpcUa_Byte));
+    OpcUa_GotoErrorIfAllocFailed(pBuffer);
+
+    pCtx = OpcUa_P_OpenSSL_PSHA256_Context_Create(a_secret.Data, a_secret.Length, a_seed.Data, a_seed.Length);
+    OpcUa_GotoErrorIfAllocFailed(pCtx);
+
+    for(i=0; i<iterations; i++)
+    {
+        /* SHA256 produces 32 Bytes of output for every iteration */
+        uStatus = OpcUa_P_OpenSSL_PSHA256_Hash_Generate(pCtx, pBuffer + (i*32));
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    uStatus = OpcUa_P_Memory_MemCpy(a_pKey->Key.Data, a_pKey->Key.Length, pBuffer, keyLen);
+
+    OpcUa_P_Memory_Free(pCtx);
+    OpcUa_P_Memory_Free(pBuffer);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pCtx != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(pCtx);
+    }
+
+    if(pBuffer != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(pBuffer);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+#endif /* OPCUA_REQUIRE_OPENSSL */

--- a/Stack/platforms/vxworks/opcua_p_openssl_rsa.c
+++ b/Stack/platforms/vxworks/opcua_p_openssl_rsa.c
@@ -1,0 +1,1013 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_memory.h>
+
+#if OPCUA_REQUIRE_OPENSSL
+
+/* System Headers */
+#include <openssl/rsa.h>
+#include <openssl/evp.h>
+
+/* own headers */
+#include <opcua_p_openssl.h>
+#include <opcua_p_pki.h>
+
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+#define get_pkey_rsa(evp) EVP_PKEY_get0_RSA(evp)
+#else
+#define get_pkey_rsa(evp) ((evp)->pkey.rsa)
+#endif
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_GenerateKeys
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_GenerateKeys(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_UInt32            a_bits,
+    OpcUa_Key*              a_pPublicKey,
+    OpcUa_Key*              a_pPrivateKey)
+{
+    RSA*            pRsa        = OpcUa_Null;
+    unsigned char*  pData;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_GenerateKeys");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_pPublicKey);
+    OpcUa_ReturnErrorIfArgumentNull(a_pPrivateKey);
+
+    a_pPublicKey->Key.Data      = OpcUa_Null;
+    a_pPrivateKey->Key.Data     = OpcUa_Null;
+
+    if((a_bits < a_pProvider->MinimumAsymmetricKeyLength*8) || (a_bits > a_pProvider->MaximumAsymmetricKeyLength*8))
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    pRsa = RSA_generate_key(a_bits, RSA_F4, NULL, OpcUa_Null);
+    OpcUa_GotoErrorIfNull(pRsa, OpcUa_Bad);
+
+    /* get required length */
+    a_pPublicKey->Key.Length = i2d_RSAPublicKey(pRsa, NULL);
+    OpcUa_GotoErrorIfTrue((a_pPublicKey->Key.Length <= 0), OpcUa_Bad);
+
+    /* allocate target buffer */
+    a_pPublicKey->Key.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pPublicKey->Key.Length);
+    OpcUa_GotoErrorIfAllocFailed(a_pPublicKey->Key.Data);
+
+    pData = a_pPublicKey->Key.Data;
+    a_pPublicKey->Key.Length = i2d_RSAPublicKey(pRsa, &pData);
+
+    /* get required length */
+    a_pPrivateKey->Key.Length = i2d_RSAPrivateKey(pRsa, NULL);
+    OpcUa_GotoErrorIfTrue((a_pPrivateKey->Key.Length <= 0), OpcUa_Bad);
+
+    /* allocate target buffer */
+    a_pPrivateKey->Key.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pPrivateKey->Key.Length);
+    OpcUa_GotoErrorIfAllocFailed(a_pPrivateKey->Key.Data);
+
+    pData = a_pPrivateKey->Key.Data;
+    a_pPrivateKey->Key.Length = i2d_RSAPrivateKey(pRsa, &pData);
+
+    /* clean up */
+    RSA_free(pRsa);
+
+    a_pPublicKey->Type = OpcUa_Crypto_KeyType_Rsa_Public;
+    a_pPrivateKey->Type = OpcUa_Crypto_KeyType_Rsa_Private;
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(a_pPublicKey->Key.Data != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(a_pPublicKey->Key.Data);
+        a_pPublicKey->Key.Data = OpcUa_Null;
+    }
+
+    if(pRsa != OpcUa_Null)
+    {
+        RSA_free(pRsa);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*===========================================================================*
+OpcUa_P_OpenSSL_RSA_Public_GetKeyLength
+*===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_Public_GetKeyLength(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Key               a_publicKey,
+    OpcUa_UInt32*           a_pKeyLen)
+{
+    EVP_PKEY*       pPublicKey      = OpcUa_Null;
+    const unsigned char *pData;
+
+    OpcUa_UInt32    uKeySize            = 0;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_Public_GetKeyLength");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_publicKey.Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pKeyLen);
+
+    *a_pKeyLen = 0;
+
+    if(a_publicKey.Type != OpcUa_Crypto_KeyType_Rsa_Public)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    pData = a_publicKey.Key.Data;
+    pPublicKey = d2i_PublicKey(EVP_PKEY_RSA, OpcUa_Null, &pData, a_publicKey.Key.Length);
+
+    if(pPublicKey == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    uKeySize = RSA_size(get_pkey_rsa(pPublicKey));
+
+    if((uKeySize < a_pProvider->MinimumAsymmetricKeyLength) || (uKeySize > a_pProvider->MaximumAsymmetricKeyLength))
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadSecurityConfig);
+    }
+
+    *a_pKeyLen = uKeySize*8;
+
+    EVP_PKEY_free(pPublicKey);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pPublicKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pPublicKey);
+    }
+
+    *a_pKeyLen = (OpcUa_UInt32)-1;
+
+OpcUa_FinishErrorHandling;
+}
+
+/*** RSA ASYMMETRIC ENCRYPTION ***/
+
+/*===========================================================================*
+OpcUa_P_OpenSSL_RSA_Public_Encrypt
+*===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_Public_Encrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32            a_plainTextLen,
+    OpcUa_Key*              a_publicKey,
+    OpcUa_Int16             a_padding,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+    EVP_PKEY*       pPublicKey      = OpcUa_Null;
+
+    OpcUa_UInt32    uKeySize            = 0;
+    OpcUa_UInt32    uEncryptedDataSize  = 0;
+    OpcUa_UInt32    uPlainTextPosition  = 0;
+    OpcUa_UInt32    uCipherTextPosition = 0;
+    OpcUa_UInt32    uBytesToEncrypt     = 0;
+    OpcUa_Int32     iEncryptedBytes     = 0;
+    const unsigned char *pData;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_Public_Encrypt");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_publicKey);
+    OpcUa_ReturnErrorIfArgumentNull(a_publicKey->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCipherTextLen);
+
+    *a_pCipherTextLen = 0;
+
+    if((OpcUa_Int32)a_plainTextLen < 1)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(a_publicKey->Type != OpcUa_Crypto_KeyType_Rsa_Public)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    pData = a_publicKey->Key.Data;
+    pPublicKey = d2i_PublicKey(EVP_PKEY_RSA, OpcUa_Null, &pData, a_publicKey->Key.Length);
+
+    if(pPublicKey == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    uKeySize = RSA_size(get_pkey_rsa(pPublicKey));
+
+    /* check padding type */
+    switch(a_padding)
+    {
+    case RSA_PKCS1_PADDING:
+        {
+            if(uKeySize <= 11)
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+            }
+            uEncryptedDataSize = uKeySize - 11;
+            break;
+        }
+    case RSA_PKCS1_OAEP_PADDING:
+        {
+            if(uKeySize <= 42)
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+            }
+            uEncryptedDataSize = uKeySize - 42;
+            break;
+        }
+    case RSA_NO_PADDING:
+        {
+            if(uKeySize == 0)
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+            }
+            uEncryptedDataSize = uKeySize;
+            break;
+        }
+    default:
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_BadNotSupported);
+        }
+    }
+
+    uPlainTextPosition  = a_plainTextLen;
+    uCipherTextPosition = ((uPlainTextPosition - 1) / uEncryptedDataSize + 1) * uKeySize;
+    uBytesToEncrypt     = (uPlainTextPosition - 1) % uEncryptedDataSize + 1;
+    *a_pCipherTextLen   = uCipherTextPosition;
+
+    if((a_pCipherText != OpcUa_Null) && (a_pPlainText != OpcUa_Null))
+    {
+
+        /* encrypt in reverse order so that a_pCipherText may alias a_pPlainText */
+        while(uPlainTextPosition > 0)
+        {
+            uCipherTextPosition -= uKeySize;
+            uPlainTextPosition  -= uBytesToEncrypt;
+
+            iEncryptedBytes = RSA_public_encrypt(   uBytesToEncrypt,                    /* how much to encrypt  */
+                                                    a_pPlainText + uPlainTextPosition,  /* what to encrypt      */
+                                                    a_pCipherText + uCipherTextPosition,/* where to encrypt     */
+                                                    get_pkey_rsa(pPublicKey),           /* public key           */
+                                                    a_padding);                         /* padding mode         */
+            if(iEncryptedBytes < 0)
+            {
+                uStatus = OpcUa_Bad;
+                OpcUa_GotoError;
+            }
+
+            uBytesToEncrypt = uEncryptedDataSize;
+        }
+
+    }
+
+    EVP_PKEY_free(pPublicKey);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pPublicKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pPublicKey);
+    }
+
+    *a_pCipherTextLen = (OpcUa_UInt32)-1;
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_Private_Decrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_Private_Decrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32            a_cipherTextLen,
+    OpcUa_Key*              a_privateKey,
+    OpcUa_Int16             a_padding,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32*           a_pPlainTextLen)
+{
+    EVP_PKEY*       pPrivateKey     = OpcUa_Null;
+
+    OpcUa_UInt32    keySize         = 0;
+    OpcUa_Int32     decryptedBytes  = 0;
+    OpcUa_UInt32    iCipherText     = 0;
+    OpcUa_UInt32    decDataSize     = 0;
+
+    const unsigned char *pData;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_Private_Decrypt");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pCipherText);
+    OpcUa_ReturnErrorIfArgumentNull(a_privateKey);
+    OpcUa_ReturnErrorIfArgumentNull(a_privateKey->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pPlainTextLen);
+
+    *a_pPlainTextLen = 0;
+
+    if((OpcUa_Int32)a_cipherTextLen < 1)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(a_privateKey->Type != OpcUa_Crypto_KeyType_Rsa_Private)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    pData = a_privateKey->Key.Data;
+    pPrivateKey = d2i_PrivateKey(EVP_PKEY_RSA, OpcUa_Null, &pData, a_privateKey->Key.Length);
+
+    if(pPrivateKey == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    keySize = RSA_size(get_pkey_rsa(pPrivateKey));
+
+    if(keySize == 0)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    if((a_cipherTextLen%keySize) != 0)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    /* check padding type */
+    switch(a_padding)
+    {
+    case RSA_PKCS1_PADDING:
+        {
+            if(keySize <= 11)
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+            }
+            decDataSize = keySize - 11;
+            break;
+        }
+    case RSA_PKCS1_OAEP_PADDING:
+        {
+            if(keySize <= 42)
+            {
+                OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+            }
+            decDataSize = keySize - 42;
+            break;
+        }
+    case RSA_NO_PADDING:
+        {
+            decDataSize = keySize;
+            break;
+        }
+    default:
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_BadNotSupported);
+        }
+    }
+
+    while(iCipherText < a_cipherTextLen)
+    {
+        if(a_pPlainText != OpcUa_Null)
+        {
+            decryptedBytes = RSA_private_decrypt(   keySize,                            /* how much to decrypt  */
+                                                    a_pCipherText + iCipherText,        /* what to decrypt      */
+                                                    a_pPlainText + (*a_pPlainTextLen),  /* where to decrypt     */
+                                                    get_pkey_rsa(pPrivateKey),          /* private key          */
+                                                    a_padding);                         /* padding mode         */
+
+            /* if decryption fails return the same result as if signature check fails */
+            /* also fail if zero bytes are decoded */
+            if(decryptedBytes <= 0)
+            {
+                /* continue decrypting the message in constant time */
+                uStatus = OpcUa_BadSignatureInvalid;
+                decryptedBytes = decDataSize;
+                /* do not leak timing information by skipping the memcpy */
+                memmove(a_pPlainText + (*a_pPlainTextLen), a_pCipherText + iCipherText, decryptedBytes);
+            }
+            /* only the last part may be smaller */
+            else if(iCipherText + keySize < a_cipherTextLen && (OpcUa_UInt32)decryptedBytes != decDataSize)
+            {
+                uStatus = OpcUa_BadSignatureInvalid;
+            }
+        }
+        else
+        {
+            decryptedBytes = decDataSize;
+        }
+
+        *a_pPlainTextLen = *a_pPlainTextLen + decryptedBytes;
+        iCipherText = iCipherText + keySize;
+    }
+
+    EVP_PKEY_free(pPrivateKey);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pPrivateKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pPrivateKey);
+    }
+
+    *a_pPlainTextLen = (OpcUa_UInt32)-1;
+
+OpcUa_FinishErrorHandling;
+}
+
+/*** RSA ASYMMETRIC SIGNATURE ***/
+
+/*===========================================================================*
+OpcUa_P_OpenSSL_RSA_Private_Sign
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_Private_Sign(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_data,
+    OpcUa_Key*            a_privateKey,
+    OpcUa_Int16           a_padding,          /* The signature algorithm used (e.g. NID_sha1). */
+    OpcUa_ByteString*     a_pSignature)       /* output length >= key length */
+{
+    EVP_PKEY*               pSSLPrivateKey  = OpcUa_Null;
+    const unsigned char*    pData           = OpcUa_Null;
+    int                     iErr            = 0;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_Private_Sign");
+
+    /* unused parameters */
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    /* check parameters */
+    OpcUa_ReturnErrorIfArgumentNull(a_data.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_privateKey);
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature);
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature->Data);
+    pData = a_privateKey->Key.Data;
+    OpcUa_ReturnErrorIfArgumentNull(pData);
+    OpcUa_ReturnErrorIfTrue((a_privateKey->Type != OpcUa_Crypto_KeyType_Rsa_Private), OpcUa_BadInvalidArgument);
+
+    /* convert private key and check key length against buffer length */
+    pSSLPrivateKey = d2i_PrivateKey(EVP_PKEY_RSA, OpcUa_Null, &pData, a_privateKey->Key.Length);
+    OpcUa_GotoErrorIfTrue((pSSLPrivateKey == OpcUa_Null), OpcUa_BadUnexpectedError);
+    OpcUa_GotoErrorIfTrue((a_pSignature->Length < RSA_size(get_pkey_rsa(pSSLPrivateKey))), OpcUa_BadInvalidArgument);
+
+    /* sign data */
+    iErr = RSA_sign(a_padding, a_data.Data, a_data.Length, a_pSignature->Data, (unsigned int*)&a_pSignature->Length, get_pkey_rsa(pSSLPrivateKey));
+    OpcUa_GotoErrorIfTrue((iErr != 1), OpcUa_BadUnexpectedError);
+
+    /* free internal key representation */
+    EVP_PKEY_free(pSSLPrivateKey);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pSSLPrivateKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pSSLPrivateKey);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_Public_Verify
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_Public_Verify(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_data,
+    OpcUa_Key*            a_publicKey,
+    OpcUa_Int16           a_padding,          /* The signature algorithm used (e.g. NID_sha1). */
+    OpcUa_ByteString*     a_pSignature)
+{
+    EVP_PKEY*            pPublicKey      = OpcUa_Null;
+    OpcUa_Int32          keySize         = 0;
+    const unsigned char *pData;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_Public_Verify");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_data.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_publicKey);
+    OpcUa_ReturnErrorIfArgumentNull(a_publicKey->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature);
+
+    if(a_publicKey->Type != OpcUa_Crypto_KeyType_Rsa_Public)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    pData = a_publicKey->Key.Data;
+    pPublicKey = d2i_PublicKey(EVP_PKEY_RSA, OpcUa_Null, &pData, a_publicKey->Key.Length);
+
+    if(pPublicKey == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    keySize = RSA_size(get_pkey_rsa(pPublicKey));
+
+    if(keySize == 0)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    if(RSA_verify(a_padding, a_data.Data, a_data.Length, a_pSignature->Data, a_pSignature->Length, get_pkey_rsa(pPublicKey)) != 1)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadSignatureInvalid);
+    }
+
+    EVP_PKEY_free(pPublicKey);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pPublicKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pPublicKey);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*** EVP-BASED RSA OAEP SHA256 ASYMMETRIC ENCRYPTION (requires OpenSSL 1.0.2) ***/
+
+/*===========================================================================*
+OpcUa_P_OpenSSL_RSA_SHA256_Public_Encrypt
+*===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_SHA256_Public_Encrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32            a_plainTextLen,
+    OpcUa_Key*              a_publicKey,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32*           a_pCipherTextLen)
+{
+#if OPENSSL_VERSION_NUMBER < 0x1000200fL
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pCipherText);
+    OpcUa_ReferenceParameter(a_pCipherTextLen);
+    OpcUa_ReferenceParameter(a_publicKey);
+    OpcUa_ReferenceParameter(a_pPlainText);
+    OpcUa_ReferenceParameter(a_plainTextLen);
+    return OpcUa_BadNotSupported;
+#else
+    EVP_PKEY_CTX*   pCtx            = OpcUa_Null;
+    EVP_PKEY*       pPublicKey      = OpcUa_Null;
+
+    OpcUa_UInt32    uKeySize            = 0;
+    OpcUa_UInt32    uEncryptedDataSize  = 0;
+    OpcUa_UInt32    uPlainTextPosition  = 0;
+    OpcUa_UInt32    uCipherTextPosition = 0;
+    OpcUa_UInt32    uBytesToEncrypt     = 0;
+    size_t          iEncryptedBytes     = 0;
+    int             ret                 = 0;
+    const unsigned char *pData;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_SHA256_Public_Encrypt");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_publicKey);
+    OpcUa_ReturnErrorIfArgumentNull(a_publicKey->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCipherTextLen);
+
+    *a_pCipherTextLen = 0;
+
+    if((OpcUa_Int32)a_plainTextLen < 1)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(a_publicKey->Type != OpcUa_Crypto_KeyType_Rsa_Public)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    pData = a_publicKey->Key.Data;
+    pPublicKey = d2i_PublicKey(EVP_PKEY_RSA, OpcUa_Null, &pData, a_publicKey->Key.Length);
+
+    if(pPublicKey == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    uKeySize = RSA_size(get_pkey_rsa(pPublicKey));
+
+    if(uKeySize <= 66)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+    uEncryptedDataSize = uKeySize - 66;
+
+    pCtx = EVP_PKEY_CTX_new(pPublicKey, NULL);
+    OpcUa_GotoErrorIfTrue((pCtx == OpcUa_Null), OpcUa_Bad);
+    ret = EVP_PKEY_encrypt_init(pCtx);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    ret = EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_OAEP_PADDING);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    ret = EVP_PKEY_CTX_set_rsa_oaep_md(pCtx, EVP_sha256());
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+
+    uPlainTextPosition  = a_plainTextLen;
+    uCipherTextPosition = ((uPlainTextPosition - 1) / uEncryptedDataSize + 1) * uKeySize;
+    uBytesToEncrypt     = (uPlainTextPosition - 1) % uEncryptedDataSize + 1;
+    *a_pCipherTextLen   = uCipherTextPosition;
+
+    if((a_pCipherText != OpcUa_Null) && (a_pPlainText != OpcUa_Null))
+    {
+
+        /* encrypt in reverse order so that a_pCipherText may alias a_pPlainText */
+        while(uPlainTextPosition > 0)
+        {
+            uCipherTextPosition -= uKeySize;
+            uPlainTextPosition  -= uBytesToEncrypt;
+
+            iEncryptedBytes = uKeySize;
+            ret = EVP_PKEY_encrypt(pCtx,
+                                   a_pCipherText + uCipherTextPosition,/* where to encrypt     */
+                                   &iEncryptedBytes,
+                                   a_pPlainText + uPlainTextPosition,  /* what to encrypt      */
+                                   uBytesToEncrypt);                   /* how much to encrypt  */
+
+            if(ret < 0)
+            {
+                uStatus = OpcUa_Bad;
+                OpcUa_GotoError;
+            }
+
+            uBytesToEncrypt = uEncryptedDataSize;
+        }
+
+    }
+
+    EVP_PKEY_CTX_free(pCtx);
+    EVP_PKEY_free(pPublicKey);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pCtx != OpcUa_Null)
+    {
+        EVP_PKEY_CTX_free(pCtx);
+    }
+
+    if(pPublicKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pPublicKey);
+    }
+
+    *a_pCipherTextLen = (OpcUa_UInt32)-1;
+
+OpcUa_FinishErrorHandling;
+#endif
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_SHA256_Private_Decrypt
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_SHA256_Private_Decrypt(
+    OpcUa_CryptoProvider*   a_pProvider,
+    OpcUa_Byte*             a_pCipherText,
+    OpcUa_UInt32            a_cipherTextLen,
+    OpcUa_Key*              a_privateKey,
+    OpcUa_Byte*             a_pPlainText,
+    OpcUa_UInt32*           a_pPlainTextLen)
+{
+#if OPENSSL_VERSION_NUMBER < 0x1000200fL
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_pCipherText);
+    OpcUa_ReferenceParameter(a_cipherTextLen);
+    OpcUa_ReferenceParameter(a_privateKey);
+    OpcUa_ReferenceParameter(a_pPlainText);
+    OpcUa_ReferenceParameter(a_pPlainTextLen);
+    return OpcUa_BadNotSupported;
+#else
+    EVP_PKEY_CTX*   pCtx            = OpcUa_Null;
+    EVP_PKEY*       pPrivateKey     = OpcUa_Null;
+
+    OpcUa_UInt32    keySize         = 0;
+    size_t          decryptedBytes  = 0;
+    OpcUa_UInt32    iCipherText     = 0;
+    OpcUa_UInt32    decDataSize     = 0;
+    int             ret             = 0;
+
+    const unsigned char *pData;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_SHA256_Private_Decrypt");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pCipherText);
+    OpcUa_ReturnErrorIfArgumentNull(a_privateKey);
+    OpcUa_ReturnErrorIfArgumentNull(a_privateKey->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pPlainTextLen);
+
+    *a_pPlainTextLen = 0;
+
+    if((OpcUa_Int32)a_cipherTextLen < 1)
+    {
+        uStatus = OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(a_privateKey->Type != OpcUa_Crypto_KeyType_Rsa_Private)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    pData = a_privateKey->Key.Data;
+    pPrivateKey = d2i_PrivateKey(EVP_PKEY_RSA, OpcUa_Null, &pData, a_privateKey->Key.Length);
+
+    if(pPrivateKey == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    keySize = RSA_size(get_pkey_rsa(pPrivateKey));
+
+    if(keySize == 0)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    if((a_cipherTextLen%keySize) != 0)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    /* check padding type */
+    if(keySize <= 66)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+    decDataSize = keySize - 66;
+
+    pCtx = EVP_PKEY_CTX_new(pPrivateKey, NULL);
+    OpcUa_GotoErrorIfTrue((pCtx == OpcUa_Null), OpcUa_Bad);
+    ret = EVP_PKEY_decrypt_init(pCtx);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    ret = EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_OAEP_PADDING);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    ret = EVP_PKEY_CTX_set_rsa_oaep_md(pCtx, EVP_sha256());
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+
+    while(iCipherText < a_cipherTextLen)
+    {
+        if(a_pPlainText != OpcUa_Null)
+        {
+            decryptedBytes = keySize; /* actually that's a lie */
+            ret = EVP_PKEY_decrypt(pCtx,
+                                   a_pPlainText + (*a_pPlainTextLen),  /* where to decrypt     */
+                                   &decryptedBytes,
+                                   a_pCipherText + iCipherText,        /* what to decrypt      */
+                                   keySize);
+
+            /* if decryption fails return the same result as if signature check fails */
+            /* also fail if zero bytes are decoded */
+            if(ret <= 0 || decryptedBytes == 0)
+            {
+                /* continue decrypting the message in constant time */
+                uStatus = OpcUa_BadSignatureInvalid;
+                decryptedBytes = decDataSize;
+                /* do not leak timing information by skipping the memcpy */
+                memmove(a_pPlainText + (*a_pPlainTextLen), a_pCipherText + iCipherText, decryptedBytes);
+            }
+            /* only the last part may be smaller */
+            else if(iCipherText + keySize < a_cipherTextLen && decryptedBytes != decDataSize)
+            {
+                uStatus = OpcUa_BadSignatureInvalid;
+            }
+        }
+        else
+        {
+            decryptedBytes = decDataSize;
+        }
+
+        *a_pPlainTextLen = *a_pPlainTextLen + decryptedBytes;
+        iCipherText = iCipherText + keySize;
+    }
+
+    EVP_PKEY_CTX_free(pCtx);
+    EVP_PKEY_free(pPrivateKey);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pCtx != OpcUa_Null)
+    {
+        EVP_PKEY_CTX_free(pCtx);
+    }
+
+    if(pPrivateKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pPrivateKey);
+    }
+
+    *a_pPlainTextLen = (OpcUa_UInt32)-1;
+
+OpcUa_FinishErrorHandling;
+#endif
+}
+
+/*** EVP-BASED RSA SSA PSS ASYMMETRIC SIGNATURE (requires OpenSSL 1.0.0) ***/
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_PSS_Private_Sign
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PSS_Private_Sign(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_data,
+    OpcUa_Key*            a_privateKey,
+    OpcUa_ByteString*     a_pSignature)
+{
+#if OPENSSL_VERSION_NUMBER < 0x1000000fL
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_data);
+    OpcUa_ReferenceParameter(a_privateKey);
+    OpcUa_ReferenceParameter(a_pSignature);
+    return OpcUa_BadNotSupported;
+#else
+    EVP_PKEY_CTX*           pCtx            = OpcUa_Null;
+    EVP_PKEY*               pSSLPrivateKey  = OpcUa_Null;
+    const unsigned char*    pData           = OpcUa_Null;
+    int                     ret             = 0;
+    size_t                  siglen          = 0;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_PSS_Private_Sign");
+
+    /* unused parameters */
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    /* check parameters */
+    OpcUa_ReturnErrorIfArgumentNull(a_data.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_privateKey);
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature);
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature->Data);
+    pData = a_privateKey->Key.Data;
+    OpcUa_ReturnErrorIfArgumentNull(pData);
+    OpcUa_ReturnErrorIfTrue((a_privateKey->Type != OpcUa_Crypto_KeyType_Rsa_Private), OpcUa_BadInvalidArgument);
+
+    /* convert private key and check key length against buffer length */
+    pSSLPrivateKey = d2i_PrivateKey(EVP_PKEY_RSA, OpcUa_Null, &pData, a_privateKey->Key.Length);
+    OpcUa_GotoErrorIfTrue((pSSLPrivateKey == OpcUa_Null), OpcUa_BadUnexpectedError);
+    OpcUa_GotoErrorIfTrue((a_pSignature->Length < RSA_size(get_pkey_rsa(pSSLPrivateKey))), OpcUa_BadInvalidArgument);
+
+    pCtx = EVP_PKEY_CTX_new(pSSLPrivateKey, NULL);
+    OpcUa_GotoErrorIfTrue((pCtx == OpcUa_Null), OpcUa_Bad);
+    ret = EVP_PKEY_sign_init(pCtx);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    ret = EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PSS_PADDING);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    ret = EVP_PKEY_CTX_set_signature_md(pCtx, EVP_sha256());
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    ret = EVP_PKEY_CTX_set_rsa_pss_saltlen(pCtx, -1);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    siglen = a_pSignature->Length;
+    ret = EVP_PKEY_sign(pCtx, a_pSignature->Data, &siglen, a_data.Data, a_data.Length);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_BadUnexpectedError);
+    a_pSignature->Length = (OpcUa_Int32)siglen;
+
+    EVP_PKEY_CTX_free(pCtx);
+    EVP_PKEY_free(pSSLPrivateKey);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pCtx != OpcUa_Null)
+    {
+        EVP_PKEY_CTX_free(pCtx);
+    }
+
+    if(pSSLPrivateKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pSSLPrivateKey);
+    }
+
+OpcUa_FinishErrorHandling;
+#endif
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_RSA_PSS_Public_Verify
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_RSA_PSS_Public_Verify(
+    OpcUa_CryptoProvider* a_pProvider,
+    OpcUa_ByteString      a_data,
+    OpcUa_Key*            a_publicKey,
+    OpcUa_ByteString*     a_pSignature)
+{
+#if OPENSSL_VERSION_NUMBER < 0x1000000fL
+    OpcUa_ReferenceParameter(a_pProvider);
+    OpcUa_ReferenceParameter(a_data);
+    OpcUa_ReferenceParameter(a_publicKey);
+    OpcUa_ReferenceParameter(a_pSignature);
+    return OpcUa_BadNotSupported;
+#else
+    EVP_PKEY_CTX*        pCtx            = OpcUa_Null;
+    EVP_PKEY*            pPublicKey      = OpcUa_Null;
+    const unsigned char *pData           = OpcUa_Null;
+    int                  ret             = 0;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "RSA_PSS_Public_Verify");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_data.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_publicKey);
+    OpcUa_ReturnErrorIfArgumentNull(a_publicKey->Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature);
+
+    if(a_publicKey->Type != OpcUa_Crypto_KeyType_Rsa_Public)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    pData = a_publicKey->Key.Data;
+    pPublicKey = d2i_PublicKey(EVP_PKEY_RSA, OpcUa_Null, &pData, a_publicKey->Key.Length);
+
+    if(pPublicKey == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    pCtx = EVP_PKEY_CTX_new(pPublicKey, NULL);
+    OpcUa_GotoErrorIfTrue((pCtx == OpcUa_Null), OpcUa_Bad);
+    ret = EVP_PKEY_verify_init(pCtx);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    ret = EVP_PKEY_CTX_set_rsa_padding(pCtx, RSA_PKCS1_PSS_PADDING);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    ret = EVP_PKEY_CTX_set_signature_md(pCtx, EVP_sha256());
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    ret = EVP_PKEY_CTX_set_rsa_pss_saltlen(pCtx, -1);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_Bad);
+    ret = EVP_PKEY_verify(pCtx, a_pSignature->Data, a_pSignature->Length, a_data.Data, a_data.Length);
+    OpcUa_GotoErrorIfTrue((ret <= 0), OpcUa_BadSignatureInvalid);
+
+    EVP_PKEY_CTX_free(pCtx);
+    EVP_PKEY_free(pPublicKey);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pCtx != OpcUa_Null)
+    {
+        EVP_PKEY_CTX_free(pCtx);
+    }
+
+    if(pPublicKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pPublicKey);
+    }
+
+OpcUa_FinishErrorHandling;
+#endif
+}
+
+#endif /* OPCUA_REQUIRE_OPENSSL */

--- a/Stack/platforms/vxworks/opcua_p_openssl_sha.c
+++ b/Stack/platforms/vxworks/opcua_p_openssl_sha.c
@@ -1,0 +1,184 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_memory.h>
+
+#if OPCUA_REQUIRE_OPENSSL
+
+/* System Headers */
+#include <openssl/hmac.h>
+#include <openssl/sha.h>
+
+/* own headers */
+#include <opcua_p_openssl.h>
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_SHA1_Generate
+ *===========================================================================*/
+/* SHA-1: 160 Bit output */
+OpcUa_StatusCode OpcUa_P_OpenSSL_SHA1_Generate(
+    OpcUa_CryptoProvider*         a_pProvider,
+    OpcUa_Byte*                   a_pData,
+    OpcUa_UInt32                  a_dataLen,
+    OpcUa_Byte*                   a_pMessageDigest)
+{
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "SHA1_Generate");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pData);
+    OpcUa_ReturnErrorIfArgumentNull(a_pMessageDigest);
+
+    if(SHA1(a_pData, a_dataLen, a_pMessageDigest) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_SHA2_224_Generate
+ *===========================================================================*/
+/* SHA-2: 224 Bits output */
+OpcUa_StatusCode OpcUa_P_OpenSSL_SHA2_224_Generate(
+    OpcUa_CryptoProvider*         a_pProvider,
+    OpcUa_Byte*                   a_pData,
+    OpcUa_UInt32                  a_dataLen,
+    OpcUa_Byte*                   a_pMessageDigest)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "SHA2_224_Generate");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pData);
+    OpcUa_ReturnErrorIfArgumentNull(a_pMessageDigest);
+
+    if(SHA224(a_pData, a_dataLen, a_pMessageDigest) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_SHA2_256_Generate
+ *===========================================================================*/
+/* SHA-2: 256 Bits output */
+OpcUa_StatusCode OpcUa_P_OpenSSL_SHA2_256_Generate(
+    OpcUa_CryptoProvider*         a_pProvider,
+    OpcUa_Byte*                   a_pData,
+    OpcUa_UInt32                  a_dataLen,
+    OpcUa_Byte*                   a_pMessageDigest)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "SHA2_256_Generate");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pData);
+    OpcUa_ReturnErrorIfArgumentNull(a_pMessageDigest);
+
+    if(SHA256(a_pData, a_dataLen, a_pMessageDigest) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_SHA2_384_Generate
+ *===========================================================================*/
+/* SHA-2: 384 Bits output */
+OpcUa_StatusCode OpcUa_P_OpenSSL_SHA2_384_Generate(
+    OpcUa_CryptoProvider*         a_pProvider,
+    OpcUa_Byte*                   a_pData,
+    OpcUa_UInt32                  a_dataLen,
+    OpcUa_Byte*                   a_pMessageDigest)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "SHA2_384_Generate");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pData);
+    OpcUa_ReturnErrorIfArgumentNull(a_pMessageDigest);
+
+    if(SHA384(a_pData, a_dataLen, a_pMessageDigest) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_SHA2_512_Generate
+ *===========================================================================*/
+/* SHA-2: 512 Bits output */
+OpcUa_StatusCode OpcUa_P_OpenSSL_SHA2_512_Generate(
+    OpcUa_CryptoProvider*         a_pProvider,
+    OpcUa_Byte*                   a_pData,
+    OpcUa_UInt32                  a_dataLen,
+    OpcUa_Byte*                   a_pMessageDigest)
+{
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "SHA2_512_Generate");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pData);
+    OpcUa_ReturnErrorIfArgumentNull(a_pMessageDigest);
+
+    if(SHA512(a_pData, a_dataLen, a_pMessageDigest) == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+OpcUa_ReturnStatusCode;
+
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+#endif /* OPCUA_REQUIRE_OPENSSL */

--- a/Stack/platforms/vxworks/opcua_p_openssl_x509.c
+++ b/Stack/platforms/vxworks/opcua_p_openssl_x509.c
@@ -1,0 +1,641 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_datetime.h>
+#include <opcua_p_memory.h>
+#include <opcua_p_string.h>
+#include <opcua_p_guid.h>
+
+#if OPCUA_REQUIRE_OPENSSL
+
+/* System Headers */
+#include <openssl/rsa.h>
+#include <openssl/evp.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+
+
+/* own headers */
+#include <opcua_p_openssl.h>
+
+/**
+  @brief Add a certificate name entry to a X.509 (X509) certificate.
+
+  internal function!
+
+  @param ppX509Name    [out]  The X509 Name Object.
+
+  @param pNameEntry    [in]   The passed Name Entry Object.
+*/
+/*============================================================================
+ * OpcUa_P_OpenSSL_X509_Name_AddEntry
+ *===========================================================================*/
+static
+OpcUa_StatusCode OpcUa_P_OpenSSL_X509_Name_AddEntry(
+    X509_NAME**               a_ppX509Name,
+    OpcUa_Crypto_NameEntry*   a_pNameEntry)
+{
+    X509_NAME_ENTRY*    pEntry  = OpcUa_Null;
+
+    OpcUa_Int           nid;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "X509_Name_AddEntry");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pNameEntry);
+
+    if((nid = OBJ_txt2nid(a_pNameEntry->key)) == NID_undef)
+    {
+        uStatus =  OpcUa_BadNotSupported;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(!(pEntry = X509_NAME_ENTRY_create_by_NID(OpcUa_Null, nid, MBSTRING_ASC, (unsigned char*)a_pNameEntry->value, -1)))
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(X509_NAME_add_entry(*a_ppX509Name, pEntry,-1,0) != 1)
+    {
+        uStatus =  OpcUa_Bad;
+    }
+
+    if(pEntry != OpcUa_Null)
+    {
+        X509_NAME_ENTRY_free(pEntry);
+    }
+
+OpcUa_ReturnStatusCode;
+
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_X509_AddCustomExtension
+ *===========================================================================*/
+static
+OpcUa_StatusCode OpcUa_P_OpenSSL_X509_AddCustomExtension(
+    X509**                   a_ppCertificate,
+    OpcUa_Crypto_Extension*  a_pExtension,
+    X509V3_CTX*              a_pX509V3Context)
+{
+    X509_EXTENSION*     pExtension   = OpcUa_Null;
+    char*               pName        = OpcUa_Null;
+    char*               pValue       = OpcUa_Null;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "X509_AddCustomExtension");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pX509V3Context);
+    OpcUa_ReturnErrorIfArgumentNull(a_pExtension->key);
+    OpcUa_ReturnErrorIfArgumentNull(a_pExtension->value);
+
+    pName = (char*)a_pExtension->key;
+    pValue = (char*)a_pExtension->value;
+
+    /* create the extension. */
+    pExtension = X509V3_EXT_conf(
+        OpcUa_Null,
+        a_pX509V3Context,
+        pName,
+        pValue);
+
+    if(pExtension == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+    /* add it to the certificate. */
+    if(!X509_add_ext(*a_ppCertificate, pExtension, -1))
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_Bad);
+    }
+
+    /* free the extension. */
+    X509_EXTENSION_free(pExtension);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pExtension != OpcUa_Null)
+    {
+        X509_EXTENSION_free(pExtension);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_X509_SelfSigned_Custom_Create
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_X509_SelfSigned_Custom_Create(
+    OpcUa_CryptoProvider*       a_pProvider,
+    OpcUa_Int32                 a_serialNumber,
+    OpcUa_UInt32                a_validToInSec,
+    OpcUa_Crypto_NameEntry*     a_pNameEntries,      /* will be used for issuer and subject thus it's selfigned cert */
+    OpcUa_UInt                  a_nameEntriesCount,  /* will be used for issuer and subject thus it's selfigned cert */
+    OpcUa_Key                   a_pSubjectPublicKey, /* EVP_PKEY* - type defines also public key algorithm */
+    OpcUa_Crypto_Extension*     a_pExtensions,
+    OpcUa_UInt                  a_extensionsCount,
+    OpcUa_UInt                  a_signatureHashAlgorithm, /* EVP_sha1(),... */
+    OpcUa_Key                   a_pIssuerPrivateKey, /* EVP_PKEY* - type defines also signature algorithm */
+    OpcUa_ByteString*           a_pCertificate)
+{
+    OpcUa_UInt          i;
+
+    X509_NAME*          pSubj               = OpcUa_Null;
+    X509V3_CTX          ctx;
+    const EVP_MD*       pDigest             = OpcUa_Null;
+
+    X509*               pCert               = OpcUa_Null;
+    EVP_PKEY*           pSubjectPublicKey   = OpcUa_Null;
+    EVP_PKEY*           pIssuerPrivateKey   = OpcUa_Null;
+    OpcUa_Byte*         pBuffer             = OpcUa_Null;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "X509_SelfSigned_Custom_Create");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pNameEntries);
+    OpcUa_ReturnErrorIfArgumentNull(a_pExtensions);
+    OpcUa_ReturnErrorIfArgumentNull(a_pIssuerPrivateKey.Key.Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificate);
+
+    if(a_pSubjectPublicKey.Type != OpcUa_Crypto_KeyType_Rsa_Public)
+    {
+        uStatus =  OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(a_pIssuerPrivateKey.Type != OpcUa_Crypto_KeyType_Rsa_Private)
+    {
+        uStatus =  OpcUa_BadInvalidArgument;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    pSubjectPublicKey = d2i_PublicKey(EVP_PKEY_RSA,OpcUa_Null,((const unsigned char**)&(a_pSubjectPublicKey.Key.Data)),a_pSubjectPublicKey.Key.Length);
+    if(pSubjectPublicKey == OpcUa_Null)
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    pIssuerPrivateKey = d2i_PrivateKey(EVP_PKEY_RSA,OpcUa_Null,((const unsigned char**)&(a_pIssuerPrivateKey.Key.Data)),a_pIssuerPrivateKey.Key.Length);
+    if(pIssuerPrivateKey == OpcUa_Null)
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* create new certificate object */
+    pCert = X509_new();
+    if(pCert == OpcUa_Null)
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* set version of certificate (V3 since internal representation starts versioning from 0) */
+    if(X509_set_version(pCert, 2L) != 1)
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* generate a unique number for a serial number if none provided. */
+    if(a_serialNumber == 0)
+    {
+        ASN1_INTEGER* pSerialNumber = X509_get_serialNumber(pCert);
+
+        /* should not be necessary */
+        if(pSerialNumber->data != NULL)
+        {
+            OPENSSL_free(pSerialNumber->data);
+        }
+
+        pSerialNumber->type   = V_ASN1_INTEGER;
+        pSerialNumber->data   = OPENSSL_malloc(16);
+        pSerialNumber->length = 16;
+
+        if(pSerialNumber->data == NULL || OpcUa_P_Guid_Create((OpcUa_Guid*)pSerialNumber->data) == NULL)
+        {
+            uStatus =  OpcUa_Bad;
+            OpcUa_GotoErrorIfBad(uStatus);
+        }
+
+        /* avoid malformed ASN1_INTEGER */
+        if(pSerialNumber->data[0] == 0x00)
+        {
+            pSerialNumber->data[0] = 0x01;
+        }
+    }
+
+    /* use the integer passed in - note the API should not be using a 32-bit integer - must fix sometime */
+    else if(ASN1_INTEGER_set(X509_get_serialNumber(pCert), a_serialNumber) == 0)
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* add key to the request */
+    if(X509_set_pubkey(pCert, pSubjectPublicKey) != 1)
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(pSubjectPublicKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pSubjectPublicKey);
+        pSubjectPublicKey = OpcUa_Null;
+    }
+
+    /* assign the subject name */
+    pSubj = X509_NAME_new();
+    if(!pSubj)
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* create and add entries to subject name */
+    for(i=0; i<a_nameEntriesCount; i++)
+    {
+        uStatus = OpcUa_P_OpenSSL_X509_Name_AddEntry(&pSubj, a_pNameEntries + i);
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* set subject name in request */
+    if(X509_set_subject_name(pCert, pSubj) != 1)
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* set name of issuer (CA) */
+    if(X509_set_issuer_name(pCert, pSubj) != 1)
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(!(X509_gmtime_adj(X509_get_notBefore(pCert), 0)))
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* set ending time of the certificate */
+    if(!(X509_gmtime_adj(X509_get_notAfter(pCert), a_validToInSec)))
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* add x509v3 extensions */
+    X509V3_set_ctx(&ctx, pCert, pCert, OpcUa_Null, OpcUa_Null, 0);
+
+    for(i=0; i<a_extensionsCount; i++)
+    {
+        uStatus = OpcUa_P_OpenSSL_X509_AddCustomExtension(&pCert, a_pExtensions+i, &ctx);
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* sign certificate with the CA private key */
+    switch(a_signatureHashAlgorithm)
+    {
+    case OPCUA_P_SHA_160:
+        pDigest = EVP_sha1();
+        break;
+    case OPCUA_P_SHA_224:
+        pDigest = EVP_sha224();
+        break;
+    case OPCUA_P_SHA_256:
+        pDigest = EVP_sha256();
+        break;
+    case OPCUA_P_SHA_384:
+        pDigest = EVP_sha384();
+        break;
+    case OPCUA_P_SHA_512:
+        pDigest = EVP_sha512();
+        break;
+    default:
+        uStatus =  OpcUa_BadNotSupported;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(!(X509_sign(pCert, pIssuerPrivateKey, pDigest)))
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(X509_verify(pCert, pIssuerPrivateKey) <= 0)
+    {
+        uStatus =  OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(pIssuerPrivateKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pIssuerPrivateKey);
+        pIssuerPrivateKey = OpcUa_Null;
+    }
+
+    if(pSubj != OpcUa_Null)
+    {
+        X509_NAME_free(pSubj);
+        pSubj = OpcUa_Null;
+    }
+
+    /* prepare container */
+    memset(a_pCertificate, 0, sizeof(OpcUa_ByteString));
+
+    /* get required length for conversion target buffer */
+    a_pCertificate->Length = i2d_X509(pCert, NULL);
+
+    if(a_pCertificate->Length <= 0)
+    {
+        /* conversion to DER not possible */
+        uStatus = OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    /* allocate conversion target buffer */
+    a_pCertificate->Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(a_pCertificate->Length);
+    OpcUa_GotoErrorIfAllocFailed(a_pCertificate->Data);
+
+    /* convert into DER */
+    pBuffer = a_pCertificate->Data;
+    a_pCertificate->Length = i2d_X509(pCert, &pBuffer);
+
+    X509_free(pCert);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    X509_free(pCert);
+
+    if(pSubjectPublicKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pSubjectPublicKey);
+    }
+
+    if(pIssuerPrivateKey != OpcUa_Null)
+    {
+        EVP_PKEY_free(pIssuerPrivateKey);
+    }
+
+    if(pSubj != OpcUa_Null)
+    {
+        X509_NAME_free(pSubj);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_X509_GetPublicKey
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_X509_GetPublicKey(
+    OpcUa_CryptoProvider*       a_pProvider,
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_StringA               a_password,             /* this could be optional */
+    OpcUa_Key*                  a_pPublicKey)
+{
+    EVP_PKEY*               pPublicKey      = OpcUa_Null;
+    RSA*                    pRsaPublicKey   = OpcUa_Null;
+    X509*                   pCertificate    = OpcUa_Null;
+    OpcUa_Byte*             pBuffer         = OpcUa_Null;
+    const unsigned char*    pTemp           = OpcUa_Null;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "X509_GetPublicKey");
+
+    OpcUa_ReferenceParameter(a_password);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificate);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificate->Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pPublicKey);
+
+    pTemp = a_pCertificate->Data;
+
+    d2i_X509(&pCertificate, &pTemp, a_pCertificate->Length);
+
+    if(pCertificate == OpcUa_Null)
+    {
+        return OpcUa_BadCertificateInvalid;
+    }
+
+    /* get EVP_PKEY from X509 certificate */
+    pPublicKey = X509_get_pubkey(pCertificate);
+    if(pPublicKey == OpcUa_Null)
+    {
+        X509_free(pCertificate);
+        return OpcUa_BadCertificateInvalid;
+    }
+
+    /* free X509 certificate, since not needed anymore */
+    X509_free(pCertificate);
+
+#if OPENSSL_VERSION_NUMBER >= 0x1000000fL
+    switch(EVP_PKEY_base_id(pPublicKey))
+#else
+    switch(EVP_PKEY_type(pPublicKey->type))
+#endif
+    {
+    case EVP_PKEY_RSA:
+
+        /* allocate memory for RSA key */
+
+        /* get RSA public key from EVP_PKEY */
+        pRsaPublicKey = EVP_PKEY_get1_RSA(pPublicKey);
+
+        /* allocate memory for DER encoded bytestring */
+        a_pPublicKey->Key.Length = i2d_RSAPublicKey(pRsaPublicKey, OpcUa_Null);
+
+        if(a_pPublicKey->Key.Data == OpcUa_Null)
+        {
+            RSA_free(pRsaPublicKey);
+            EVP_PKEY_free(pPublicKey);
+
+            OpcUa_ReturnStatusCode;
+        }
+
+        /* convert RSA key to DER encoded bytestring */
+        pBuffer = a_pPublicKey->Key.Data;
+        a_pPublicKey->Key.Length = i2d_RSAPublicKey(pRsaPublicKey, &pBuffer);
+        a_pPublicKey->Type = OpcUa_Crypto_KeyType_Rsa_Public;
+
+        /* free memory for RSA key */
+        RSA_free(pRsaPublicKey);
+
+        break;
+
+    case EVP_PKEY_EC:
+    case EVP_PKEY_DSA:
+    case EVP_PKEY_DH:
+    default:
+        OpcUa_GotoErrorWithStatus(OpcUa_BadNotSupported);
+    }
+
+    /*** clean up ***/
+    EVP_PKEY_free(pPublicKey);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    EVP_PKEY_free(pPublicKey);
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_X509_GetSignature
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_X509_GetSignature(
+    OpcUa_CryptoProvider*       a_pProvider,
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_Signature*            a_pSignature)
+{
+    X509*                   pX509Certificate    = OpcUa_Null;
+    const unsigned char*    pTemp               = OpcUa_Null;
+    const ASN1_BIT_STRING*  signature           = OpcUa_Null;
+    const X509_ALGOR*       sig_alg             = OpcUa_Null;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "X509_GetSignature");
+
+    OpcUa_ReferenceParameter(a_pProvider);
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificate);
+    OpcUa_ReturnErrorIfArgumentNull(a_pSignature);
+
+    /* d2i_X509 modifies the given pointer -> use local replacement */
+    pTemp = a_pCertificate->Data;
+
+    d2i_X509(&pX509Certificate, &pTemp, a_pCertificate->Length);
+
+    if(pX509Certificate == OpcUa_Null)
+    {
+        uStatus = OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+    X509_get0_signature(&signature, &sig_alg, pX509Certificate);
+#else
+    signature = pX509Certificate->signature;
+    sig_alg   = pX509Certificate->sig_alg;
+#endif
+
+    a_pSignature->Signature.Length = signature->length;
+
+    a_pSignature->Algorithm = OBJ_obj2nid(sig_alg->algorithm);
+
+    if(a_pSignature->Algorithm == NID_undef)
+    {
+        uStatus = OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(a_pSignature->Signature.Data != OpcUa_Null)
+    {
+        uStatus = OpcUa_P_Memory_MemCpy(a_pSignature->Signature.Data,
+                                        a_pSignature->Signature.Length,
+                                        signature->data,
+                                        signature->length);
+
+    }
+
+    X509_free(pX509Certificate);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pX509Certificate != OpcUa_Null)
+    {
+        X509_free(pX509Certificate);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_OpenSSL_X509_GetCertificateThumbprint
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_OpenSSL_X509_GetCertificateThumbprint(
+    OpcUa_CryptoProvider*       a_pProvider,
+    OpcUa_ByteString*           a_pCertificate,
+    OpcUa_ByteString*           a_pCertificateThumbprint)
+{
+    X509*                   pX509Certificate    = OpcUa_Null;
+    const unsigned char*    pTemp               = OpcUa_Null;
+
+OpcUa_InitializeStatus(OpcUa_Module_P_OpenSSL, "X509_GetCertificateThumbprint");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificate);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificate->Data);
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificateThumbprint);
+
+    /* SHA-1 produces 20 bytes */
+    a_pCertificateThumbprint->Length = SHA_DIGEST_LENGTH;
+
+    if(a_pCertificateThumbprint->Data == OpcUa_Null)
+    {
+        OpcUa_ReturnStatusCode;
+    }
+
+    /* d2i_X509 modifies the given pointer -> use local replacement */
+    pTemp = a_pCertificate->Data;
+
+    d2i_X509(&pX509Certificate, &pTemp, a_pCertificate->Length);
+
+    if(pX509Certificate == OpcUa_Null)
+    {
+        uStatus = OpcUa_Bad;
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(X509_digest(pX509Certificate, EVP_sha1(), a_pCertificateThumbprint->Data, NULL) <= 0)
+    {
+        uStatus = OpcUa_Bad;
+    }
+
+    X509_free(pX509Certificate);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+#endif /* OPCUA_REQUIRE_OPENSSL */

--- a/Stack/platforms/vxworks/opcua_p_pki.h
+++ b/Stack/platforms/vxworks/opcua_p_pki.h
@@ -1,0 +1,123 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_P_PKI_H_
+#define _OpcUa_P_PKI_H_ 1
+
+OPCUA_BEGIN_EXTERN_C
+
+/**
+  @brief The supported PKIs.
+*/
+typedef enum _OpcUa_P_PKI_Types
+{
+    OpcUa_Invalid_PKI   = 0,
+    OpcUa_NO_PKI        = 1,
+    OpcUa_Override      = 2,
+    OpcUa_OpenSSL_PKI   = 3
+} OpcUa_P_PKI_Types;
+
+/* OPENSSL PKI specific flags */
+#define OPCUA_P_PKI_OPENSSL_USE_DEFAULT_CERT_CRL_LOOKUP_METHOD       0x0001
+#define OPCUA_P_PKI_OPENSSL_DONT_ADD_TRUST_LIST_TO_ROOT_CERTIFICATES 0x0002
+#define OPCUA_P_PKI_OPENSSL_ADD_UNTRUSTED_LIST_TO_ROOT_CERTIFICATES  0x0004
+#define OPCUA_P_PKI_OPENSSL_UNTRUSTED_LIST_IS_INDEX                  0x0008
+#define OPCUA_P_PKI_OPENSSL_REVOCATION_LIST_IS_INDEX                 0x0010
+#define OPCUA_P_PKI_OPENSSL_REVOCATION_LIST_IS_CONCATENATED_PEM_FILE 0x0020
+#define OPCUA_P_PKI_OPENSSL_SUPPRESS_CERT_VALIDITY_PERIOD_CHECK      0x0040
+#define OPCUA_P_PKI_OPENSSL_SUPPRESS_CRL_VALIDITY_PERIOD_CHECK       0x0080
+#define OPCUA_P_PKI_OPENSSL_SUPPRESS_CRL_NOT_FOUND_ERROR             0x0100
+#define OPCUA_P_PKI_OPENSSL_CHECK_REVOCATION_ONLY_LEAF               0x0200
+#define OPCUA_P_PKI_OPENSSL_CHECK_REVOCATION_ALL_EXCEPT_SELF_SIGNED  0x0400
+#define OPCUA_P_PKI_OPENSSL_CHECK_REVOCATION_ALL                     0x0600
+#define OPCUA_P_PKI_OPENSSL_CHECK_SELF_SIGNED_SIGNATURE              0x0800
+#define OPCUA_P_PKI_OPENSSL_REQUIRE_CHAIN_CERTIFICATE_IN_TRUST_LIST  0x1000
+#define OPCUA_P_PKI_OPENSSL_ALLOW_PROXY_CERTIFICATES                 0x2000
+#define OPCUA_P_PKI_OPENSSL_OVERRIDE_IS_DHPARAM_FILE                 0x4000
+
+/* Override PKI specific flags */
+#define OPCUA_P_PKI_OVERRIDE_HANDLE_IS_DHPARAM_FILE                  0x4000
+
+/**
+  @brief The openssl pki config.
+  */
+struct _OpcUa_P_OpenSSL_CertificateStore_Config
+{
+    /*! @brief used PKI type. */
+    OpcUa_P_PKI_Types   PkiType;
+
+    /*! @brief The trusted certificate store location. */
+    OpcUa_StringA       CertificateTrustListLocation;
+
+    /*! @brief The certificate revocation list. */
+    OpcUa_StringA       CertificateRevocationListLocation;
+
+    /*! @brief The untrusted certificate store location. */
+    OpcUa_StringA       CertificateUntrustedListLocation;
+
+    /*! @brief PKI-specific flags. */
+    OpcUa_UInt32        Flags;
+
+    /*! @brief External PKIProvider IF to override default implementation. Checked when Configuration name is "Override" */
+    OpcUa_Void*         Override;
+};
+typedef struct _OpcUa_P_OpenSSL_CertificateStore_Config OpcUa_P_OpenSSL_CertificateStore_Config;
+
+/** note on: .PkiType == OpcUa_OpenSSL_PKI:
+ *
+ * recommended flags:
+ * .Flags = OPCUA_P_PKI_OPENSSL_ADD_UNTRUSTED_LIST_TO_ROOT_CERTIFICATES|
+ *          OPCUA_P_PKI_OPENSSL_REQUIRE_CHAIN_CERTIFICATE_IN_TRUST_LIST|
+ *          OPCUA_P_PKI_OPENSSL_CHECK_REVOCATION_ALL;
+ *
+ * .CertificateTrustListLocation = "<trusted-certs-directory>";
+ * .CertificateUntrustedListLocation = "<untrusted-certs-directory>";
+ * .CertificateRevocationListLocation = "<revoked-certs-directory>";
+ *
+ * compatibility:
+ * .Flags = 0;
+ * .CertificateTrustListLocation = "<certs-directory>";
+ */
+
+
+/**
+  @brief The certificate und key format enumeration.
+*/
+typedef enum _OpcUa_P_FileFormat
+{
+    OpcUa_Crypto_Encoding_Invalid   = 0,
+    OpcUa_Crypto_Encoding_DER       = 1,
+    OpcUa_Crypto_Encoding_PEM       = 2,
+    OpcUa_Crypto_Encoding_PKCS12    = 3
+}
+OpcUa_P_FileFormat;
+
+OPCUA_END_EXTERN_C
+
+#endif

--- a/Stack/platforms/vxworks/opcua_p_pkifactory.c
+++ b/Stack/platforms/vxworks/opcua_p_pkifactory.c
@@ -1,0 +1,224 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_memory.h>
+#include <opcua_p_string.h>
+
+/* own */
+#include <opcua_p_openssl_pki.h>
+#include <opcua_p_pkifactory.h>
+
+/*============================================================================
+ * OpcUa_P_PKIFactory_CreatePKIProvider
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_PKIFactory_CreatePKIProvider(OpcUa_Void*         a_pCertificateStoreConfig,
+                                                                    OpcUa_PKIProvider*  a_pPkiProvider)
+{
+    OpcUa_P_OpenSSL_CertificateStore_Config*    pCertificateStoreCfg    = OpcUa_Null;
+
+    OpcUa_InitializeStatus(OpcUa_Module_P_PKIFactory, "CreatePKIProvider");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pCertificateStoreConfig);
+    OpcUa_ReturnErrorIfArgumentNull(a_pPkiProvider);
+
+    pCertificateStoreCfg = (OpcUa_P_OpenSSL_CertificateStore_Config*)a_pCertificateStoreConfig;
+    a_pPkiProvider->Handle = a_pCertificateStoreConfig;
+
+    switch(pCertificateStoreCfg->PkiType)
+    {
+    case OpcUa_NO_PKI:
+        {
+            a_pPkiProvider->OpenCertificateStore    = OpcUa_P_OpenSSL_PKI_NoSecurity_OpenCertificateStore;
+            a_pPkiProvider->CloseCertificateStore   = OpcUa_P_OpenSSL_PKI_NoSecurity_CloseCertificateStore;
+            a_pPkiProvider->ValidateCertificate     = OpcUa_P_OpenSSL_PKI_NoSecurity_ValidateCertificate;
+            a_pPkiProvider->LoadCertificate         = OpcUa_P_OpenSSL_PKI_NoSecurity_LoadCertificate;
+            a_pPkiProvider->SaveCertificate         = OpcUa_P_OpenSSL_PKI_NoSecurity_SaveCertificate;
+            a_pPkiProvider->LoadPrivateKeyFromFile  = OpcUa_P_OpenSSL_PKI_NoSecurity_LoadPrivateKeyFromFile;
+            a_pPkiProvider->ExtractCertificateData  = OpcUa_P_OpenSSL_PKI_NoSecurity_ExtractCertificateData;
+            break;
+        }
+#if OPCUA_SUPPORT_PKI
+#if OPCUA_SUPPORT_PKI_OVERRIDE
+    case OpcUa_Override:
+        {
+            /* check if replacement for default is set and use it instead of the default */
+            OpcUa_PKIProvider* pOverride = (OpcUa_PKIProvider*)pCertificateStoreCfg->Override;
+
+            OpcUa_GotoErrorIfArgumentNull(pOverride);
+
+            if(pOverride->OpenCertificateStore == OpcUa_Null)
+            {
+                a_pPkiProvider->OpenCertificateStore = OpcUa_P_OpenSSL_PKI_OpenCertificateStore;
+            }
+            else
+            {
+                a_pPkiProvider->OpenCertificateStore = pOverride->OpenCertificateStore;
+            }
+
+            if(pOverride->CloseCertificateStore == OpcUa_Null)
+            {
+                a_pPkiProvider->CloseCertificateStore = OpcUa_P_OpenSSL_PKI_CloseCertificateStore;
+            }
+            else
+            {
+                a_pPkiProvider->CloseCertificateStore = pOverride->CloseCertificateStore;
+            }
+
+            if(pOverride->ValidateCertificate == OpcUa_Null)
+            {
+                a_pPkiProvider->ValidateCertificate = OpcUa_P_OpenSSL_PKI_ValidateCertificate;
+            }
+            else
+            {
+                a_pPkiProvider->ValidateCertificate = pOverride->ValidateCertificate;
+            }
+
+            if(pOverride->LoadCertificate == OpcUa_Null)
+            {
+                a_pPkiProvider->LoadCertificate = OpcUa_P_OpenSSL_PKI_LoadCertificate;
+            }
+            else
+            {
+                a_pPkiProvider->LoadCertificate = pOverride->LoadCertificate;
+            }
+
+            if(pOverride->SaveCertificate == OpcUa_Null)
+            {
+                a_pPkiProvider->SaveCertificate = OpcUa_P_OpenSSL_PKI_SaveCertificate;
+            }
+            else
+            {
+                a_pPkiProvider->SaveCertificate = pOverride->SaveCertificate;
+            }
+
+            if(pOverride->LoadPrivateKeyFromFile == OpcUa_Null)
+            {
+                a_pPkiProvider->LoadPrivateKeyFromFile = OpcUa_P_OpenSSL_PKI_LoadPrivateKeyFromFile;
+            }
+            else
+            {
+                a_pPkiProvider->LoadPrivateKeyFromFile = pOverride->LoadPrivateKeyFromFile;
+            }
+
+            if(pOverride->ExtractCertificateData == OpcUa_Null)
+            {
+                a_pPkiProvider->ExtractCertificateData = OpcUa_P_OpenSSL_PKI_ExtractCertificateData;
+            }
+            else
+            {
+                a_pPkiProvider->ExtractCertificateData = pOverride->ExtractCertificateData;
+            }
+            break;
+        }
+#endif /* OPCUA_SUPPORT_PKI_OVERRIDE */
+#if OPCUA_SUPPORT_PKI_OPENSSL
+    case OpcUa_OpenSSL_PKI:
+        {
+            a_pPkiProvider->OpenCertificateStore    = OpcUa_P_OpenSSL_PKI_OpenCertificateStore;
+            a_pPkiProvider->CloseCertificateStore   = OpcUa_P_OpenSSL_PKI_CloseCertificateStore;
+            a_pPkiProvider->ValidateCertificate     = OpcUa_P_OpenSSL_PKI_ValidateCertificate;
+            a_pPkiProvider->LoadCertificate         = OpcUa_P_OpenSSL_PKI_LoadCertificate;
+            a_pPkiProvider->SaveCertificate         = OpcUa_P_OpenSSL_PKI_SaveCertificate;
+            a_pPkiProvider->LoadPrivateKeyFromFile  = OpcUa_P_OpenSSL_PKI_LoadPrivateKeyFromFile;
+            a_pPkiProvider->ExtractCertificateData  = OpcUa_P_OpenSSL_PKI_ExtractCertificateData;
+            break;
+        }
+#endif /* OPCUA_SUPPORT_PKI_OPENSSL */
+#endif /* OPCUA_SUPPORT_PKI */
+    default:
+        {
+            uStatus = OpcUa_BadNotSupported;
+        }
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_PKIFactory_DeletePKIProvider
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_PKIFactory_DeletePKIProvider(OpcUa_PKIProvider* a_pProvider)
+{
+OpcUa_InitializeStatus(OpcUa_Module_P_PKIFactory, "DeletePKIProvider");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pProvider);
+
+    a_pProvider->Handle = OpcUa_Null;
+    a_pProvider->OpenCertificateStore = OpcUa_Null;
+    a_pProvider->CloseCertificateStore = OpcUa_Null;
+    a_pProvider->LoadCertificate = OpcUa_Null;
+    a_pProvider->LoadPrivateKeyFromFile = OpcUa_Null;
+    a_pProvider->SaveCertificate = OpcUa_Null;
+    a_pProvider->ValidateCertificate = OpcUa_Null;
+    a_pProvider->ExtractCertificateData = OpcUa_Null;
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * OpcUa_P_PKIFactory_GetDHParamFileName
+ *===========================================================================*/
+OpcUa_StringA OpcUa_P_PKIFactory_GetDHParamFileName(OpcUa_Void* a_pPKIConfig)
+{
+    OpcUa_P_OpenSSL_CertificateStore_Config* pCertificateStoreCfg;
+
+    pCertificateStoreCfg = (OpcUa_P_OpenSSL_CertificateStore_Config*)a_pPKIConfig;
+
+    if(pCertificateStoreCfg != OpcUa_Null)
+    {
+#if OPCUA_SUPPORT_PKI
+#if OPCUA_SUPPORT_PKI_OPENSSL
+        if(pCertificateStoreCfg->PkiType == OpcUa_OpenSSL_PKI &&
+           pCertificateStoreCfg->Flags & OPCUA_P_PKI_OPENSSL_OVERRIDE_IS_DHPARAM_FILE)
+        {
+            return (OpcUa_StringA)pCertificateStoreCfg->Override;
+        }
+#endif /* OPCUA_SUPPORT_PKI_OPENSSL */
+#if OPCUA_SUPPORT_PKI_OVERRIDE
+        if(pCertificateStoreCfg->PkiType == OpcUa_Override &&
+           pCertificateStoreCfg->Flags & OPCUA_P_PKI_OVERRIDE_HANDLE_IS_DHPARAM_FILE)
+        {
+            OpcUa_PKIProvider* pOverride = (OpcUa_PKIProvider*)pCertificateStoreCfg->Override;
+            if(pOverride != OpcUa_Null)
+            {
+                return (OpcUa_StringA)pOverride->Handle;
+            }
+        }
+#endif /* OPCUA_SUPPORT_PKI_OVERRIDE */
+#endif /* OPCUA_SUPPORT_PKI */
+    }
+
+    return OpcUa_Null;
+}

--- a/Stack/platforms/vxworks/opcua_p_pkifactory.h
+++ b/Stack/platforms/vxworks/opcua_p_pkifactory.h
@@ -1,0 +1,53 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_P_PKIFactory_H_
+#define _OpcUa_P_PKIFactory_H_ 1
+
+OPCUA_BEGIN_EXTERN_C
+/**
+  @brief Create the PKI Factory object
+*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_PKIFactory_CreatePKIProvider(    OpcUa_Void*         pCertificateStoreConfig,
+                                                                        OpcUa_PKIProvider*  pProvider);
+
+/**
+  @brief Delete the PKI Factory object
+*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_PKIFactory_DeletePKIProvider(    OpcUa_PKIProvider*  pProvider);
+
+
+/**
+  @brief Extract DH parameter file name from PKI Config
+  Return NULL if not available
+*/
+OpcUa_StringA OpcUa_P_PKIFactory_GetDHParamFileName(OpcUa_Void* pPKIConfig);
+
+OPCUA_END_EXTERN_C
+#endif

--- a/Stack/platforms/vxworks/opcua_p_semaphore.c
+++ b/Stack/platforms/vxworks/opcua_p_semaphore.c
@@ -1,0 +1,213 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright (c) 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+07nov18,lan  use VxWorks native api to implement OPC-UA semaphore.
+*/
+
+#include <vxWorks.h>
+#include <semLib.h>
+#include <sysLib.h>
+#include <errnoLib.h>
+#include <time.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+
+/* additional UA dependencies */
+#include <opcua_p_datetime.h>
+#include <opcua_p_memory.h>
+#include <opcua_utilities.h>
+
+/* own headers */
+#include <opcua_semaphore.h>
+#include <opcua_p_semaphore.h>
+
+/** Creates a new semaphore.
+ * @param a_Semaphore Pointer to semaphore handle. 
+ *        This returns the newly created semaphore.
+ * @param a_uInitalValue The initial value of the semaphore.
+ * @param a_uMaxRange The maximum value of the semaphore. This has no effect 
+ *        on linux, because the system has no maximim limit. But the parameter is checked 
+ *        to make sense 0 &lt;= InitValue &lt; MaxRange.
+ * @return OpcUa_Good if the semaphore could be created, OpcUa_BadInvalidArgument 
+ *         MaxRange is not plausible, or OpcUa_BadInternalError in case of a system call error.
+ */
+OpcUa_StatusCode OpcUa_P_Semaphore_Create
+    (
+    OpcUa_Semaphore*  a_Semaphore,
+    OpcUa_UInt32      a_uInitalValue,
+    OpcUa_UInt32      a_uMaxRange
+    )
+    {
+    SEM_ID  semid;
+
+    *a_Semaphore = OpcUa_Null;
+    if (a_uMaxRange == 0 || a_uMaxRange < a_uInitalValue) 
+        {
+        return OpcUa_BadInvalidArgument;
+        }
+
+    /* don't set SEM_INTERRUPTIBLE option */
+
+    semid = semCCreate (SEM_Q_PRIORITY|SEM_Q_FIFO, 
+                        (int) a_uInitalValue);
+    if (semid == SEM_ID_NULL)
+        {
+        return OpcUa_Bad;
+        }
+
+    *a_Semaphore = (OpcUa_Semaphore) semid;
+    return OpcUa_Good;
+    }
+
+/** Deletes the semaphore. */
+OpcUa_Void OpcUa_P_Semaphore_Delete
+    (
+    OpcUa_Semaphore* pRawSemaphore
+    )
+    {
+    SEM_ID  semid;
+    if (pRawSemaphore == OpcUa_Null || *pRawSemaphore == OpcUa_Null) 
+        return;
+
+    semid = (SEM_ID) *pRawSemaphore;
+    (void) semDelete (semid);
+    *pRawSemaphore = OpcUa_Null;
+    return;
+    }
+
+/** Aquires a resource.
+ * This function blocks until a resource could be aquired.
+ * Use OpcUa_P_Semaphore_TimedWait if you don't wont to block forever.
+ * This function handles interruptions due to signals and automatically
+ * restarts the wait operation.
+ * @param RawSemaphore Handle to semaphore.
+ * @return OpcUa_Good if the resource was successfully aquired,
+ * OpcUa_BadInternalError in case of a system call error.
+ */
+OpcUa_StatusCode OpcUa_P_Semaphore_Wait
+    (
+    OpcUa_Semaphore RawSemaphore
+    )
+    {
+    SEM_ID  semid = (SEM_ID) RawSemaphore;
+    STATUS  vxst;
+    
+    vxst = semTake (semid, WAIT_FOREVER); 
+    if (vxst != OK)
+        {
+        return OpcUa_BadInternalError;            
+        }
+    return OpcUa_Good;
+    }
+
+/** Aquires a resource.
+ * This function behaves like OpcUa_P_Semaphore_Wait, but does not block forever.
+ * In case of a timeout the function returns OpcUa_GoodNonCriticalTimeout.
+ * @param RawSemaphore Handle to semaphore.
+ * @param msecTimeout Maximum time to wait to aquire the resource.
+ * @return OpcUa_Good if the resource was successfully aquired, 
+ *         OpcUa_GoodNonCriticalTimeout in case of a timeout,
+ * OpcUa_BadInternalError in case of a system call error.
+ */
+OpcUa_StatusCode OpcUa_P_Semaphore_TimedWait
+    (
+    OpcUa_Semaphore RawSemaphore, 
+    OpcUa_UInt32    msecTimeout
+    )
+    {
+    SEM_ID       semid = (SEM_ID) RawSemaphore;
+    STATUS       vxst;
+    UINT64       ticks;
+    int          err;
+
+    if (msecTimeout == OpcUa_Infinite)
+        {
+        vxst = semTake (semid, WAIT_FOREVER);
+        if (vxst != OK)
+            return OpcUa_BadInternalError;
+        }
+    else
+        {
+        /* msecTimeout  millisecond */
+
+        ticks = sysClkRateGet() * msecTimeout / 1000;  
+        if (ticks == 0)
+            ticks = 1;
+        vxst = semTake (semid, (_Vx_ticks_t) ticks);
+        err = errnoGet ();
+        if (vxst != OK)
+            {
+            if (err == S_objLib_OBJ_TIMEOUT) /* timeout*/
+                {
+                return OpcUa_GoodNonCriticalTimeout;
+                }
+            return OpcUa_BadInternalError;
+            }
+        }
+
+    return OpcUa_Good;
+    }
+
+/** Gives back a number of aquired resources.
+ * This means it unblocks other blocking OpcUa_P_Semaphore_Wait or OpcUa_P_Semaphore_TimedWait calls.
+ * @param RawSemaphore Handle to semaphore.
+ * @param uReleaseCount Gives back uReleaseCount resources.
+ * @return OpcUa_Good on success or OpcUa_BadInternalError in case of a system call error.
+ */
+OpcUa_StatusCode OpcUa_P_Semaphore_Post
+    (
+    OpcUa_Semaphore RawSemaphore,
+    OpcUa_UInt32    uReleaseCount
+    )
+    {
+    SEM_ID  semid = (SEM_ID) RawSemaphore;
+    STATUS  vxst;
+
+    if (uReleaseCount == 0) 
+        return OpcUa_BadInvalidArgument;
+
+    while (uReleaseCount > 0)
+        {
+        vxst = semGive (semid);  
+        if (vxst != OK)  
+            return OpcUa_BadInternalError;
+        --uReleaseCount;
+        }
+
+    return OpcUa_Good;
+    }

--- a/Stack/platforms/vxworks/opcua_p_semaphore.h
+++ b/Stack/platforms/vxworks/opcua_p_semaphore.h
@@ -1,0 +1,42 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+OpcUa_StatusCode    OPCUA_DLLCALL OpcUa_P_Semaphore_Create( OpcUa_Semaphore*    phRawSemaphore,
+                                                            OpcUa_UInt32        uInitalValue,
+                                                            OpcUa_UInt32        uMaxRange);
+
+OpcUa_Void          OPCUA_DLLCALL OpcUa_P_Semaphore_Delete( OpcUa_Semaphore*    phRawSemaphore);
+
+OpcUa_StatusCode    OPCUA_DLLCALL OpcUa_P_Semaphore_Wait(   OpcUa_Semaphore     hRawSemaphore);
+
+OpcUa_StatusCode    OPCUA_DLLCALL OpcUa_P_Semaphore_TimedWait(OpcUa_Semaphore   hRawSemaphore,
+                                                            OpcUa_UInt32        msecTimeout);
+
+OpcUa_StatusCode    OPCUA_DLLCALL OpcUa_P_Semaphore_Post(   OpcUa_Semaphore     hRawSemaphore,
+                                                            OpcUa_UInt32        uReleaseCount);

--- a/Stack/platforms/vxworks/opcua_p_socket.c
+++ b/Stack/platforms/vxworks/opcua_p_socket.c
@@ -1,0 +1,1005 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright (c) 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+26jul18,lan  port to vxWorks.
+*/
+ 
+/* System Headers */
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <unistd.h>
+#include <string.h>
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_utilities.h>
+#include <opcua_vxworks_socket.h>
+
+/* own headers */
+#include <opcua_p_socket.h>
+
+/*============================================================================
+ * Initialize the platform network interface
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_InitializeNetwork(OpcUa_Void)
+{
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * Clean the platform network interface up.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_CleanupNetwork(OpcUa_Void)
+{
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * Shutdown Socket.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_Shutdown(OpcUa_RawSocket a_RawSocket,
+                                            OpcUa_Int       a_iHow)
+{
+    int     rawSocket;
+    int     iRetVal;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_Shutdown");
+
+    rawSocket = (int)a_RawSocket;
+
+    /* shutdown socket */
+    iRetVal = shutdown(rawSocket, a_iHow); /* SD_RECEIVE=0, SD_SEND=1, SD_BOTH=2 */
+
+    /* check uStatus */
+    if(iRetVal == OPCUA_P_SOCKET_SOCKETERROR)
+    {
+        int result = OpcUa_P_RawSocket_GetLastError((OpcUa_RawSocket)rawSocket);
+
+        switch (result)
+        {
+            case EBADF:
+                OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+                break;
+            case EINVAL:
+                OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+                break;
+            case ENOTCONN:
+                OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidState);
+                break;
+            case ENOTSOCK:
+                OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidState);
+                break;
+            case ENOBUFS:
+                OpcUa_GotoErrorWithStatus(OpcUa_BadOutOfMemory);
+                break;
+            default:
+                uStatus = OpcUa_BadUnexpectedError;
+                break;
+        }
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Close Socket.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_Close(OpcUa_RawSocket a_RawSocket)
+{
+    int     gnuSocket;
+    int     iRetVal;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_Close");
+
+    gnuSocket = (int)a_RawSocket;
+    iRetVal = close(gnuSocket);
+
+    /* check uStatus */
+    if(iRetVal == OPCUA_P_SOCKET_SOCKETERROR)
+    {
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Create Socket.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_Create(  OpcUa_RawSocket*    a_pRawSocket,
+                                            OpcUa_Boolean       a_bNagleOff,
+                                            OpcUa_Boolean       a_bReuseAddrOn)
+{
+    OpcUa_StatusCode    uStatus     = OpcUa_Good;
+    int                 flag        = 1;
+#if OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE
+    OpcUa_Int           iBufferSize = OPCUA_P_TCPRCVBUFFERSIZE;
+#endif /* OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE */
+
+    int                 linSocket   = OPCUA_P_SOCKET_INVALID;
+
+    OpcUa_GotoErrorIfArgumentNull(a_pRawSocket);
+
+    /* create socket through platform API */
+    linSocket = socket(AF_INET, SOCK_STREAM, 0);
+
+    /* check if socket creation was successful */
+    if(linSocket == OPCUA_P_SOCKET_INVALID)
+    {
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+
+    /* set socketoptions */
+    if(a_bNagleOff)
+    {
+        if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(linSocket, IPPROTO_TCP, TCP_NODELAY, (char*)&flag, sizeof(int)))
+        {
+            uStatus = OpcUa_BadCommunicationError;
+            goto Error;
+        }
+    }
+    if(a_bReuseAddrOn)
+    {
+        /* set socket options */
+        if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(linSocket, SOL_SOCKET,  SO_REUSEADDR, (char*)&flag, sizeof(int)))
+        {
+            uStatus = OpcUa_BadCommunicationError;
+            goto Error;
+        }
+    }
+
+#if OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE
+    iBufferSize = OPCUA_P_TCPRCVBUFFERSIZE;
+    if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(linSocket, SOL_SOCKET,  SO_RCVBUF, (char*)&iBufferSize, sizeof(int)))
+    {
+        /*int result = OpcUa_P_RawSocket_GetLastError((OpcUa_RawSocket)linSocket);*/
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+#endif /* OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE */
+
+#if OPCUA_P_SOCKET_SETTCPSNDBUFFERSIZE
+    iBufferSize = OPCUA_P_TCPSNDBUFFERSIZE;
+    if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(linSocket, SOL_SOCKET,  SO_SNDBUF, (char*)&iBufferSize, sizeof(int)))
+    {
+        /*int result = OpcUa_P_RawSocket_GetLastError((OpcUa_RawSocket)linSocket);*/
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+#endif /* OPCUA_P_SOCKET_SETTCPSNDBUFFERSIZE */
+
+
+    *a_pRawSocket = (OpcUa_RawSocket)linSocket;
+
+    return OpcUa_Good;
+
+Error:
+
+    if(linSocket != OPCUA_P_SOCKET_INVALID)
+    {
+        OpcUa_P_RawSocket_Close((OpcUa_RawSocket)linSocket);
+        *a_pRawSocket = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+    }
+
+    return uStatus;
+}
+
+/*============================================================================
+ * Create IPv6 Socket.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_CreateV6(  OpcUa_RawSocket*    a_pRawSocket,
+                                              OpcUa_Boolean       a_bNagleOff,
+                                              OpcUa_Boolean       a_bReuseAddrOn,
+                                              OpcUa_Boolean       a_bV6Only)
+{
+    OpcUa_StatusCode    uStatus     = OpcUa_Good;
+    int                 flag        = 1;
+#if OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE
+    OpcUa_Int           iBufferSize = OPCUA_P_TCPRCVBUFFERSIZE;
+#endif /* OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE */
+
+    int                 linSocket   = OPCUA_P_SOCKET_INVALID;
+
+    OpcUa_GotoErrorIfArgumentNull(a_pRawSocket);
+
+    /* create socket through platform API */
+    linSocket = socket(AF_INET6, SOCK_STREAM, 0);
+
+    /* check if socket creation was successful */
+    if(linSocket == OPCUA_P_SOCKET_INVALID)
+    {
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+
+    /* set socketoptions */
+    if(a_bNagleOff)
+    {
+        if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(linSocket, IPPROTO_TCP, TCP_NODELAY, (char*)&flag, sizeof(int)))
+        {
+            uStatus = OpcUa_BadCommunicationError;
+            goto Error;
+        }
+    }
+    if(a_bReuseAddrOn)
+    {
+        /* set socket options */
+        if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(linSocket, SOL_SOCKET,  SO_REUSEADDR, (char*)&flag, sizeof(int)))
+        {
+            uStatus = OpcUa_BadCommunicationError;
+            goto Error;
+        }
+    }
+
+#if OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE
+    iBufferSize = OPCUA_P_TCPRCVBUFFERSIZE;
+    if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(linSocket, SOL_SOCKET,  SO_RCVBUF, (char*)&iBufferSize, sizeof(int)))
+    {
+        /*int result = OpcUa_P_RawSocket_GetLastError((OpcUa_RawSocket)linSocket);*/
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+#endif /* OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE */
+
+#if OPCUA_P_SOCKET_SETTCPSNDBUFFERSIZE
+    iBufferSize = OPCUA_P_TCPSNDBUFFERSIZE;
+    if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(linSocket, SOL_SOCKET,  SO_SNDBUF, (char*)&iBufferSize, sizeof(int)))
+    {
+        /*int result = OpcUa_P_RawSocket_GetLastError((OpcUa_RawSocket)linSocket);*/
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+#endif /* OPCUA_P_SOCKET_SETTCPSNDBUFFERSIZE */
+
+    flag = a_bV6Only != OpcUa_False;
+    if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(linSocket, IPPROTO_IPV6,  IPV6_V6ONLY, (char*)&flag, sizeof(int)))
+    {
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+
+    *a_pRawSocket = (OpcUa_RawSocket)linSocket;
+
+    return OpcUa_Good;
+
+Error:
+
+    if(linSocket != OPCUA_P_SOCKET_INVALID)
+    {
+        OpcUa_P_RawSocket_Close((OpcUa_RawSocket)linSocket);
+        *a_pRawSocket = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+    }
+
+    return uStatus;
+}
+
+/*============================================================================
+ * Create a Socket Pair.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_CreateSocketPair(  OpcUa_RawSocket* pRawSocketRead,
+                                                      OpcUa_RawSocket* pRawSocketWrite)
+{
+  int filedes[2];
+  int retval = socketpair(AF_UNIX, SOCK_STREAM, 0, filedes);
+
+  if(retval<0)
+  {
+    *pRawSocketRead  = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+    *pRawSocketWrite = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+    return OpcUa_Bad;
+  }
+
+  *pRawSocketRead  = (OpcUa_RawSocket)filedes[1];
+  *pRawSocketWrite = (OpcUa_RawSocket)filedes[0];
+  return OpcUa_Good;
+}
+
+/*============================================================================
+ * Connect Socket for Client.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_Connect( OpcUa_RawSocket a_RawSocket,
+                                            OpcUa_Int16     a_nPort,
+                                            OpcUa_StringA   a_sHost)
+{
+    socklen_t           intSize;
+    int                 linSocket = OPCUA_P_SOCKET_INVALID;
+    struct sockaddr     *pName;
+    struct sockaddr_in  srv;
+    char*               localhost = "127.0.0.1";
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_Connect");
+    OpcUa_GotoErrorIfTrue(a_RawSocket == OPCUA_P_SOCKET_INVALID,
+                              OpcUa_BadCommunicationError);
+
+    linSocket = (int)a_RawSocket;
+
+    intSize = sizeof(struct sockaddr_in);
+    OpcUa_MemSet(&srv, 0, intSize);
+
+    if(!strcmp("localhost", a_sHost))
+    {
+        a_sHost = localhost;
+    }
+
+    srv.sin_addr.s_addr = inet_addr(a_sHost);
+
+    if(srv.sin_addr.s_addr == INADDR_NONE)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    srv.sin_port   = htons(a_nPort);
+    srv.sin_family = AF_INET;
+
+    pName = (struct sockaddr *) &srv;
+
+    if(connect(linSocket, pName, intSize) == OPCUA_P_SOCKET_SOCKETERROR)
+    {
+        int result = OpcUa_P_RawSocket_GetLastError((OpcUa_RawSocket)linSocket);
+
+        /* a connect takes some time and this "error" is common with nonblocking sockets */
+        if(result == EINPROGRESS)
+        {
+            uStatus = OpcUa_BadWouldBlock;
+        }
+        else
+        {
+            uStatus = OpcUa_BadCommunicationError;
+        }
+        goto Error;
+    }
+
+    uStatus = OpcUa_Good;
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Connect IPv6 Socket for Client.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_ConnectV6( OpcUa_RawSocket a_RawSocket,
+                                              OpcUa_Int16     a_nPort,
+                                              OpcUa_StringA   a_sHost)
+{
+    socklen_t           intSize;
+    int                 linSocket = OPCUA_P_SOCKET_INVALID;
+    struct sockaddr     *pName;
+    struct sockaddr_in6 srv;
+    struct in6_addr     localhost = IN6ADDR_LOOPBACK_INIT;
+    char                *pScopeId;
+    int                 apiResult;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_ConnectV6");
+    OpcUa_GotoErrorIfTrue(a_RawSocket == OPCUA_P_SOCKET_INVALID,
+                              OpcUa_BadCommunicationError);
+
+    linSocket = (int)a_RawSocket;
+
+    intSize = sizeof(struct sockaddr_in6);
+    OpcUa_MemSet(&srv, 0, intSize);
+
+    if(!strcmp("localhost", a_sHost))
+    {
+        srv.sin6_addr = localhost;
+    }
+    else
+    {
+        pScopeId = strchr(a_sHost, '%');
+        if(pScopeId != NULL)
+        {
+            srv.sin6_scope_id = OpcUa_P_CharAToInt(pScopeId+1);
+            *pScopeId = 0;
+        }
+        apiResult = inet_pton(AF_INET6, a_sHost, (void*)&srv.sin6_addr);
+        if(pScopeId != NULL)
+        {
+            *pScopeId = '%';
+        }
+        if(apiResult <= 0)
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_BadCommunicationError);
+        }
+    }
+
+    srv.sin6_port       = htons(a_nPort);
+    srv.sin6_family     = AF_INET6;
+    pName               = (struct sockaddr*)&srv;
+
+    if(connect(linSocket, pName, intSize) == OPCUA_P_SOCKET_SOCKETERROR)
+    {
+        int result = OpcUa_P_RawSocket_GetLastError((OpcUa_RawSocket)linSocket);
+
+        /* a connect takes some time and this "error" is common with nonblocking sockets */
+        if(result == EINPROGRESS)
+        {
+            uStatus = OpcUa_BadWouldBlock;
+        }
+        else
+        {
+            uStatus = OpcUa_BadCommunicationError;
+        }
+        goto Error;
+    }
+
+    uStatus = OpcUa_Good;
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Bind to Socket
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_Bind(    OpcUa_RawSocket a_RawSocket,
+                                            OpcUa_Int16     a_nPort)
+{
+    socklen_t           intSize;
+    int                 linSocket  = OPCUA_P_SOCKET_INVALID;
+    struct sockaddr_in  srv;
+    struct sockaddr     *pName;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_Bind");
+    OpcUa_GotoErrorIfTrue(a_RawSocket == OPCUA_P_SOCKET_INVALID,
+                              OpcUa_BadCommunicationError);
+
+    linSocket = (int)a_RawSocket;
+
+    intSize = sizeof(struct sockaddr_in);
+    OpcUa_MemSet(&srv, 0, intSize);
+
+    srv.sin_addr.s_addr = INADDR_ANY;
+    srv.sin_port        = htons(a_nPort);
+    srv.sin_family      = AF_INET;
+    pName               = (struct sockaddr*)&srv;
+
+    if(bind(linSocket, pName, intSize) == OPCUA_P_SOCKET_SOCKETERROR)
+    {
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Bind to Socket to a specific adapter
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_BindEx(  OpcUa_RawSocket a_RawSocket,
+                                            OpcUa_StringA   a_IpAddress,
+                                            OpcUa_Int16     a_nPort)
+{
+    socklen_t           intSize;
+    int                 linSocket  = OPCUA_P_SOCKET_INVALID;
+    struct sockaddr_in  srv;
+    struct sockaddr     *pName;
+    unsigned long       uIp = INADDR_ANY;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_BindEx");
+    OpcUa_GotoErrorIfTrue(a_RawSocket == OPCUA_P_SOCKET_INVALID,
+                              OpcUa_BadCommunicationError);
+
+    linSocket = (int)a_RawSocket;
+
+    intSize = sizeof(struct sockaddr_in);
+    OpcUa_MemSet(&srv, 0, intSize);
+
+    if(a_IpAddress != OpcUa_Null)
+    {
+        uIp = inet_addr(a_IpAddress);
+    }
+
+    srv.sin_addr.s_addr = uIp;
+    srv.sin_port        = htons(a_nPort);
+    srv.sin_family      = AF_INET;
+    pName               = (struct sockaddr*)&srv;
+
+    if(bind(linSocket, pName, intSize) == OPCUA_P_SOCKET_SOCKETERROR)
+    {
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Bind to Socket to a specific adapter
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_BindV6(  OpcUa_RawSocket a_RawSocket,
+                                            OpcUa_StringA   a_IpAddress,
+                                            OpcUa_Int16     a_nPort)
+{
+    socklen_t           intSize;
+    int                 linSocket  = OPCUA_P_SOCKET_INVALID;
+    struct sockaddr_in6 srv;
+    struct sockaddr     *pName;
+    char                *pScopeId;
+    int                 apiResult;
+
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_BindV6");
+    OpcUa_GotoErrorIfTrue(a_RawSocket == OPCUA_P_SOCKET_INVALID,
+                              OpcUa_BadCommunicationError);
+
+    linSocket = (int)a_RawSocket;
+
+    intSize = sizeof(struct sockaddr_in6);
+    OpcUa_MemSet(&srv, 0, intSize);
+
+    if(a_IpAddress != OpcUa_Null)
+    {
+        pScopeId = strchr(a_IpAddress, '%');
+        if(pScopeId != NULL)
+        {
+            srv.sin6_scope_id = OpcUa_P_CharAToInt(pScopeId+1);
+            *pScopeId = 0;
+        }
+        apiResult = inet_pton(AF_INET6, a_IpAddress, (void*)&srv.sin6_addr);
+        if(pScopeId != NULL)
+        {
+            *pScopeId = '%';
+        }
+        if(apiResult <= 0)
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_BadCommunicationError);
+        }
+    }
+
+    srv.sin6_port       = htons(a_nPort);
+    srv.sin6_family     = AF_INET6;
+    pName               = (struct sockaddr*)&srv;
+
+    if(bind(linSocket, pName, intSize) == OPCUA_P_SOCKET_SOCKETERROR)
+    {
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Bind to Socket and set to listen for Server.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_Listen(OpcUa_RawSocket a_RawSocket)
+{
+    int gnuSocket;
+
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_Listen");
+    OpcUa_GotoErrorIfTrue(a_RawSocket == OPCUA_P_SOCKET_INVALID,
+                              OpcUa_BadCommunicationError);
+
+    gnuSocket = (int)a_RawSocket;
+
+    if(listen(gnuSocket, SOMAXCONN) == OPCUA_P_SOCKET_SOCKETERROR)
+    {
+        uStatus = OpcUa_BadCommunicationError;
+        goto Error;
+    }
+
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Accept Socket connection from Client.
+ *===========================================================================*/
+OpcUa_RawSocket OpcUa_P_RawSocket_Accept(   OpcUa_RawSocket a_RawSocket,
+                                            OpcUa_Boolean   a_bNagleOff,
+                                            OpcUa_Boolean   a_bKeepAliveOn)
+{
+    int                 iFlag           = 1;
+    int                 gnuSocketServer;
+    int                 gnuSocketClient;
+#if OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE || OPCUA_P_SOCKET_SETTCPSNDBUFFERSIZE
+    OpcUa_Int           iBufferSize = OPCUA_P_TCPRCVBUFFERSIZE;
+#endif /* OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE || OPCUA_P_SOCKET_SETTCPSNDBUFFERSIZE */
+
+    if(a_RawSocket == (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+    {
+        return (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+    }
+
+    gnuSocketServer = (int)a_RawSocket;
+
+    gnuSocketClient = accept(gnuSocketServer, NULL, NULL);
+    if(gnuSocketClient == OPCUA_P_SOCKET_INVALID)
+    {
+        /* accept failed */
+        goto Error;
+    }
+
+    if(a_bNagleOff)
+    {
+        /* set socket options */
+        if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(gnuSocketClient, IPPROTO_TCP, TCP_NODELAY, (const char*)&iFlag, sizeof(int)))
+        {
+            goto Error;
+        }
+    }
+
+    if(a_bKeepAliveOn)
+    {
+        /* set socket options */
+        if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt( gnuSocketClient, IPPROTO_TCP, SO_KEEPALIVE, (const char*)&iFlag, sizeof(int)))
+        {
+            goto Error;
+        }
+    }
+#if OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE
+    iBufferSize = OPCUA_P_TCPRCVBUFFERSIZE;
+    if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(gnuSocketClient, SOL_SOCKET,  SO_RCVBUF, (const char*)&iBufferSize, sizeof(int)))
+    {
+        /*int result = OpcUa_RawSocket_GetLastError((OpcUa_RawSocket)gnuSocketClient);*/
+        goto Error;
+    }
+#endif /* OPCUA_P_SOCKET_SETTCPRCVBUFFERSIZE */
+#if OPCUA_P_SOCKET_SETTCPSNDBUFFERSIZE
+    iBufferSize = OPCUA_P_TCPSNDBUFFERSIZE;
+    if(OPCUA_P_SOCKET_SOCKETERROR == setsockopt(gnuSocketClient, SOL_SOCKET,  SO_SNDBUF, (const char*)&iBufferSize, sizeof(int)))
+    {
+        /*int result = OpcUa_RawSocket_GetLastError((OpcUa_RawSocket)gnuSocketClient);*/
+        goto Error;
+    }
+#endif /* OPCUA_P_SOCKET_SETTCPSNDBUFFERSIZE */
+    return (OpcUa_RawSocket)gnuSocketClient;
+
+Error:
+    if(gnuSocketClient != OPCUA_P_SOCKET_INVALID)
+    {
+        OpcUa_P_RawSocket_Close((OpcUa_RawSocket)gnuSocketClient);
+    }
+
+    return (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+}
+
+/*============================================================================
+ * Read Socket.
+ *===========================================================================*/
+OpcUa_Int32 OpcUa_P_RawSocket_Read( OpcUa_RawSocket a_RawSocket,
+                                    OpcUa_Byte*     a_pBuffer,
+                                    OpcUa_UInt32    a_nBufferSize)
+{
+    ssize_t intBytesReceived;
+
+    int gnuSocket;
+
+    if(a_RawSocket == (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+    {
+        return 0;
+    }
+
+    gnuSocket = (int)a_RawSocket;
+
+    intBytesReceived = recv(gnuSocket, (char*)a_pBuffer, a_nBufferSize, 0);
+
+    return intBytesReceived;
+}
+
+/*============================================================================
+ * Write Socket.
+ *===========================================================================*/
+OpcUa_Int32 OpcUa_P_RawSocket_Write(    OpcUa_RawSocket a_RawSocket,
+                                        OpcUa_Byte*     a_pBuffer,
+                                        OpcUa_UInt32    a_uBufferSize)
+{
+    ssize_t   intBytesSend;
+
+    int  gnuSocket;
+
+    if(a_RawSocket == (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+    {
+        return 0;
+    }
+
+    gnuSocket = (int)a_RawSocket;
+
+    intBytesSend = send(gnuSocket, (char*)a_pBuffer, a_uBufferSize, 0);
+
+    return intBytesSend;
+}
+
+
+/*============================================================================
+ * Set socket to nonblocking mode
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_SetBlockMode(    OpcUa_RawSocket a_RawSocket,
+                                                    OpcUa_Boolean   a_bBlocking)
+{
+    int                 gnuSocket;
+    OpcUa_StatusCode    uStatus     = OpcUa_Good;
+    int                 flags       = 0;
+    int                 apiResult;
+
+    if(a_RawSocket == (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    gnuSocket = (int)a_RawSocket;
+    flags = fcntl (gnuSocket, F_GETFL);
+    if(flags == -1)
+    {
+        return OpcUa_BadCommunicationError;
+    }
+
+    if(a_bBlocking)
+    {
+        apiResult = fcntl (gnuSocket, F_SETFL, flags & ~O_NONBLOCK);
+    }
+    else
+    {
+        apiResult = fcntl (gnuSocket, F_SETFL, flags | O_NONBLOCK);
+    }
+    if(apiResult == -1)
+    {
+        uStatus = OpcUa_BadCommunicationError;
+    }
+    return uStatus;
+}
+
+
+/*============================================================================
+ * Network Byte Order Conversion Helper Functions
+ *===========================================================================*/
+OpcUa_UInt32 OpcUa_P_RawSocket_NToHL(OpcUa_UInt32 netLong)
+{
+    OpcUa_UInt32 retval = ntohl(netLong);
+    return retval;
+}
+
+OpcUa_UInt16 OpcUa_P_RawSocket_NToHS(OpcUa_UInt16 netShort)
+{
+    OpcUa_UInt16 retval = ntohs(netShort);
+    return retval;
+}
+
+OpcUa_UInt32 OpcUa_P_RawSocket_HToNL(OpcUa_UInt32 hstLong)
+{
+    OpcUa_UInt32 retval = htonl(hstLong);
+    return retval;
+}
+
+OpcUa_UInt16 OpcUa_P_RawSocket_HToNS(OpcUa_UInt16 hstShort)
+{
+    OpcUa_UInt16 retval = htons(hstShort);
+    return retval;
+}
+
+
+
+/*============================================================================
+ * Get address information about the peer
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_GetPeerInfo( OpcUa_RawSocket a_RawSocket,
+                                                OpcUa_CharA*    a_achPeerInfoBuffer,
+                                                OpcUa_UInt32    a_uiPeerInfoBufferSize)
+{
+    int                 apiResult;
+    struct sockaddr_storage sockAddrIn;
+    socklen_t           sockAddrInLen   = sizeof(sockAddrIn);
+    int                 gnuSocket;
+    char                IpAddrStr[INET6_ADDRSTRLEN];
+    OpcUa_UInt16        usPort;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "GetPeerInfo");
+
+    /* initial parameter check */
+    OpcUa_ReturnErrorIfTrue((a_RawSocket == (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID), OpcUa_BadInvalidArgument);
+    OpcUa_ReturnErrorIfArgumentNull(a_achPeerInfoBuffer);
+    OpcUa_ReturnErrorIfTrue((a_uiPeerInfoBufferSize < OPCUA_P_PEERINFO_MIN_SIZE), OpcUa_BadInvalidArgument);
+
+    gnuSocket = (int)a_RawSocket;
+    apiResult = getpeername(gnuSocket, (struct sockaddr*)&sockAddrIn, &sockAddrInLen);
+
+    OpcUa_ReturnErrorIfTrue((apiResult != 0), OpcUa_BadInternalError);
+
+    if(sockAddrIn.ss_family == AF_INET6)
+    {
+        struct sockaddr_in6* pAddr = (struct sockaddr_in6*)&sockAddrIn;
+
+        /* IP */
+        if(inet_ntop(AF_INET6, (void*)&pAddr->sin6_addr,
+                     IpAddrStr, INET6_ADDRSTRLEN) == NULL)
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+        }
+
+        /* Port */
+        usPort = OpcUa_P_RawSocket_NToHS((OpcUa_UInt16)pAddr->sin6_port);
+
+        if(pAddr->sin6_scope_id)
+        {
+            sprintf(a_achPeerInfoBuffer, "%s%%%u:%u", IpAddrStr, pAddr->sin6_scope_id, usPort);
+        }
+        else
+        {
+            sprintf(a_achPeerInfoBuffer, "%s:%u", IpAddrStr, usPort);
+        }
+    }
+    else if(sockAddrIn.ss_family == AF_INET)
+    {
+        struct sockaddr_in* pAddr = (struct sockaddr_in*)&sockAddrIn;
+
+        /* IP */
+        if(inet_ntop(AF_INET, (void*)&pAddr->sin_addr,
+                     IpAddrStr, INET_ADDRSTRLEN) == NULL)
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+        }
+
+        /* Port */
+        usPort = OpcUa_P_RawSocket_NToHS((OpcUa_UInt16)pAddr->sin_port);
+
+        sprintf(a_achPeerInfoBuffer, "%s:%u", IpAddrStr, usPort);
+    }
+    else
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Get IP Address and Port Number of the local connection
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_GetLocalInfo(    OpcUa_RawSocket a_RawSocket,
+                                                    OpcUa_UInt16*   a_pPort)
+{
+    int                 apiResult;
+    struct sockaddr_storage sockAddrIn;
+    socklen_t           sockAddrInLen = sizeof(sockAddrIn);
+    int                 gnuSocket;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "GetLocalInfo");
+
+    OpcUa_ReturnErrorIfTrue((a_RawSocket == (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID), OpcUa_BadInvalidArgument);
+    OpcUa_ReturnErrorIfArgumentNull(a_pPort);
+
+    gnuSocket = (int)a_RawSocket;
+    apiResult = getsockname(gnuSocket, (struct sockaddr*)&sockAddrIn, &sockAddrInLen);
+
+    OpcUa_ReturnErrorIfTrue((apiResult != 0), OpcUa_BadInternalError);
+
+    if(sockAddrIn.ss_family == AF_INET6)
+    {
+        struct sockaddr_in6* pAddr = (struct sockaddr_in6*)&sockAddrIn;
+
+        *a_pPort = OpcUa_P_RawSocket_NToHS((OpcUa_UInt16)pAddr->sin6_port);
+    }
+    else if(sockAddrIn.ss_family == AF_INET)
+    {
+        struct sockaddr_in* pAddr = (struct sockaddr_in*)&sockAddrIn;
+
+        *a_pPort = OpcUa_P_RawSocket_NToHS((OpcUa_UInt16)pAddr->sin_port);
+    }
+    else
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+    }
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Select usable socket. (maxfds ignored in win32)
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_RawSocket_Select(  OpcUa_RawSocket         a_MaxFds,
+                                            OpcUa_P_Socket_Array*   a_pFdSetRead,
+                                            OpcUa_P_Socket_Array*   a_pFdSetWrite,
+                                            OpcUa_P_Socket_Array*   a_pFdSetException,
+                                            OpcUa_UInt32            a_uTimeout)
+{
+    int                 apiResult;
+    struct timeval      timeout;
+
+    OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_Select");
+    OpcUa_GotoErrorIfArgumentNull(a_pFdSetRead);
+    OpcUa_GotoErrorIfArgumentNull(a_pFdSetWrite);
+    OpcUa_GotoErrorIfArgumentNull(a_pFdSetException);
+    timeout.tv_sec  = a_uTimeout / 1000;
+    timeout.tv_usec = (a_uTimeout % 1000) * 1000;
+
+
+    do
+    {
+        apiResult = select(
+                (int)a_MaxFds + 1,
+                &a_pFdSetRead->SocketArray,
+                &a_pFdSetWrite->SocketArray,
+                &a_pFdSetException->SocketArray,
+                &timeout);
+    }
+    while(apiResult == OPCUA_P_SOCKET_SOCKETERROR && errno == EINTR);
+
+
+    if(apiResult == OPCUA_P_SOCKET_SOCKETERROR)
+    {
+        uStatus   = OpcUa_BadCommunicationError;
+        OpcUa_Trace(OPCUA_TRACE_LEVEL_ERROR,"Error while OpcUa_RawSocket_Select: (API result is %d, errno is %d\n",apiResult,errno);
+    }
+
+    OpcUa_ReturnStatusCode;
+    OpcUa_BeginErrorHandling;
+    OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Get last socket error.
+ *===========================================================================*/
+OpcUa_Int32 OpcUa_P_RawSocket_GetLastError( OpcUa_RawSocket a_RawSocket)
+{
+    OpcUa_ReferenceParameter(a_RawSocket); /* Not needed in this implementation. */
+    return (OpcUa_Int32)errno;
+}
+
+/*============================================================================
+ * Initialize the platform network interface
+ *===========================================================================*/
+OpcUa_UInt32 OpcUa_P_RawSocket_InetAddr(OpcUa_StringA sRemoteAddress)
+{
+    if(sRemoteAddress != OpcUa_Null)
+    {
+        return (OpcUa_UInt32)inet_addr(sRemoteAddress);
+    }
+
+    return 0;
+}

--- a/Stack/platforms/vxworks/opcua_p_socket.h
+++ b/Stack/platforms/vxworks/opcua_p_socket.h
@@ -1,0 +1,389 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_P_Socket_H_
+#define _OpcUa_P_Socket_H_
+
+/** @brief shutdown directions */
+#define OPCUA_P_SOCKET_SD_RECV  SHUT_RD
+#define OPCUA_P_SOCKET_SD_SEND  SHUT_WR
+#define OPCUA_P_SOCKET_SD_BOTH  SHUT_RDWR
+
+/**
+* The internally used socket handle.
+*/
+typedef int OpcUa_RawSocket; /* pointer to a socket of the platform type */
+
+
+/**
+* @brief Internal representation for file descriptor sets.
+*/
+
+#include <sys/select.h>
+typedef struct _OpcUa_P_Socket_Array
+{
+    /*! @brief An array of raw (platform) sockets. */
+    fd_set SocketArray;
+} OpcUa_P_Socket_Array;
+
+/*! @brief Symbol for stream oriented data transmission. */
+#define OPCUA_P_SOCKET_STREAM                   (1u)
+
+/*! @brief Symbol for packet oriented data transmission. */
+#define OPCUA_P_SOCKET_DGRAM                    (2u)
+
+/*! @brief Set all entries in a socket array to "not set". */
+#define OPCUA_P_SOCKET_ARRAY_ZERO(pSA) FD_ZERO(&(pSA)->SocketArray)
+
+/*! @brief Checks if a specific entry in a socket array is set. */
+#define OPCUA_P_SOCKET_ARRAY_ISSET(rawsck, pSA) FD_ISSET(rawsck,&(pSA)->SocketArray)
+
+/*! @brief Sets a specific socket in a socket array. */
+#define OPCUA_P_SOCKET_ARRAY_SET(rawsck, pSA) FD_SET(rawsck,&(pSA)->SocketArray)
+
+/*! @brief Value for an invalid raw socket. */
+#define OPCUA_P_SOCKET_INVALID      (-1)
+
+/*! @brief Wait for an infinite amount of time. */
+#define OPCUA_P_SOCKET_INFINITE     0xffffffffU     /* wait infinite time */
+
+/*! @brief Value returned by platform API if an error happened. */
+#define OPCUA_P_SOCKET_SOCKETERROR  (-1)            /* platform representation of socket error */
+
+/*============================================================================
+ * Functions
+ *===========================================================================*/
+
+/*!
+ * @brief Initialize the platform network interface. (interface)
+ *
+ * This function initializes all platform and functional resources used by the
+ * p socket module. This includes static variables.
+ *
+ * @return Good if initialization went fine. A bad status code in any other case.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_InitializeNetwork(void);
+
+
+/*!
+ * @brief Clean up the platform network interface.
+ *
+ * Cleans up all data allocated by the p socket module and shuts down the
+ * platforms network system as far as possible/needed.
+ *
+ * @return Good if initialization went fine. A bad status code in any other case.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_CleanupNetwork(void);
+
+
+/*!
+ * @brief Close a system socket.
+ *
+ * @param RawSocket [in] The system socket to be closed.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_Close(OpcUa_RawSocket RawSocket);
+
+/*!
+ * @brief Shut a system socket down.
+ *
+ * @param RawSocket [in] The system socket to be shut down.
+ * @param iHow      [in] Which direction (see OPCUA_P_SOCKET_SD_*).
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_Shutdown(OpcUa_RawSocket RawSocket,
+                                            OpcUa_Int       iHow);
+
+/*!
+ * @brief Connect the given system socket to the specified address.
+ *
+ * @param RawSocket [in]    The socket to connect.
+ * @param Port      [in]    To which port should be connected.
+ * @param Host      [in]    The server IP address in string representation.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ *         OpcUa_BadWouldBlock should not be handled as error, if non blocking sockets are used.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_Connect( OpcUa_RawSocket RawSocket,
+                                            OpcUa_Int16     Port,
+                                            OpcUa_StringA   Host);
+
+/*!
+ * @brief Connect the given IPv6 socket to the specified address.
+ *
+ * @param RawSocket [in]    The socket to connect.
+ * @param Port      [in]    To which port should be connected.
+ * @param Host      [in]    The server IP address in string representation.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ *         OpcUa_BadWouldBlock should not be handled as error, if non blocking sockets are used.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_ConnectV6( OpcUa_RawSocket RawSocket,
+                                              OpcUa_Int16     Port,
+                                              OpcUa_StringA   Host);
+
+/*!
+ * @brief Bind the given system socket to all network interfaces.
+ *
+ * @param RawSocket [in]    The socket to bind.
+ * @param Port      [in]    Bind the socket to this port.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_Bind(OpcUa_RawSocket RawSocket,
+                                        OpcUa_Int16     Port);
+
+/*!
+ * @brief Bind the given system socket to the specified network interface.
+ *
+ * @param RawSocket [in]    The socket to bind.
+ * @param IpAddress [in]    The network interface where the socket is to bind to.
+ * @param Port      [in]    Bind the socket to this port.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_BindEx(OpcUa_RawSocket RawSocket,
+                                          OpcUa_StringA   IpAddress,
+                                          OpcUa_Int16     Port);
+
+/*!
+ * @brief Bind the given IPv6 socket to the specified network interface.
+ *
+ * @param RawSocket [in]    The socket to bind.
+ * @param IpAddress [in]    The network interface where the socket is to bind to.
+ * @param Port      [in]    Bind the socket to this port.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_BindV6(OpcUa_RawSocket RawSocket,
+                                          OpcUa_StringA   IpAddress,
+                                          OpcUa_Int16     Port);
+
+/*!
+ * @brief Start listening on the given system socket.
+ *
+ * @param RawSocket [in]    The server socket, which should accept connect requests.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_Listen(OpcUa_RawSocket RawSocket);
+
+/*!
+ * @brief Accept connections on the given system socket.
+ *
+ * Accepts a connection from another network node and returns the
+ * port and address as well as the newly created system socket
+ * for the connection.
+ *
+ * @param RawSocket     [in]    Accept connection requests on this socket.
+ * @param NagleOff      [in]    If the new connection has Nagling activated.
+ * @param KeepAliveOn   [in]    If the new connection sends keep alive pakets.
+ *
+ * @return The created system socket. An invalid socket (OPCUA_P_SOCKET_INVALID) in case of error.
+ */
+OpcUa_RawSocket OpcUa_P_RawSocket_Accept(   OpcUa_RawSocket RawSocket,
+                                            OpcUa_Boolean   NagleOff,
+                                            OpcUa_Boolean   KeepAliveOn);
+
+/*!
+ * @brief Read data from the given system socket into a buffer.
+ *
+ * Tries to read data from the given system socket into the buffer.
+ * The amount of the received data will fit into the given buffersize.
+ *
+ * @param RawSocket     [in]        The socket to read from.
+ * @param Buffer        [in/out]    Will receive the read data.
+ * @param BufferSize    [in]        Maximum number of bytes to receive.
+ *
+ * @return The number of bytes read, OPCUA_P_SOCKET_SOCKETERROR or 0 if the peer disconnected.
+ */
+OpcUa_Int32 OpcUa_P_RawSocket_Read( OpcUa_RawSocket RawSocket,
+                                    OpcUa_Byte*     Buffer,
+                                    OpcUa_UInt32    BufferSize);
+
+/*!
+ * @brief Write data over the given system socket.
+ *
+ * Send the given data in the buffer and size over the system socket.
+ *
+ * @param RawSocket     [in]    Socket to send the data over.
+ * @param Buffer        [in]    Buffer holding the data to be sent.
+ * @param BufferSize    [in]    How much data should be sent, in bytes.
+ *
+ * @return The number of bytes written, a OPCUA_P_SOCKET_SOCKETERROR
+ */
+OpcUa_Int32 OpcUa_P_RawSocket_Write(OpcUa_RawSocket RawSocket,
+                                    OpcUa_Byte*     Buffer,
+                                    OpcUa_UInt32    BufferSize);
+
+/*!
+ * @brief Set the system socket to non-blocking or mode.
+ *
+ * @param RawSocket [in]    The system socket descriptor.
+ * @param bBlocking [in]    Socket will be set to block, if true, nonblocking else.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_SetBlockMode(    OpcUa_RawSocket RawSocket,
+                                                    OpcUa_Boolean   bBlocking);
+
+/*!
+ * @brief Convert the given value from network into host byte order.
+ *
+ * @param netLong   [in]    Value to be converted.
+ *
+ * @return The converted value.
+ */
+OpcUa_UInt32 OpcUa_P_RawSocket_NToHL(OpcUa_UInt32 netLong);
+
+/*!
+ * @brief Convert the given value from network into host byte order.
+ *
+ * @param netShort  [in]    Value to be converted.
+ *
+ * @return The converted value.
+ */
+OpcUa_UInt16 OpcUa_P_RawSocket_NToHS(OpcUa_UInt16 netShort);
+
+/*!
+ * @brief Convert the given value from host into network byte order.
+ *
+ * @param hstLong   [in]    Value to be converted.
+ *
+ * @return The converted value.
+ */
+OpcUa_UInt32 OpcUa_P_RawSocket_HToNL(OpcUa_UInt32 hstLong);
+
+/*!
+ * @brief Convert the given value from host into network byte order.
+ *
+ * @param hstShort  [in]    Value to be converted.
+ *
+ * @return The converted value.
+ */
+OpcUa_UInt16 OpcUa_P_RawSocket_HToNS(OpcUa_UInt16 hstShort);
+
+/*!
+ * @brief Set sockets in given file descriptor sets if a certain event occurred.
+ *
+ * @param RawSocket         [in]        The maximum file descriptor. Ignored in win32.
+ * @param FdSetRead         [in/out]    OpcUa_Socket_FdSet with all sockets set, that wait on read events. Holds all sockets where this event occurred afterwards.
+ * @param FdSetWrite        [in/out]    OpcUa_Socket_FdSet with all sockets set, that wait on write events. Holds all sockets where this event occurred afterwards.
+ * @param FdSetException    [in/out]    OpcUa_Socket_FdSet with all sockets set, that wait on exception events. Holds all sockets where this event occurred afterwards.
+ * @param Timeout           [in]        The maximume time to block at this call.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_Select(  OpcUa_RawSocket         RawSocket,
+                                            OpcUa_P_Socket_Array*   FdSetRead,
+                                            OpcUa_P_Socket_Array*   FdSetWrite,
+                                            OpcUa_P_Socket_Array*   FdSetException,
+                                            OpcUa_UInt32            Timeout);
+
+/*!
+ * @brief Get address information for the peer connected to the given socket socket handle.
+ *
+ * @param RawSocket             [in] Identifier for the connection.
+ * @param achPeerInfoBuffer     [in] Where the address information gets stored.
+ * @param uiPeerInfoBufferSize  [in] The size of the given buffer.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_GetPeerInfo( OpcUa_RawSocket RawSocket,
+                                                OpcUa_CharA*    achPeerInfoBuffer,
+                                                OpcUa_UInt32    uiPeerInfoBufferSize);
+
+/*!
+ * @brief Get IP address and port number of the local network node.
+ *
+ * @param RawSocket [in]    Identifier for the connection.
+ * @param Port      [out]   Where the port gets stored.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_GetLocalInfo(OpcUa_RawSocket RawSocket,
+                                                OpcUa_UInt16*   Port);
+
+/*!
+ * @brief Get last socket error that happened.
+ *
+ * This function is currently mostly for debugging reasons, since no real error
+ * mapping exists, yet (and probably won't).
+ *
+ * @param RawSocket [in]    Identifier for the connection, which error code is requested.
+ *
+ * @return The raw error value.
+ */
+OpcUa_Int32 OpcUa_P_RawSocket_GetLastError(OpcUa_RawSocket RawSocket);
+
+/*!
+ * @brief Create a system socket.
+ *
+ * @param pRawSocket    [out]   Pointer to a system socket to store the new one.
+ * @param NagleOff      [in]    Switch for Nagle algorithm.
+ * @param ReuseAddrOn   [in]    Switch for TCP address reuse.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_Create(  OpcUa_RawSocket* pRawSocket,
+                                            OpcUa_Boolean    NagleOff,
+                                            OpcUa_Boolean    ReuseAddrOn);
+
+/*!
+ * @brief Create a IPv6 system socket.
+ *
+ * @param pRawSocket    [out]   Pointer to a system socket to store the new one.
+ * @param NagleOff      [in]    Switch for Nagle algorithm.
+ * @param ReuseAddrOn   [in]    Switch for TCP address reuse.
+ * @param V6Only        [in]    Switch for V6 Only flag.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_CreateV6(  OpcUa_RawSocket* pRawSocket,
+                                              OpcUa_Boolean    NagleOff,
+                                              OpcUa_Boolean    ReuseAddrOn,
+                                              OpcUa_Boolean    V6Only);
+
+/*!
+ * @brief Create a socket pair.
+ *
+ * @param pRawSocketRead  [out]  Pointer to the read end of the pipe
+ * @param pRawSocketWrite [out]  Pointer to the write end of the pipe
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_RawSocket_CreateSocketPair(  OpcUa_RawSocket* pRawSocketRead,
+                                                      OpcUa_RawSocket* pRawSocketWrite);
+
+
+OpcUa_UInt32 OpcUa_P_RawSocket_InetAddr(    OpcUa_StringA   sRemoteAddress);
+
+#endif /* _OpcUa_P_Socket_H_ */

--- a/Stack/platforms/vxworks/opcua_p_socket_interface.c
+++ b/Stack/platforms/vxworks/opcua_p_socket_interface.c
@@ -1,0 +1,838 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+07nov18,lan  port to vxWorks.
+*/
+
+/* System Headers */
+#include <stdlib.h>
+#include <memory.h>
+#include <pthread.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+
+/* UA platform definitions */
+#include <opcua_datetime.h>
+
+#include <opcua_p_semaphore.h>
+#include <opcua_p_thread.h>
+#include <opcua_p_mutex.h>
+#include <opcua_p_utilities.h>
+#include <opcua_p_memory.h>
+
+/* own headers */
+#include <opcua_p_socket.h>
+#include <opcua_p_socket_internal.h>
+#include <opcua_p_socket_interface.h>
+
+extern int OpcUa_Stack_P_Priority;
+
+#if OPCUA_MULTITHREADED
+/*============================================================================
+ * This function serves a single socket manager in multithreading configuration.
+ *===========================================================================*/
+/* HINT: That is a thread entry point and wrapper for the real serverloop. */
+static
+OpcUa_Void OpcUa_P_SocketManager_ServerLoopThread(OpcUa_Void* a_pArgument)
+{
+    OpcUa_StatusCode                uStatus                 = OpcUa_Good;                   /* only needed for internal reasons */
+    OpcUa_InternalSocketManager*    pInternalSocketManager  = (OpcUa_InternalSocketManager*)a_pArgument;
+    OpcUa_Int32                     iSocketManagerSlot;
+
+    OpcUa_Trace(OPCUA_TRACE_LEVEL_INFO, "NetworkThread: Message Loop started...\n");
+
+    do
+    {
+        uStatus = OpcUa_P_SocketManager_ServeLoopInternal(  pInternalSocketManager,
+                                                            OpcUa_UInt32_Max,
+                                                            OpcUa_False);
+
+        if(OpcUa_IsEqual(OpcUa_GoodShutdownEvent))
+        {
+            /* leave this loop if a shutdown was signalled */
+            break;
+        }
+
+    } while(OpcUa_IsGood(uStatus));
+
+    /* Debug Output */
+    OpcUa_Trace(OPCUA_TRACE_LEVEL_INFO, "NetworkThread: Message Loop shutting down! (0x%08X)\n", uStatus);
+
+    if(pInternalSocketManager->Flags.bSpawnThreadOnAccept != 0)
+    {
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Lock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+        for(iSocketManagerSlot = 0; iSocketManagerSlot < OPCUA_SOCKET_MAXMANAGERS; iSocketManagerSlot++)
+        {
+            if(pInternalSocketManager->pSocketManagers[iSocketManagerSlot] != OpcUa_Null)
+            {
+                OpcUa_InternalSocketManager *pSpawnedSocketManager = pInternalSocketManager->pSocketManagers[iSocketManagerSlot];
+                pInternalSocketManager->pSocketManagers[iSocketManagerSlot] = OpcUa_Null;
+
+                pSpawnedSocketManager->pThreadToJoin  = pInternalSocketManager->pThreadToJoin;
+                pInternalSocketManager->pThreadToJoin = pSpawnedSocketManager->pThread;
+                pSpawnedSocketManager->pThread        = OpcUa_Null;
+
+                OpcUa_P_SocketManager_InterruptLoop(pSpawnedSocketManager,
+                                                    OPCUA_SOCKET_SHUTDOWN_EVENT,
+                                                    OpcUa_False);
+            }
+        }
+
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Unlock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+        if(pInternalSocketManager->pThreadToJoin != OpcUa_Null)
+        {
+            OpcUa_P_Thread_Delete(&pInternalSocketManager->pThreadToJoin);
+        }
+    }
+
+    return;
+}
+#else
+static OpcUa_SocketManager OpcUa_Socket_g_SocketManager = OpcUa_Null;
+#endif /* OPCUA_MULTITHREADED */
+
+
+/*============================================================================
+ * Create a new signal socket
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_SocketManager_NewSignalSocket(OpcUa_SocketManager a_pSocketManager)
+{
+    OpcUa_InternalSocket*           pIntSignalSocket = OpcUa_Null;
+    OpcUa_InternalSocketManager*    pInternalSocketManager      = (OpcUa_InternalSocketManager*)a_pSocketManager;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "NewSignalSocket");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocketManager);
+
+    pIntSignalSocket = (OpcUa_InternalSocket*)OpcUa_SocketManager_FindFreeSocket(a_pSocketManager, OpcUa_True);
+
+    if(pIntSignalSocket == OpcUa_Null)
+    {
+        uStatus = OpcUa_BadResourceUnavailable;
+        goto Error;
+    }
+
+    uStatus = OpcUa_P_RawSocket_CreateSocketPair( &pIntSignalSocket->rawSocket,
+                                                  &pInternalSocketManager->pCookie);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    pIntSignalSocket->Flags.EventMask =   OPCUA_SOCKET_CLOSE_EVENT
+                                        | OPCUA_SOCKET_READ_EVENT
+                                        | OPCUA_SOCKET_EXCEPT_EVENT
+                                        | OPCUA_SOCKET_TIMEOUT_EVENT;
+
+    uStatus = OpcUa_P_RawSocket_SetBlockMode (pIntSignalSocket->rawSocket, OpcUa_False);
+    if (OpcUa_IsBad(uStatus))
+    {
+        OpcUa_P_RawSocket_Close(pIntSignalSocket->rawSocket);
+        OpcUa_P_RawSocket_Close(pInternalSocketManager->pCookie);
+        OpcUa_GotoErrorWithStatus(uStatus);
+    }
+
+    uStatus = OpcUa_P_RawSocket_SetBlockMode (pInternalSocketManager->pCookie, OpcUa_False);
+    if (OpcUa_IsBad(uStatus))
+    {
+        OpcUa_P_RawSocket_Close(pIntSignalSocket->rawSocket);
+        OpcUa_P_RawSocket_Close(pInternalSocketManager->pCookie);
+        OpcUa_GotoErrorWithStatus(uStatus);
+    }
+
+    OPCUA_SOCKET_SETVALID(pIntSignalSocket);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pIntSignalSocket)
+    {
+        pIntSignalSocket->rawSocket = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+        OPCUA_SOCKET_INVALIDATE(pIntSignalSocket);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+
+/*============================================================================
+ * Break server loop(s) and issue event(s).
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_InterruptLoop( OpcUa_SocketManager a_pSocketManager,
+                                                                    OpcUa_UInt32        a_uEvent,
+                                                                    OpcUa_Boolean       a_bAllManagers)
+{
+    OpcUa_RawSocket                 pSignalSocket;
+    OpcUa_InternalSocketManager*    pInternalSocketManager;
+    unsigned char                   dummy[1] = {0};
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "InterruptLoop");
+
+    OpcUa_ReferenceParameter(a_bAllManagers);
+
+    if(a_uEvent == OPCUA_SOCKET_NO_EVENT)
+    {
+        return OpcUa_BadInternalError;
+    }
+
+    if(a_pSocketManager == OpcUa_Null)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    pInternalSocketManager = (OpcUa_InternalSocketManager*)a_pSocketManager;
+
+    pSignalSocket = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+
+#if OPCUA_MULTITHREADED
+
+    /* get exclusive access to the list */
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+
+    /************ core begin ************/
+    /* set event(s) */
+    if ((pInternalSocketManager->uintLastExternalEvent & a_uEvent) != a_uEvent)
+    {
+        pInternalSocketManager->uintLastExternalEvent |= a_uEvent;
+
+        /* get the signal socket, which is hidden as a cookie */
+        pSignalSocket = pInternalSocketManager->pCookie;
+    }
+
+    /************* core end *************/
+
+    /* release exclusive access to the list */
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    /* if there, send a dummy byte to break selects */
+    if(pSignalSocket != (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+    {
+        OpcUa_P_RawSocket_Write(pSignalSocket, dummy, sizeof(dummy));
+    }
+
+#endif /* OPCUA_MULTITHREADED */
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Call the main serve loop for a certain socket list.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_ServeLoop( OpcUa_SocketManager a_pSocketManager,
+                                                                OpcUa_UInt32        a_msecTimeout,
+                                                                OpcUa_Boolean       a_bRunOnce)
+{
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "ServeLoop");
+
+#if !OPCUA_MULTITHREADED
+    if(a_pSocketManager == OpcUa_Null)
+    {
+        a_pSocketManager = OpcUa_Socket_g_SocketManager;
+    }
+#endif
+
+    uStatus =  OpcUa_P_SocketManager_ServeLoopInternal( a_pSocketManager,
+                                                        a_msecTimeout,
+                                                        a_bRunOnce);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Create a new socket manager or initialize the global one (OpcUa_Null first).
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_Create(OpcUa_SocketManager*    a_pSocketManager,
+                                                            OpcUa_UInt32            a_nSockets,
+                                                            OpcUa_UInt32            a_nFlags)
+{
+    OpcUa_InternalSocketManager*    pInternalSocketManager   = OpcUa_Null;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SocketManager_Create");
+
+    if(a_nFlags & 0xFFFFFFF8)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    if(a_nSockets > OPCUA_P_SOCKETMANAGER_NUMBEROFSOCKETS)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    /* set number of socket to maximum */
+    if(a_nSockets == 0)
+    {
+        a_nSockets = OPCUA_P_SOCKETMANAGER_NUMBEROFSOCKETS;
+    }
+
+    a_nSockets += 1; /* add signal socket to requested sockets */
+
+#if !OPCUA_MULTITHREADED
+    if(a_pSocketManager == OpcUa_Null && OpcUa_Socket_g_SocketManager == OpcUa_Null)
+    {
+        a_pSocketManager = &OpcUa_Socket_g_SocketManager;
+    }
+#endif
+
+    if(a_pSocketManager == OpcUa_Null)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    *a_pSocketManager = OpcUa_SocketManager_Alloc();
+    OpcUa_GotoErrorIfAllocFailed(*a_pSocketManager);
+
+    pInternalSocketManager = (OpcUa_InternalSocketManager*)*a_pSocketManager;
+
+    OpcUa_SocketManager_Initialize(pInternalSocketManager);
+
+#if OPCUA_USE_SYNCHRONISATION
+    uStatus = OpcUa_P_Mutex_Create(&pInternalSocketManager->pMutex);
+    OpcUa_GotoErrorIfBad(uStatus);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    /* preallocate socket structures for all possible sockets (maxsockets) */
+    uStatus = OpcUa_SocketManager_CreateSockets((OpcUa_SocketManager)pInternalSocketManager, a_nSockets);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    pInternalSocketManager->uintLastExternalEvent  = OPCUA_SOCKET_NO_EVENT;
+
+    /* set the behaviour flags */
+    if((a_nFlags & OPCUA_SOCKET_SPAWN_THREAD_ON_ACCEPT)    != OPCUA_SOCKET_NO_FLAG)
+    {
+        pInternalSocketManager->Flags.bSpawnThreadOnAccept      = OpcUa_True;
+    }
+
+    if((a_nFlags & OPCUA_SOCKET_REJECT_ON_NO_THREAD)       != OPCUA_SOCKET_NO_FLAG)
+    {
+        pInternalSocketManager->Flags.bRejectOnThreadFail       = OpcUa_True;
+    }
+
+    if((a_nFlags & OPCUA_SOCKET_DONT_CLOSE_ON_EXCEPT)      != OPCUA_SOCKET_NO_FLAG)
+    {
+        pInternalSocketManager->Flags.bDontCloseOnExcept        = OpcUa_True;
+    }
+
+    uStatus = OpcUa_P_SocketManager_NewSignalSocket(pInternalSocketManager);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+#if OPCUA_MULTITHREADED
+    if (pInternalSocketManager->Flags.bSpawnThreadOnAccept)
+    {
+        /* create a semaphore with no free resources for which a host can wait to be signalled. */
+        uStatus = OpcUa_P_Semaphore_Create(&pInternalSocketManager->pStartupSemaphore, 0, 1);
+        OpcUa_GotoErrorIfBad(uStatus);
+
+        pInternalSocketManager->pSocketManagers = OpcUa_P_Memory_Alloc(sizeof(OpcUa_InternalSocketManager*) * OPCUA_SOCKET_MAXMANAGERS);
+        OpcUa_GotoErrorIfAllocFailed(pInternalSocketManager->pSocketManagers);
+        OpcUa_MemSet(pInternalSocketManager->pSocketManagers, 0, sizeof(OpcUa_InternalSocketManager*) * OPCUA_SOCKET_MAXMANAGERS);
+    }
+
+    /* if multithreaded, create and start the server thread if the list is not the global list. */
+    uStatus = OpcUa_P_Thread_Create(&pInternalSocketManager->pThread); /* make raw thread */
+    OpcUa_GotoErrorIfBad(uStatus);
+    (void) OpcUa_P_Thread_SetAttribute (pInternalSocketManager->pThread,
+    		                            "tUaStackM", OpcUa_Stack_P_Priority, 
+                                        1024*10);
+    uStatus = OpcUa_P_Thread_Start( pInternalSocketManager->pThread,
+                                    OpcUa_P_SocketManager_ServerLoopThread,
+                                    (OpcUa_Void*)pInternalSocketManager);
+    OpcUa_GotoErrorIfBad(uStatus);
+#endif /* OPCUA_MULTITHREADED */
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pInternalSocketManager != OpcUa_Null)
+    {
+#if OPCUA_MULTITHREADED
+        if(pInternalSocketManager->pThread != OpcUa_Null)
+        {
+            OpcUa_P_Thread_Delete(&pInternalSocketManager->pThread);
+        }
+        if(pInternalSocketManager->pSocketManagers != OpcUa_Null)
+        {
+            OpcUa_P_Memory_Free(pInternalSocketManager->pSocketManagers);
+        }
+        if(pInternalSocketManager->pStartupSemaphore != OpcUa_Null)
+        {
+            OpcUa_P_Semaphore_Delete(&pInternalSocketManager->pStartupSemaphore);
+        }
+#endif /* OPCUA_MULTITHREADED */
+        if(pInternalSocketManager->pCookie != (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+        {
+            OpcUa_P_RawSocket_Close(pInternalSocketManager->pCookie);
+        }
+        if(pInternalSocketManager->pSockets != OpcUa_Null)
+        {
+            if(pInternalSocketManager->pSockets[0].rawSocket != (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+            {
+                OpcUa_P_RawSocket_Close(pInternalSocketManager->pSockets[0].rawSocket);
+            }
+            OpcUa_P_Memory_Free(pInternalSocketManager->pSockets);
+        }
+#if OPCUA_USE_SYNCHRONISATION
+        if(pInternalSocketManager->pMutex != OpcUa_Null)
+        {
+            OpcUa_P_Mutex_Delete(&pInternalSocketManager->pMutex);
+        }
+#endif /* OPCUA_USE_SYNCHRONISATION */
+        OpcUa_P_Memory_Free(pInternalSocketManager);
+    }
+
+    *a_pSocketManager = OpcUa_Null;
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Delete SocketManager Type (closes all sockets)
+ *===========================================================================*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_SocketManager_Delete(OpcUa_SocketManager* a_pSocketManager)
+{
+    OpcUa_InternalSocketManager* pInternalSocketManager = OpcUa_Null;
+    OpcUa_UInt32                 uintIndex              = 0;
+
+#if !OPCUA_MULTITHREADED
+    if(a_pSocketManager == OpcUa_Null && OpcUa_Socket_g_SocketManager != OpcUa_Null)
+    {
+        a_pSocketManager = &OpcUa_Socket_g_SocketManager;
+    }
+#endif
+
+    if(a_pSocketManager == OpcUa_Null || *a_pSocketManager == OpcUa_Null)
+    {
+        OpcUa_Trace(OPCUA_TRACE_LEVEL_ERROR, "OpcUa_SocketManager_Delete: Invalid Socket Manager!\n");
+        return;
+    }
+
+    pInternalSocketManager = (OpcUa_InternalSocketManager*)*a_pSocketManager;
+
+    /* send shutdown event to serveloop */
+    OpcUa_P_SocketManager_InterruptLoop(pInternalSocketManager, OPCUA_SOCKET_SHUTDOWN_EVENT, OpcUa_False);
+
+#if OPCUA_MULTITHREADED
+    if(pInternalSocketManager->pThread != OpcUa_Null)
+    {
+        OpcUa_P_Thread_Delete(&(pInternalSocketManager->pThread));
+    }
+    else
+    {
+        OpcUa_Trace(OPCUA_TRACE_LEVEL_ERROR, "OpcUa_SocketManager_Delete: Invalid Thread Handle!\n");
+        return;
+    }
+#endif /* OPCUA_MULTITHREADED */
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    /* handle the socket list content (close, cleanup, etc.) */
+    if(pInternalSocketManager->pSockets != OpcUa_Null)
+    {
+        for(uintIndex = 0; uintIndex < pInternalSocketManager->uintMaxSockets; uintIndex++)
+        {
+            OpcUa_Socket pSocketTemp = &(pInternalSocketManager->pSockets[uintIndex]);
+
+            if(   (pInternalSocketManager->pSockets[uintIndex].bSocketIsInUse != OpcUa_False)
+               && (pInternalSocketManager->pSockets[uintIndex].bInvalidSocket == OpcUa_False))
+            {
+                OpcUa_Socket_HandleEvent(pSocketTemp, OPCUA_SOCKET_CLOSE_EVENT);
+                OpcUa_P_RawSocket_Close(pInternalSocketManager->pSockets[uintIndex].rawSocket);
+            }
+
+            OpcUa_Socket_Clear(pSocketTemp);
+        }
+
+        OpcUa_P_Memory_Free(pInternalSocketManager->pSockets);
+    } /* if(pInternalSocketManager->pSockets != OpcUa_Null) */
+
+    OpcUa_P_RawSocket_Close(pInternalSocketManager->pCookie);
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocketManager->pMutex);
+    OpcUa_P_Mutex_Delete(&pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+#if OPCUA_MULTITHREADED
+    if(pInternalSocketManager->pStartupSemaphore != OpcUa_Null)
+    {
+        OpcUa_P_Semaphore_Delete(&pInternalSocketManager->pStartupSemaphore);
+    }
+    if(pInternalSocketManager->pSocketManagers != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(pInternalSocketManager->pSocketManagers);
+    }
+#endif
+
+    OpcUa_P_Memory_Free(*a_pSocketManager);
+    *a_pSocketManager = OpcUa_Null;
+
+    return;
+}
+
+/*============================================================================
+ * Initialize the platform network interface
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_InitializeNetwork(OpcUa_Void)
+{
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "InitializeNetwork");
+
+    uStatus = OpcUa_P_RawSocket_InitializeNetwork();
+    OpcUa_GotoErrorIfBad(uStatus);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    /* cleanup everything */
+    OpcUa_P_Socket_CleanupNetwork();
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Clean the platform network interface up.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_CleanupNetwork(OpcUa_Void)
+{
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "CleanupNetwork");
+
+    /* cleanup platform networking */
+    uStatus = OpcUa_P_RawSocket_CleanupNetwork();
+    OpcUa_GotoErrorIfBad(uStatus);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Create a server socket
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_CreateServer(  OpcUa_SocketManager         a_pSocketManager,
+                                                                    OpcUa_StringA               a_sAddress,
+                                                                    OpcUa_Boolean               a_bListenOnAllInterfaces,
+                                                                    OpcUa_Socket_EventCallback  a_pfnSocketCallBack,
+                                                                    OpcUa_Void*                 a_pCallbackData,
+                                                                    OpcUa_Socket*               a_pSocket)
+{
+    OpcUa_InternalSocketManager*    pInternalSocketManager  = OpcUa_Null;
+    OpcUa_UInt16                    uPort                   = 0;
+    OpcUa_StringA                   sRemoteAdress           = OpcUa_Null;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "CreateServer");
+
+#if !OPCUA_MULTITHREADED
+    if(a_pSocketManager == OpcUa_Null)
+    {
+        a_pSocketManager = OpcUa_Socket_g_SocketManager;
+    }
+#endif
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSocketManager);
+    OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+
+    pInternalSocketManager = (OpcUa_InternalSocketManager*)a_pSocketManager;
+
+    /* parse address */
+    uStatus = OpcUa_P_ParseUrl( a_sAddress,
+                                &sRemoteAdress,
+                                &uPort);
+
+    OpcUa_ReturnErrorIfBad(uStatus);
+    if(a_bListenOnAllInterfaces)
+    {
+        if(sRemoteAdress != OpcUa_Null)
+        {
+            OpcUa_P_Memory_Free(sRemoteAdress);
+            sRemoteAdress = OpcUa_Null;
+        }
+    }
+
+    uStatus = OpcUa_SocketManager_InternalCreateServer( pInternalSocketManager,
+                                                        sRemoteAdress,
+                                                        uPort,
+                                                        a_pfnSocketCallBack,
+                                                        a_pCallbackData,
+                                                        a_pSocket);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+
+    OpcUa_P_SocketManager_InterruptLoop(pInternalSocketManager,
+                                        OPCUA_SOCKET_RENEWLOOP_EVENT,
+                                        OpcUa_False);
+
+    if(sRemoteAdress != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(sRemoteAdress);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(sRemoteAdress != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(sRemoteAdress);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Create a client socket
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_CreateClient(  OpcUa_SocketManager         a_hSocketManager,
+                                                                    OpcUa_StringA               a_sRemoteAddress,
+                                                                    OpcUa_UInt16                a_uLocalPort,
+                                                                    OpcUa_Socket_EventCallback  a_pfnSocketCallBack,
+                                                                    OpcUa_Void*                 a_pCallbackData,
+                                                                    OpcUa_Socket*               a_pSocket)
+{
+    OpcUa_InternalSocket*        pNewClientSocket       = OpcUa_Null;
+    OpcUa_InternalSocketManager* pInternalSocketManager = OpcUa_Null;
+    OpcUa_UInt16                 uPort                  = 0;
+    OpcUa_StringA                sRemoteAdress          = OpcUa_Null;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "CreateClient");
+
+#if !OPCUA_MULTITHREADED
+    if(a_hSocketManager == OpcUa_Null)
+    {
+        a_hSocketManager = OpcUa_Socket_g_SocketManager;
+    }
+#endif
+
+    OpcUa_ReturnErrorIfArgumentNull(a_hSocketManager);
+    OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+    OpcUa_ReturnErrorIfArgumentNull(a_sRemoteAddress);
+
+    /* parse address */
+    uStatus = OpcUa_P_ParseUrl( a_sRemoteAddress,
+                                &sRemoteAdress,
+                                &uPort);
+    OpcUa_ReturnErrorIfBad(uStatus);
+
+    pInternalSocketManager = (OpcUa_InternalSocketManager*)a_hSocketManager;
+
+    pNewClientSocket = (OpcUa_InternalSocket*)OpcUa_SocketManager_FindFreeSocket(   (OpcUa_SocketManager)pInternalSocketManager,
+                                                                                    OpcUa_False);
+    if (pNewClientSocket == OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(sRemoteAdress);
+        uStatus = OpcUa_BadMaxConnectionsReached; /* no socket left in the list. */
+        goto Error;
+    }
+
+    /* Create client socket. */
+    pNewClientSocket->rawSocket = OpcUa_P_Socket_CreateClient(  a_uLocalPort,
+                                                                uPort,
+                                                                sRemoteAdress,
+                                                                &uStatus);
+
+    OpcUa_P_Memory_Free(sRemoteAdress);
+
+    OpcUa_GotoErrorIfTrue(  pNewClientSocket->rawSocket == (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID,
+                            OpcUa_BadCommunicationError);
+
+    pNewClientSocket->pfnEventCallback       = a_pfnSocketCallBack;
+    pNewClientSocket->pvUserData             = a_pCallbackData;
+    pNewClientSocket->Flags.bOwnThread       = OpcUa_False;
+    pNewClientSocket->Flags.EventMask        = OPCUA_SOCKET_READ_EVENT
+                                             | OPCUA_SOCKET_EXCEPT_EVENT
+                                             | OPCUA_SOCKET_CONNECT_EVENT
+                                             | OPCUA_SOCKET_TIMEOUT_EVENT;
+
+    /* return the new client socket */
+    *a_pSocket = pNewClientSocket;
+
+    OPCUA_SOCKET_SETVALID(pNewClientSocket);
+
+    /* break loop to add new socket into eventing */
+    uStatus = OpcUa_P_SocketManager_InterruptLoop(  a_hSocketManager,
+                                                    OPCUA_SOCKET_RENEWLOOP_EVENT,
+                                                    OpcUa_False);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(pNewClientSocket != OpcUa_Null)
+    {
+        if(pNewClientSocket->rawSocket != (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+        {
+            OpcUa_P_RawSocket_Close(pNewClientSocket->rawSocket);
+            pNewClientSocket->rawSocket = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+        }
+        OPCUA_SOCKET_INVALIDATE(pNewClientSocket);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Get last socket error
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_GetLastError(OpcUa_Socket a_pSocket)
+{
+    OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+
+    return (*ppSocketServiceTable)->SocketGetLastError(a_pSocket);
+}
+
+/*============================================================================
+ * Signal a certain event on a socket.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_SignalEvent(   OpcUa_SocketManager     a_pSocketManager,
+                                                                    OpcUa_UInt32            a_uEvent,
+                                                                    OpcUa_Boolean           a_bAllManagers)
+{
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SignalEvent");
+
+    uStatus = OpcUa_P_SocketManager_InterruptLoop(a_pSocketManager, a_uEvent, a_bAllManagers);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Read Socket.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_Read( OpcUa_Socket    a_pSocket,
+                                                    OpcUa_Byte*     a_pBuffer,
+                                                    OpcUa_UInt32    a_nBufferSize,
+                                                    OpcUa_UInt32*   a_pBytesRead)
+{
+    OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+
+    return (*ppSocketServiceTable)->SocketRead(a_pSocket, a_pBuffer, a_nBufferSize, a_pBytesRead);
+}
+
+/*============================================================================
+ * Write Socket.
+ *===========================================================================*/
+/* returns number of bytes written to the socket */
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_Socket_Write( OpcUa_Socket    a_pSocket,
+                                                OpcUa_Byte*     a_pBuffer,
+                                                OpcUa_UInt32    a_uBufferSize,
+                                                OpcUa_Boolean   a_bBlock)
+{
+    OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+
+    return (*ppSocketServiceTable)->SocketWrite(a_pSocket, a_pBuffer, a_uBufferSize, a_bBlock);
+}
+
+/*============================================================================
+ * Close Socket.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_Close(OpcUa_Socket a_pSocket)
+{
+    OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+
+    return (*ppSocketServiceTable)->SocketClose(a_pSocket);
+}
+
+/*============================================================================
+ * Get IP Address and Port Number of the Peer
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_GetPeerInfo(  OpcUa_Socket a_pSocket,
+                                                            OpcUa_CharA* a_achPeerInfoBuffer,
+                                                            OpcUa_UInt32 a_uiPeerInfoBufferSize)
+{
+    OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+
+    return (*ppSocketServiceTable)->SocketGetPeerInfo(a_pSocket, a_achPeerInfoBuffer, a_uiPeerInfoBufferSize);
+}
+
+/*============================================================================
+ * Convert OpcUa_StringA into binary ip address
+ *===========================================================================*/
+OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_Socket_InetAddr(OpcUa_StringA a_sRemoteAddress)
+{
+    return OpcUa_P_RawSocket_InetAddr(a_sRemoteAddress);
+}
+
+/*============================================================================
+ * Get the name of the local host.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_GetHostName( OpcUa_CharA* a_pBuffer,
+                                                           OpcUa_UInt32 a_uiBufferLength)
+{
+    int iRet = gethostname( (char*)a_pBuffer,
+                            (int)a_uiBufferLength);
+
+    return (iRet==0)?OpcUa_Good:OpcUa_Bad;
+}
+
+/*============================================================================
+ * Set socket user data
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_SetUserData( OpcUa_Socket a_pSocket,
+                                                           OpcUa_Void*  a_pvUserData)
+{
+    OpcUa_SocketServiceTable** ppSocketServiceTable = (OpcUa_SocketServiceTable**)a_pSocket;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pSocket);
+
+    return (*ppSocketServiceTable)->SocketSetUserData(a_pSocket, a_pvUserData);
+
+}

--- a/Stack/platforms/vxworks/opcua_p_socket_interface.h
+++ b/Stack/platforms/vxworks/opcua_p_socket_interface.h
@@ -1,0 +1,155 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_Socket_Interface_H_
+#define _OpcUa_Socket_Interface_H_ 1
+
+OPCUA_BEGIN_EXTERN_C
+
+/*============================================================================
+ * Create a new socket manager or initialize the global one (OpcUa_Null first).
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_Create(        OpcUa_SocketManager*    pSocketManager,
+                                                                    OpcUa_UInt32            nSockets,
+                                                                    OpcUa_UInt32            nFlags);
+
+/*============================================================================
+ *
+ *===========================================================================*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_SocketManager_Delete(              OpcUa_SocketManager*    pSocketManager);
+
+/*============================================================================
+ * Create a server socket
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_CreateServer(  OpcUa_SocketManager         pSocketManager,
+                                                                    OpcUa_StringA               sAddress,
+                                                                    OpcUa_Boolean               bListenOnAllInterfaces,
+                                                                    OpcUa_Socket_EventCallback  pfnSocketCallBack,
+                                                                    OpcUa_Void*                 pCallbackData,
+                                                                    OpcUa_Socket*               pSocket);
+
+/*============================================================================
+ * Create a client socket
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_CreateClient(  OpcUa_SocketManager         pSocketManager,
+                                                                    OpcUa_StringA               sRemoteAddress,
+                                                                    OpcUa_UInt16                uLocalPort,
+                                                                    OpcUa_Socket_EventCallback  pfnSocketCallBack,
+                                                                    OpcUa_Void*                 pCallbackData,
+                                                                    OpcUa_Socket*               pSocket);
+
+/*============================================================================
+ * Signal a certain event on a socket.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_SignalEvent(   OpcUa_SocketManager pSocketManager,
+                                                                    OpcUa_UInt32        uEvent,
+                                                                    OpcUa_Boolean       bAllManagers);
+
+/*============================================================================
+ *
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_ServeLoop(     OpcUa_SocketManager     pSocketManager,
+                                                                    OpcUa_UInt32            msecTimeout,
+                                                                    OpcUa_Boolean           bRunOnce);
+
+/*============================================================================
+ * Create a new signal socket
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_SocketManager_NewSignalSocket(OpcUa_SocketManager a_pSocketManager);
+
+/*============================================================================
+ * Break server loop(s) and issue event(s).
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_InterruptLoop( OpcUa_SocketManager pSocketManager,
+                                                                    OpcUa_UInt32        uEvent,
+                                                                    OpcUa_Boolean       bAllManagers);
+
+/*============================================================================
+ * Get last socket error
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_GetLastError(         OpcUa_Socket    pSocket);
+
+/*============================================================================
+ * Read Socket.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_Read(                 OpcUa_Socket    pSocket,
+                                                                    OpcUa_Byte*     pBuffer,
+                                                                    OpcUa_UInt32    nBufferSize,
+                                                                    OpcUa_UInt32*   pBytesRead);
+
+/*============================================================================
+ * Write Socket.
+ *===========================================================================*/
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_Socket_Write(                     OpcUa_Socket    pSocket,
+                                                                    OpcUa_Byte*     pBuffer,
+                                                                    OpcUa_UInt32    uBufferSize,
+                                                                    OpcUa_Boolean   bBlock);
+
+/*============================================================================
+ * Close Socket.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_Close(                OpcUa_Socket pSocket);
+
+/*============================================================================
+ * Get IP Address and Port Number of the Peer
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_GetPeerInfo(          OpcUa_Socket pSocket,
+                                                                    OpcUa_CharA* a_achPeerInfoBuffer,
+                                                                    OpcUa_UInt32 a_uiPeerInfoBufferSize);
+
+/*============================================================================
+ * Initialize the platform network interface
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_InitializeNetwork(    void);
+
+/*============================================================================
+ * Clean the platform network interface up.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_CleanupNetwork(       void);
+
+/*============================================================================
+ * Convert a text encoded internet address to its binary representation.
+ *===========================================================================*/
+OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_Socket_InetAddr(                 OpcUa_StringA sRemoteAddress);
+
+/*============================================================================
+ * Get the name of the local host.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_GetHostName(          OpcUa_CharA* pBuffer,
+                                                                    OpcUa_UInt32 uiBufferLength);
+
+/*============================================================================
+ * Set socket user data
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Socket_SetUserData(          OpcUa_Socket pSocket,
+                                                                    OpcUa_Void*  pvUserData);
+
+OPCUA_END_EXTERN_C
+
+#endif /* _OpcUa_Socket_Interface_H_ */

--- a/Stack/platforms/vxworks/opcua_p_socket_internal.c
+++ b/Stack/platforms/vxworks/opcua_p_socket_internal.c
@@ -1,0 +1,1556 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* System Headers */
+#include <stdlib.h>
+#include <memory.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <errno.h>
+#include <unistd.h>
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+
+/* additional UA dependencies */
+#include <opcua_datetime.h>
+
+/* platform layer includes */
+#include <opcua_p_thread.h>
+#include <opcua_p_mutex.h>
+#include <opcua_p_semaphore.h>
+#include <opcua_p_utilities.h>
+
+/* own headers */
+#include <opcua_p_socket.h>
+#include <opcua_p_memory.h>
+#include <opcua_p_socket_internal.h>
+#include <opcua_p_socket_interface.h>
+
+/* platform layer includes */
+#include <opcua_p_timer.h> /* for timered select */
+
+
+/*============================================================================
+ * Read Socket.
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_P_SocketService_Read( OpcUa_Socket    a_pSocket,
+                                                    OpcUa_Byte*     a_pBuffer,
+                                                    OpcUa_UInt32    a_nBufferSize,
+                                                    OpcUa_UInt32*   a_pBytesRead)
+{
+    OpcUa_Int32 result = 0;
+    OpcUa_InternalSocket*   pInternalSocket     = (OpcUa_InternalSocket*)a_pSocket;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "Read");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+    OpcUa_GotoErrorIfArgumentNull(a_pBuffer);
+    OpcUa_GotoErrorIfArgumentNull(a_pBytesRead);
+
+    if(!(pInternalSocket->Flags.EventMask & OPCUA_SOCKET_READ_EVENT))
+    {
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Lock(pInternalSocket->pSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+        pInternalSocket->Flags.EventMask |= OPCUA_SOCKET_READ_EVENT;
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Unlock(pInternalSocket->pSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+    }
+
+    /* returns the number of bytes received or 0 or a negative value in case of disconnect or error. */
+    result = OpcUa_P_RawSocket_Read(    pInternalSocket->rawSocket,
+                                        a_pBuffer,
+                                        a_nBufferSize);
+
+    /* decide if the result is an error or the number of bytes read. */
+    if(result > 0)
+    {
+        *a_pBytesRead = (OpcUa_UInt32)result;
+    }
+    else /* result <=0 (error or disconnect) */
+    {
+        *a_pBytesRead = 0;
+
+        if(result == 0)
+        {
+            uStatus = OpcUa_BadDisconnect;
+        }
+        else
+        {
+            OpcUa_Int32 uLastError = OpcUa_P_RawSocket_GetLastError(pInternalSocket->rawSocket);
+
+            switch(uLastError)
+            {
+            case EWOULDBLOCK:
+                {
+                    /* this needs to be set specific because some */
+                    /* callers might want to ignore this error    */
+                    uStatus = OpcUa_BadWouldBlock;
+                    break;
+                }
+            case ECONNABORTED:
+            case ECONNRESET:
+                {
+                    uStatus = OpcUa_BadDisconnect;
+                    break;
+                }
+            default:
+                {
+                    uStatus = OpcUa_BadCommunicationError;
+                    break;
+                }
+            }
+        }
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Write Socket.
+ *===========================================================================*/
+/* returns number of bytes written to the socket */
+static OpcUa_Int32 OpcUa_P_SocketService_Write( OpcUa_Socket    a_pSocket,
+                                                OpcUa_Byte*     a_pBuffer,
+                                                OpcUa_UInt32    a_uBufferSize,
+                                                OpcUa_Boolean   a_bBlock)
+{
+    OpcUa_Int32             result;
+    OpcUa_Int32             intError;
+    OpcUa_Byte*             pBuffer             = a_pBuffer;
+    OpcUa_UInt32            RemainingBufferSize = a_uBufferSize;
+    OpcUa_InternalSocket*   pInternalSocket     = (OpcUa_InternalSocket*)a_pSocket;
+    OpcUa_RawSocket         hRawSocket;
+
+    /* check for errors */
+    OpcUa_ReturnErrorIfNull(a_pSocket, OPCUA_SOCKET_ERROR);
+    OpcUa_ReturnErrorIfNull(a_pBuffer, OPCUA_SOCKET_ERROR);
+
+    if(a_bBlock != OpcUa_False)
+    {
+        OpcUa_Trace(OPCUA_TRACE_LEVEL_ERROR, "OpcUa_P_Socket_Write: Blocking write not supported.\n");
+        return OPCUA_SOCKET_ERROR;
+    }
+
+    if(a_uBufferSize == 0)
+    {
+        return OPCUA_SOCKET_ERROR;
+    }
+
+    if(     pInternalSocket->bSocketIsInUse == OpcUa_False
+        ||  pInternalSocket->bInvalidSocket != OpcUa_False)
+    {
+        return OPCUA_SOCKET_ERROR;
+    }
+
+    hRawSocket = pInternalSocket->rawSocket;
+
+    /* send loop */
+    do /* while no error and not all send */
+    {
+        /* send data */
+        result = OpcUa_P_RawSocket_Write(   hRawSocket,
+                                            pBuffer,
+                                            RemainingBufferSize);
+
+        /* special treatment for wouldblock */
+        if(result == OPCUA_P_SOCKET_SOCKETERROR)
+        {
+            intError = OpcUa_P_RawSocket_GetLastError(hRawSocket);
+
+            if(intError != EWOULDBLOCK)
+            {
+                /* error, but no wouldblock */
+                return OPCUA_SOCKET_ERROR;
+            }
+        }
+        else if (result == 0)
+        {
+            return OPCUA_SOCKET_ERROR; /* closed socket? */
+        }
+        else /* no error */
+        {
+            /* update data size */
+            RemainingBufferSize = RemainingBufferSize - result;
+
+            /* move data pointer */
+            pBuffer = pBuffer + result;
+        }
+    }
+    while((RemainingBufferSize > 0) && (result > 0)); /* loop until all data sent or error occurred */
+
+    /* update size before returning */
+    result = a_uBufferSize - RemainingBufferSize;
+
+    /* give the application a callback as soon as more tcp bytes can be sent */
+    if(     (RemainingBufferSize > 0)
+        && !(pInternalSocket->Flags.EventMask & OPCUA_SOCKET_WRITE_EVENT))
+    {
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Lock(pInternalSocket->pSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+        pInternalSocket->Flags.EventMask |= OPCUA_SOCKET_WRITE_EVENT;
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Unlock(pInternalSocket->pSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+#if OPCUA_MULTITHREADED
+        if(pInternalSocket->Flags.bFromApplication == OpcUa_False)
+        {
+            OpcUa_P_SocketManager_InterruptLoop(    pInternalSocket->pSocketManager,
+                                                    OPCUA_SOCKET_RENEWLOOP_EVENT,
+                                                    OpcUa_False);
+        }
+#endif /* OPCUA_MULTITHREADED */
+    }
+
+    return result;
+}
+
+/*============================================================================
+ * Close Socket.
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_P_SocketService_Close(OpcUa_Socket a_pSocket)
+{
+    OpcUa_InternalSocket* pInternalSocket = (OpcUa_InternalSocket*)a_pSocket;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "Close");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+
+    if(     pInternalSocket->bSocketIsInUse == OpcUa_False
+        ||  pInternalSocket->bInvalidSocket != OpcUa_False)
+    {
+        return OpcUa_Bad;
+    }
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(pInternalSocket->pSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    if(pInternalSocket->Flags.bClosedSocket != OpcUa_False)
+    {
+        /* caller tried to close an invalid socket, what may happen intentionally... */
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Unlock(pInternalSocket->pSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+        return OpcUa_Bad;
+    }
+
+    pInternalSocket->Flags.bClosedSocket = OpcUa_True;
+
+    OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_P_Socket_Close: Shutting down socket %p!\n", a_pSocket);
+    uStatus = OpcUa_P_RawSocket_Shutdown(pInternalSocket->rawSocket, OPCUA_P_SOCKET_SD_BOTH);
+
+#if OPCUA_MULTITHREADED
+    /* the if this is a client connection in a own thread, the loop should be notified to shut down */
+    if(pInternalSocket->Flags.bOwnThread != 0)
+    {
+        OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_P_Socket_Close: Notifying SocketManager to shut down ... \n");
+        OpcUa_P_SocketManager_InterruptLoop(    pInternalSocket->pSocketManager,
+                                                OPCUA_SOCKET_SHUTDOWN_EVENT,
+                                                OpcUa_False);
+    }
+#endif /* OPCUA_MULTITHREADED */
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocket->pSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Get IP Address and Port Number of the Peer
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_P_SocketService_GetPeerInfo(  OpcUa_Socket  a_pSocket,
+                                                            OpcUa_CharA*  a_achPeerInfoBuffer,
+                                                            OpcUa_UInt32  a_uiPeerInfoBufferSize)
+{
+    OpcUa_InternalSocket* pInternalSocket = (OpcUa_InternalSocket*)a_pSocket;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "GetPeerInfo");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+    OpcUa_GotoErrorIfArgumentNull(a_achPeerInfoBuffer);
+
+    a_achPeerInfoBuffer[0] = 0;
+    uStatus = OpcUa_P_RawSocket_GetPeerInfo((OpcUa_RawSocket)pInternalSocket->rawSocket, a_achPeerInfoBuffer, a_uiPeerInfoBufferSize);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Get last socket error
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_P_SocketService_GetLastError(OpcUa_Socket a_pSocket)
+{
+    OpcUa_InternalSocket*   pInternalSocket = (OpcUa_InternalSocket*)a_pSocket;
+    OpcUa_Int32             iLastError;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "GetLastError");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+    OpcUa_GotoErrorIfTrue(pInternalSocket->rawSocket == OPCUA_P_SOCKET_INVALID,
+                          OpcUa_BadCommunicationError);
+
+    iLastError = OpcUa_P_RawSocket_GetLastError(pInternalSocket->rawSocket);
+
+    if(iLastError != 0)
+    {
+        /* TODO: Map errorcodes. */
+        switch(iLastError)
+        {
+        case EWOULDBLOCK:
+        case EINPROGRESS:
+            {
+                uStatus = OpcUa_BadWouldBlock;
+                break;
+            }
+        case ECONNABORTED:
+        case ECONNRESET:
+            {
+                uStatus = OpcUa_BadDisconnect;
+                break;
+            }
+        default:
+            {
+                OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "OpcUa_P_Socket_GetLastError: Error 0x%08X\n", iLastError);
+                uStatus = OpcUa_BadCommunicationError;
+            }
+        }
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Set socket user data
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_P_SocketService_SetUserData(OpcUa_Socket a_pSocket,
+                                                          OpcUa_Void*  a_pvUserData)
+{
+    OpcUa_InternalSocket*   pInternalSocket = (OpcUa_InternalSocket*)a_pSocket;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SetUserData");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+
+    pInternalSocket->pvUserData = a_pvUserData;
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Initialize Socket Service Table
+ *===========================================================================*/
+static OpcUa_SocketServiceTable OpcUa_RawSocketServiceTable =
+{
+  OpcUa_P_SocketService_Read,
+  OpcUa_P_SocketService_Write,
+  OpcUa_P_SocketService_Close,
+  OpcUa_P_SocketService_GetPeerInfo,
+  OpcUa_P_SocketService_GetLastError,
+  OpcUa_P_SocketService_SetUserData
+};
+
+/*============================================================================
+ * Initialize Socket Type
+ *===========================================================================*/
+OpcUa_Void OpcUa_Socket_Initialize(OpcUa_Socket a_pSocket)
+{
+    OpcUa_InternalSocket* pInternalSocket = OpcUa_Null;
+
+    if(a_pSocket == OpcUa_Null)
+    {
+        return;
+    }
+
+    pInternalSocket = (OpcUa_InternalSocket*)a_pSocket;
+
+    pInternalSocket->pSocketServiceTable = &OpcUa_RawSocketServiceTable;
+
+    pInternalSocket->bSocketIsInUse = OpcUa_False;
+
+    pInternalSocket->rawSocket = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+}
+
+/*============================================================================
+ * Clear Socket Type
+ *===========================================================================*/
+OpcUa_Void OpcUa_Socket_Clear(OpcUa_Socket a_pSocket)
+{
+    OpcUa_InternalSocket* pInternalSocket = OpcUa_Null;
+
+    if(a_pSocket == OpcUa_Null)
+    {
+        OpcUa_Trace(OPCUA_TRACE_LEVEL_ERROR, "OpcUa_Socket_Clear: Invalid handle!\n");
+        return;
+    }
+
+    pInternalSocket = (OpcUa_InternalSocket*)a_pSocket;
+
+    pInternalSocket->bSocketIsInUse = OpcUa_False;
+
+    pInternalSocket->rawSocket = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+}
+
+/*============================================================================
+ * Allocate SocketManager Type
+ *===========================================================================*/
+OpcUa_SocketManager OpcUa_SocketManager_Alloc(OpcUa_Void)
+{
+    OpcUa_InternalSocketManager*    pInternalSocketManager  = OpcUa_Null;
+
+    pInternalSocketManager = (OpcUa_InternalSocketManager*)OpcUa_P_Memory_Alloc(sizeof(OpcUa_InternalSocketManager));
+
+    if(pInternalSocketManager == OpcUa_Null)
+    {
+        return OpcUa_Null;
+    }
+
+    return (OpcUa_SocketManager)pInternalSocketManager;
+}
+
+/*============================================================================
+ * Initialize SocketManager Type
+ *===========================================================================*/
+OpcUa_Void OpcUa_SocketManager_Initialize(OpcUa_SocketManager a_pSocketManager)
+{
+    OpcUa_InternalSocketManager* pInternalSocketManager = OpcUa_Null;
+
+    if(a_pSocketManager == OpcUa_Null)
+    {
+        return;
+    }
+
+    OpcUa_MemSet(a_pSocketManager, 0, sizeof(OpcUa_InternalSocketManager));
+
+    pInternalSocketManager = (OpcUa_InternalSocketManager*)a_pSocketManager;
+
+    pInternalSocketManager->pSockets                = OpcUa_Null;
+    pInternalSocketManager->uintMaxSockets          = 0;
+    pInternalSocketManager->pCookie                 = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+    pInternalSocketManager->uintLastExternalEvent   = OPCUA_SOCKET_NO_EVENT;
+}
+
+/*============================================================================
+ * Create the Sockets in the List
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_SocketManager_CreateSockets(
+    OpcUa_SocketManager a_pSocketManager,
+    OpcUa_UInt32        a_uMaxSockets)
+{
+    OpcUa_UInt32                 ntemp                  = 0;
+    OpcUa_InternalSocketManager* pInternalSocketManager = OpcUa_Null;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "CreateSockets");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocketManager);
+
+    pInternalSocketManager = (OpcUa_InternalSocketManager*)a_pSocketManager;
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    pInternalSocketManager->pSockets = (OpcUa_InternalSocket *)OpcUa_P_Memory_Alloc(sizeof(OpcUa_InternalSocket) * a_uMaxSockets);
+    OpcUa_GotoErrorIfAllocFailed(pInternalSocketManager->pSockets);
+
+    /* initialize the whole socket list with zero */
+    OpcUa_MemSet(pInternalSocketManager->pSockets, 0, sizeof(OpcUa_InternalSocket) * a_uMaxSockets);
+
+    for(ntemp = 0; ntemp < a_uMaxSockets; ntemp++)
+    {
+        OpcUa_Socket_Initialize(&(pInternalSocketManager->pSockets[ntemp]));
+    }
+
+    pInternalSocketManager->uintMaxSockets = a_uMaxSockets;
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/************************* Internal Helper Functions *************************/
+
+/*============================================================================
+ * Internal helper function to create a server socket
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_SocketManager_InternalCreateServer(
+    OpcUa_SocketManager         a_pSocketManager,
+    OpcUa_StringA               a_sIpAddress,
+    OpcUa_UInt16                a_uPort,
+    OpcUa_Socket_EventCallback  a_pfnSocketCallBack,
+    OpcUa_Void*                 a_pCallbackData,
+    OpcUa_Socket*               a_ppSocket)
+{
+    OpcUa_StatusCode        uStatus         = OpcUa_Good;
+    OpcUa_InternalSocket*   pInternalSocket = OpcUa_Null;
+
+    *a_ppSocket = OpcUa_Null;
+
+    /* create the main server socket and raise error if no socket is found */
+    pInternalSocket = (OpcUa_InternalSocket*)OpcUa_SocketManager_FindFreeSocket(a_pSocketManager,
+                                                                                OpcUa_False);
+    /* no free sockets, out of resources.. */
+    OpcUa_ReturnErrorIfNull(pInternalSocket, OpcUa_BadMaxConnectionsReached);
+
+    pInternalSocket->rawSocket = OpcUa_P_Socket_CreateServer(a_sIpAddress, a_uPort, &uStatus);
+
+    if(OpcUa_IsBad(uStatus))
+    {
+        OPCUA_SOCKET_INVALIDATE(pInternalSocket);
+        return OpcUa_BadCommunicationError;
+    }
+
+    pInternalSocket->pfnEventCallback       = a_pfnSocketCallBack;
+    pInternalSocket->pvUserData             = a_pCallbackData;
+    pInternalSocket->Flags.bOwnThread       = OpcUa_False;
+    pInternalSocket->Flags.EventMask        = OPCUA_SOCKET_READ_EVENT | OPCUA_SOCKET_EXCEPT_EVENT | OPCUA_SOCKET_ACCEPT_EVENT | OPCUA_SOCKET_CLOSE_EVENT | OPCUA_SOCKET_TIMEOUT_EVENT;
+    pInternalSocket->usPort                 = a_uPort;
+
+    OPCUA_SOCKET_SETVALID(pInternalSocket);
+
+    *a_ppSocket = pInternalSocket;
+
+    return uStatus;
+}
+
+/*============================================================================
+*
+*===========================================================================*/
+static
+OpcUa_StatusCode OpcUa_Socket_HandleAcceptEvent(    OpcUa_Socket a_pListenSocket,
+                                                    OpcUa_Socket a_pAcceptedSocket) /* this is allowed to be null */
+{
+    OpcUa_RawSocket         AcceptedRawSocket       = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+    OpcUa_InternalSocket*   pListenInternalSocket   = (OpcUa_InternalSocket*)a_pListenSocket;
+    OpcUa_InternalSocket*   pAcceptInternalSocket   = (OpcUa_InternalSocket*)a_pAcceptedSocket;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_pListenSocket);
+
+    AcceptedRawSocket = OpcUa_P_RawSocket_Accept(   pListenInternalSocket->rawSocket,
+                                                    OpcUa_True,
+                                                    OpcUa_False);
+
+    /* accept but close if caller provided a null argument */
+    if(a_pAcceptedSocket == OpcUa_Null)
+    {
+        if(AcceptedRawSocket != (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+        {
+            OpcUa_P_RawSocket_Close(AcceptedRawSocket);
+        }
+
+        return OpcUa_BadMaxConnectionsReached;
+    }
+    else
+    {
+        pAcceptInternalSocket->rawSocket = AcceptedRawSocket;
+    }
+
+    if( pAcceptInternalSocket->rawSocket == (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+    {
+        OPCUA_SOCKET_INVALIDATE(pAcceptInternalSocket);
+        return OpcUa_BadCommunicationError;
+    }
+
+    OpcUa_P_RawSocket_SetBlockMode ( pAcceptInternalSocket->rawSocket,
+                                     OpcUa_False);
+
+    /* inherit from parent (listen) socket */
+    pAcceptInternalSocket->pfnEventCallback       = pListenInternalSocket->pfnEventCallback;
+    pAcceptInternalSocket->pvUserData             = pListenInternalSocket->pvUserData;
+    pAcceptInternalSocket->Flags.bOwnThread       = OpcUa_False;
+    pAcceptInternalSocket->Flags.EventMask        =   OPCUA_SOCKET_READ_EVENT
+                                                    | OPCUA_SOCKET_EXCEPT_EVENT
+                                                    | OPCUA_SOCKET_CLOSE_EVENT
+                                                    | OPCUA_SOCKET_TIMEOUT_EVENT;
+    pAcceptInternalSocket->usPort                 = pListenInternalSocket->usPort;
+    pAcceptInternalSocket->uintTimeout            = OPCUA_TCPLISTENER_TIMEOUT;
+    pAcceptInternalSocket->uintLastAccess         = OpcUa_P_GetTickCount();
+
+    OPCUA_SOCKET_SETVALID(pAcceptInternalSocket);
+
+    return OpcUa_Good;
+}
+
+#if OPCUA_MULTITHREADED
+/*============================================================================
+*
+*===========================================================================*/
+static OpcUa_Int32 OpcUa_SocketManager_GetSocketManagerSlot(OpcUa_InternalSocketManager* a_pSocketManager,
+                                                            OpcUa_InternalSocketManager* a_pSpawnedManager)
+{
+    OpcUa_Int32 iSocketManagerSlot;
+
+    /* we are syncronized via the pStartupSemaphore... */
+
+    for(iSocketManagerSlot = 0; iSocketManagerSlot < OPCUA_SOCKET_MAXMANAGERS; iSocketManagerSlot++)
+    {
+        if(a_pSocketManager->pSocketManagers[iSocketManagerSlot] == OpcUa_Null)
+        {
+            a_pSocketManager->pSocketManagers[iSocketManagerSlot] = a_pSpawnedManager;
+
+            return iSocketManagerSlot;
+        }
+    }
+
+    if (a_pSpawnedManager->pThread != OpcUa_Null && a_pSpawnedManager->pThreadToJoin == OpcUa_Null)
+    {
+        a_pSpawnedManager->pThreadToJoin = a_pSocketManager->pThreadToJoin;
+        a_pSocketManager->pThreadToJoin  = a_pSpawnedManager->pThread;
+        a_pSpawnedManager->pThread       = OpcUa_Null;
+    }
+
+    return -1;
+}
+
+/*============================================================================
+*
+*===========================================================================*/
+static OpcUa_Void OpcUa_SocketManager_ReleaseSocketManagerSlot(OpcUa_InternalSocketManager* a_pSocketManager, OpcUa_Int32 a_uSlot)
+{
+    OpcUa_InternalSocketManager* pSpawnedManager;
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(a_pSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    pSpawnedManager = a_pSocketManager->pSocketManagers[a_uSlot];
+    a_pSocketManager->pSocketManagers[a_uSlot] = OpcUa_Null;
+
+    if (pSpawnedManager != OpcUa_Null && pSpawnedManager->pThread != OpcUa_Null && pSpawnedManager->pThreadToJoin == OpcUa_Null)
+    {
+        pSpawnedManager->pThreadToJoin  = a_pSocketManager->pThreadToJoin;
+        a_pSocketManager->pThreadToJoin = pSpawnedManager->pThread;
+        pSpawnedManager->pThread        = OpcUa_Null;
+    }
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(a_pSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    return;
+}
+
+/*============================================================================
+* Takes appropriate action based on an event on a certain socket.
+*===========================================================================*/
+static
+OpcUa_Void OpcUa_SocketManager_AcceptHandlerThread(OpcUa_Void* a_pArgument)
+{
+
+    OpcUa_InternalSocket*       pInternalSocket     = (OpcUa_InternalSocket*)a_pArgument;
+    OpcUa_InternalSocketManager* pSocketManager     = pInternalSocket->pSocketManager;
+    OpcUa_StatusCode            uStatus             = OpcUa_Good;
+    OpcUa_Int32                 iSocketManagerSlot  = -1;
+    OpcUa_InternalSocket*       pClientSocket       = OpcUa_Null;
+    OpcUa_InternalSocket        ClientSocket[2]; /* one for the client, one for _signals_ */
+    OpcUa_InternalSocketManager SpawnedSocketManager;
+
+
+    OpcUa_MemSet(&ClientSocket, 0, sizeof(OpcUa_InternalSocket) * 2);
+    OpcUa_MemSet(&SpawnedSocketManager, 0, sizeof(OpcUa_InternalSocketManager));
+
+    SpawnedSocketManager.pThread                    = pSocketManager->pSpawnedThread;
+    SpawnedSocketManager.uintMaxSockets             = 2;
+    SpawnedSocketManager.pSockets                   = ClientSocket;
+    SpawnedSocketManager.pCookie                    = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+    SpawnedSocketManager.uintLastExternalEvent      = OPCUA_SOCKET_NO_EVENT;
+
+    SpawnedSocketManager.Flags.bSpawnThreadOnAccept = 0;
+    SpawnedSocketManager.Flags.bRejectOnThreadFail  = 0;
+
+    ClientSocket[1].pSocketServiceTable             = &OpcUa_RawSocketServiceTable;
+
+    pSocketManager->pSpawnedThread = OpcUa_Null;
+
+    /* obtain slot in global socket list array */
+    uStatus = OpcUa_P_Mutex_Create(&SpawnedSocketManager.pMutex);
+
+    if(OpcUa_IsGood(uStatus))
+    {
+        uStatus = OpcUa_P_SocketManager_NewSignalSocket(&SpawnedSocketManager);
+    }
+
+    if(OpcUa_IsGood(uStatus))
+    {
+        iSocketManagerSlot = OpcUa_SocketManager_GetSocketManagerSlot(pSocketManager, &SpawnedSocketManager);
+        if(iSocketManagerSlot == -1)
+        {
+            uStatus = OpcUa_BadOutOfMemory;
+        }
+    }
+
+    if(OpcUa_IsGood(uStatus))
+    {
+        pClientSocket = (OpcUa_InternalSocket*)OpcUa_SocketManager_FindFreeSocket(&SpawnedSocketManager, OpcUa_False);
+    }
+
+    /* handle event */
+    uStatus = OpcUa_Socket_HandleAcceptEvent(  pInternalSocket,    /* listen socket */
+                                               pClientSocket);     /* accepted socket */
+
+    if(OpcUa_IsGood(uStatus))
+    {
+        /* fire accept event */
+        pClientSocket->Flags.bOwnThread = OpcUa_True;
+        pClientSocket->Flags.bFromApplication = OpcUa_True;
+        pClientSocket->pfnEventCallback(    (OpcUa_Socket)pClientSocket,
+                                            OPCUA_SOCKET_ACCEPT_EVENT,
+                                            pClientSocket->pvUserData,
+                                            pClientSocket->usPort,
+                                            OpcUa_False);
+        pClientSocket->Flags.bFromApplication = OpcUa_False;
+
+        /* release spawn semaphore */
+        OpcUa_P_Semaphore_Post( pSocketManager->pStartupSemaphore,
+                                1);
+
+        do
+        {
+            uStatus = OpcUa_P_SocketManager_ServeLoopInternal(  &SpawnedSocketManager,
+                                                                OPCUA_INFINITE,
+                                                                OpcUa_False);
+
+            if(OpcUa_IsEqual(OpcUa_GoodShutdownEvent))
+            {
+                /* leave this loop if a shutdown was signalled */
+                break;
+            }
+        } while(OpcUa_IsGood(uStatus));
+
+        OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_SocketManager_AcceptHandlerThread: Client Handler shutting down! (0x%08X)\n", uStatus);
+
+        OpcUa_SocketManager_ReleaseSocketManagerSlot(pSocketManager, iSocketManagerSlot);
+
+        OpcUa_P_Mutex_Lock(SpawnedSocketManager.pMutex);
+
+        if((ClientSocket[0].bSocketIsInUse != OpcUa_False) &&
+           (ClientSocket[0].bInvalidSocket == OpcUa_False))
+        {
+            OpcUa_Socket_HandleEvent(&ClientSocket[0], OPCUA_SOCKET_CLOSE_EVENT);
+            OpcUa_P_RawSocket_Close(ClientSocket[0].rawSocket);
+        }
+        if((ClientSocket[1].bSocketIsInUse != OpcUa_False) &&
+           (ClientSocket[1].bInvalidSocket == OpcUa_False))
+        {
+            OpcUa_Socket_HandleEvent(&ClientSocket[1], OPCUA_SOCKET_CLOSE_EVENT);
+            OpcUa_P_RawSocket_Close(ClientSocket[1].rawSocket);
+        }
+        OpcUa_P_RawSocket_Close(SpawnedSocketManager.pCookie);
+
+        OpcUa_P_Mutex_Unlock(SpawnedSocketManager.pMutex);
+        OpcUa_P_Mutex_Delete(&SpawnedSocketManager.pMutex);
+
+        /* loop ended */
+    }
+    else
+    {
+        /* release spawn semaphore */
+        OpcUa_P_Semaphore_Post( pSocketManager->pStartupSemaphore,
+                                1);
+
+        /* error, configuration maximum reached */
+        if(iSocketManagerSlot != -1)
+        {
+            OpcUa_SocketManager_ReleaseSocketManagerSlot(pSocketManager, iSocketManagerSlot);
+        }
+        if(SpawnedSocketManager.pCookie != (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+        {
+            OpcUa_P_RawSocket_Close(SpawnedSocketManager.pCookie);
+            OpcUa_P_RawSocket_Close(ClientSocket[0].rawSocket);
+        }
+        if(SpawnedSocketManager.pMutex != OpcUa_Null)
+        {
+            OpcUa_P_Mutex_Delete(&SpawnedSocketManager.pMutex);
+        }
+    }
+
+    if(SpawnedSocketManager.pThreadToJoin != OpcUa_Null)
+    {
+        OpcUa_P_Thread_Delete(&SpawnedSocketManager.pThreadToJoin);
+    }
+
+    return;
+}
+#endif /* OPCUA_MULTITHREADED */
+
+/*============================================================================
+* Takes appropriate action based on an event on a certain socket.
+*===========================================================================*/
+OpcUa_StatusCode OpcUa_Socket_HandleEvent(  OpcUa_Socket a_pSocket,
+                                            OpcUa_UInt32 a_uEvent)
+{
+    OpcUa_Socket            pAcceptedSocket = OpcUa_Null;
+    OpcUa_InternalSocket*   pInternalSocket = OpcUa_Null;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "HandleEvent");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+
+    pInternalSocket = (OpcUa_InternalSocket*)a_pSocket;
+
+    /* update last access variable */
+    pInternalSocket->uintLastAccess = OpcUa_P_GetTickCount();
+
+    switch(a_uEvent)
+    {
+    case OPCUA_SOCKET_READ_EVENT:
+        {
+            /* OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_Socket_HandleEvent: OPCUA_SOCKET_READ_EVENT\n"); */
+            pInternalSocket->Flags.EventMask &= (~OPCUA_SOCKET_READ_EVENT);
+            break;
+        }
+    case OPCUA_SOCKET_WRITE_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_Socket_HandleEvent: OPCUA_SOCKET_WRITE_EVENT\n");
+            pInternalSocket->Flags.EventMask &= (~OPCUA_SOCKET_WRITE_EVENT);
+            break;
+        }
+    case OPCUA_SOCKET_CONNECT_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_Socket_HandleEvent: OPCUA_SOCKET_CONNECT_EVENT\n");
+            OpcUa_P_RawSocket_GetLocalInfo(pInternalSocket->rawSocket, &(pInternalSocket->usPort));
+            pInternalSocket->Flags.EventMask &= (~OPCUA_SOCKET_CONNECT_EVENT);
+            break;
+        }
+    case OPCUA_SOCKET_CLOSE_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_Socket_HandleEvent: OPCUA_SOCKET_CLOSE_EVENT\n");
+            break;
+        }
+    case OPCUA_SOCKET_TIMEOUT_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_Socket_HandleEvent: OPCUA_SOCKET_TIMEOUT_EVENT\n");
+            break;
+        }
+    case OPCUA_SOCKET_EXCEPT_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_Socket_HandleEvent: OPCUA_SOCKET_EXCEPT_EVENT\n");
+            break;
+        }
+    case OPCUA_SOCKET_ACCEPT_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_Socket_HandleEvent: OPCUA_SOCKET_ACCEPT_EVENT\n");
+
+#if OPCUA_MULTITHREADED
+            if(pInternalSocket->pSocketManager->Flags.bSpawnThreadOnAccept != 0)
+            {
+                OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_Socket_HandleEvent: Spawning Client Connection thread.\n");
+
+                uStatus = OpcUa_P_Thread_Create(&pInternalSocket->pSocketManager->pSpawnedThread);
+                if(OpcUa_IsGood(uStatus))
+                {
+                    uStatus = OpcUa_P_Thread_Start( pInternalSocket->pSocketManager->pSpawnedThread, /* handle */
+                                                    OpcUa_SocketManager_AcceptHandlerThread,         /* handler */
+                                                    (OpcUa_Void*)pInternalSocket);                   /* argument */
+                    if(OpcUa_IsGood(uStatus))
+                    {
+                        /* we must wait until the spawned thread handled the accept event */
+                        OpcUa_P_Semaphore_TimedWait(pInternalSocket->pSocketManager->pStartupSemaphore,
+                                                    OPCUA_INFINITE);
+
+                        OpcUa_ReturnStatusCode;
+                    }
+                    else
+                    {
+                        OpcUa_P_Thread_Delete(&pInternalSocket->pSocketManager->pSpawnedThread);
+                    }
+                }
+
+                if(pInternalSocket->pSocketManager->Flags.bRejectOnThreadFail != 0)
+                {
+                    OpcUa_Socket_HandleAcceptEvent(a_pSocket, pAcceptedSocket);
+                    OpcUa_ReturnStatusCode;
+                }
+            }
+#endif /* OPCUA_MULTITHREADED */
+
+            pAcceptedSocket = OpcUa_SocketManager_FindFreeSocket(pInternalSocket->pSocketManager, OpcUa_False);
+            OpcUa_Socket_HandleAcceptEvent(a_pSocket, pAcceptedSocket);
+            OpcUa_GotoErrorIfNull(pAcceptedSocket, OpcUa_BadMaxConnectionsReached);
+            a_pSocket = pAcceptedSocket;
+            break;
+        }
+    default:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "OpcUa_Socket_HandleEvent: Unknown event!\n");
+            break;
+        }
+
+    }; /* end of event dispatcher */
+
+    /* begin dispatching of remaining events */
+    if(pInternalSocket->pfnEventCallback != OpcUa_Null)
+    {
+        pInternalSocket->Flags.bFromApplication = OpcUa_True;
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Unlock(pInternalSocket->pSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+        pInternalSocket->pfnEventCallback(a_pSocket, a_uEvent, pInternalSocket->pvUserData, pInternalSocket->usPort, OpcUa_False);
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Lock(pInternalSocket->pSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+        pInternalSocket->Flags.bFromApplication = OpcUa_False;
+    }
+    else
+    {
+        OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_Socket_HandleEvent: pfnEventCallback is OpcUa_Null\n");
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Set the event mask for this socket.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Socket_SetEventMask( OpcUa_Socket a_pSocket,
+                                            OpcUa_UInt32 a_uEventMask)
+{
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SetEventMask");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+    OpcUa_GotoErrorIfTrue(((OpcUa_InternalSocket*)a_pSocket)->rawSocket == OPCUA_P_SOCKET_INVALID,
+                          OpcUa_BadCommunicationError);
+
+    ((OpcUa_InternalSocket*)a_pSocket)->Flags.EventMask = (OpcUa_Int)a_uEventMask;
+
+    OpcUa_P_SocketManager_SignalEvent(  ((OpcUa_InternalSocket*)a_pSocket)->pSocketManager,
+                                        OPCUA_SOCKET_RENEWLOOP_EVENT,
+                                        OpcUa_False);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Get the currently set event mask for this socket.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_Socket_GetEventMask(
+    OpcUa_Socket a_pSocket,
+    OpcUa_UInt32* a_pEventMask)
+{
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "GetEventMask");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+    OpcUa_GotoErrorIfTrue(((OpcUa_InternalSocket*)a_pSocket)->rawSocket == OPCUA_P_SOCKET_INVALID,
+                          OpcUa_BadCommunicationError);
+
+    *a_pEventMask = (OpcUa_UInt32)((OpcUa_InternalSocket*)a_pSocket)->Flags.EventMask;
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Find a free socket in the given list.
+ *===========================================================================*/
+OpcUa_Socket OpcUa_SocketManager_FindFreeSocket(    OpcUa_SocketManager     a_pSocketManager,
+                                                    OpcUa_Boolean           a_bIsSignalSocket)
+{
+    OpcUa_UInt32                 uIndex       = 0;
+    OpcUa_Boolean                bFound       = OpcUa_False;
+    OpcUa_InternalSocketManager* pInternalSocketManager  = (OpcUa_InternalSocketManager*)a_pSocketManager;
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    for(uIndex = 0; uIndex < pInternalSocketManager->uintMaxSockets; uIndex++)
+    {
+        if(uIndex == 0 && !a_bIsSignalSocket)
+        {
+            continue;
+        }
+
+        if(pInternalSocketManager->pSockets[uIndex].bSocketIsInUse == OpcUa_False)
+        {
+            pInternalSocketManager->pSockets[uIndex].bInvalidSocket         = OpcUa_True;
+            pInternalSocketManager->pSockets[uIndex].Flags.bClosedSocket    = OpcUa_False;
+            pInternalSocketManager->pSockets[uIndex].Flags.bOwnThread       = OpcUa_False;
+            pInternalSocketManager->pSockets[uIndex].Flags.bFromApplication = OpcUa_False;
+            pInternalSocketManager->pSockets[uIndex].Flags.EventMask        = 0;
+            pInternalSocketManager->pSockets[uIndex].uintTimeout            = 0;
+            pInternalSocketManager->pSockets[uIndex].uintLastAccess         = OpcUa_P_GetTickCount();
+            pInternalSocketManager->pSockets[uIndex].pvUserData             = OpcUa_Null;
+            pInternalSocketManager->pSockets[uIndex].pfnEventCallback       = OpcUa_Null;
+            pInternalSocketManager->pSockets[uIndex].pSocketManager         = (OpcUa_InternalSocketManager *)a_pSocketManager;
+            pInternalSocketManager->pSockets[uIndex].rawSocket              = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+            pInternalSocketManager->pSockets[uIndex].bSocketIsInUse         = OpcUa_True;
+
+            bFound = OpcUa_True;
+
+            break; /* for loop */
+        }
+    }
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    if(bFound)
+    {
+        return &(pInternalSocketManager->pSockets[uIndex]);
+    }
+    else
+    {
+        return OpcUa_Null;
+    }
+}
+
+
+
+
+/*============================================================================
+* Main socket based server loop.
+*===========================================================================*/
+OpcUa_StatusCode OpcUa_P_SocketManager_ServeLoopInternal(   OpcUa_SocketManager   a_pSocketManager,
+                                                            OpcUa_UInt32          a_msecTimeout,
+                                                            OpcUa_Boolean         bRunOnce)
+{
+    OpcUa_StatusCode                selectStatus            = OpcUa_Good;
+
+    OpcUa_P_Socket_Array            readFdSet;
+    OpcUa_P_Socket_Array            writeFdSet;
+    OpcUa_P_Socket_Array            exceptFdSet;
+
+    int                             max;
+    OpcUa_InternalSocketManager*    pInternalSocketManager  = OpcUa_Null;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_ServeLoop");
+
+    /* cap */
+    if(a_msecTimeout > OPCUA_SOCKET_MAXLOOPTIME)
+    {
+        a_msecTimeout = OPCUA_SOCKET_MAXLOOPTIME;
+    }
+
+    if(a_pSocketManager == OpcUa_Null)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    pInternalSocketManager = (OpcUa_InternalSocketManager*)a_pSocketManager;
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    /* the serving loop */
+    do
+    {
+        /* fill fdsets with the sockets from the SocketManager */
+        max = OpcUa_P_Socket_FillFdSet(pInternalSocketManager, &readFdSet, OPCUA_SOCKET_READ_EVENT, 0);
+        max = OpcUa_P_Socket_FillFdSet(pInternalSocketManager, &writeFdSet, (OPCUA_SOCKET_WRITE_EVENT | OPCUA_SOCKET_CONNECT_EVENT), max);
+        max = OpcUa_P_Socket_FillFdSet(pInternalSocketManager, &exceptFdSet, OPCUA_SOCKET_EXCEPT_EVENT, max);
+
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Unlock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+        /****************************************************************/
+        /* This is the only point in the whole engine, where blocking   */
+        /* of the current thread is allowed. Else, processing of        */
+        /* network events is slowed down!                               */
+#if OPCUA_MULTITHREADED
+        selectStatus = OpcUa_P_RawSocket_Select(    (OpcUa_RawSocket)max, /* ignore on win */
+                                                    &readFdSet,
+                                                    &writeFdSet,
+                                                    &exceptFdSet,
+                                                    a_msecTimeout);
+#else
+        /* if we're here, the processing socketmanager should better be the global one...! */
+        /* maybe test this state here */
+        /* The provided ST config implements lowres timers via the global socketmanager's select timeout ... yes, it's lame ... */
+        /* Thanks to Andy Griffith for the TimeredSelect and the Timer implementation in general. */
+        selectStatus = OpcUa_P_Socket_TimeredSelect((OpcUa_RawSocket)max, /* ignore on win */
+                                                    &readFdSet,
+                                                    &writeFdSet,
+                                                    &exceptFdSet,
+                                                    a_msecTimeout);
+#endif
+        /*                                                              */
+        /****************************************************************/
+
+
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Lock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+        /* handle errors in select, excluding timeout */
+        /* "good" errors result from timeout and closeing the signal socket; the rest is bad... */
+        if(OpcUa_IsBad(selectStatus))
+        {
+            uStatus = OpcUa_BadCommunicationError;
+            goto Error;
+        }
+
+        /* check for external events */
+        /* right after possible select delay */
+        if (OPCUA_P_SOCKET_ARRAY_ISSET(pInternalSocketManager->pSockets[0].rawSocket, &readFdSet))
+        {
+            uStatus = OpcUa_P_Socket_HandleExternalEvent(pInternalSocketManager);
+            OpcUa_GotoErrorIfBad(uStatus);
+
+            /* continue if a renew event was signalled */
+            if(OpcUa_IsEqual(OpcUa_GoodCallAgain))
+            {
+                continue;
+            }
+
+            /* leave if a shutdown event was signalled */
+            if(OpcUa_IsEqual(OpcUa_GoodShutdownEvent))
+            {
+                break;
+            }
+        }
+
+        /* Handle Events by calling the registered callbacks (all sockets except the waiting socket) */
+        OpcUa_P_Socket_HandleFdSet(pInternalSocketManager, &exceptFdSet,  OPCUA_SOCKET_EXCEPT_EVENT);
+        OpcUa_P_Socket_HandleFdSet(pInternalSocketManager, &writeFdSet,  (OPCUA_SOCKET_WRITE_EVENT | OPCUA_SOCKET_CONNECT_EVENT));
+        OpcUa_P_Socket_HandleFdSet(pInternalSocketManager, &readFdSet,    OPCUA_SOCKET_READ_EVENT);
+
+    } while(!bRunOnce);
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocketManager->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+* FillFdSet
+*===========================================================================*/
+int OpcUa_P_Socket_FillFdSet(  OpcUa_SocketManager     pSocketManager,
+                               OpcUa_P_Socket_Array*   pSocketArray,
+                               OpcUa_UInt32            uintEvent,
+                               int                     max)
+{
+    OpcUa_UInt32                    uintIndex      = 0;
+    OpcUa_UInt32                    uintTempEvent  = 0;
+    OpcUa_InternalSocketManager*    pInternalSocketManager    = (OpcUa_InternalSocketManager*)pSocketManager;
+
+    OPCUA_P_SOCKET_ARRAY_ZERO(pSocketArray);
+
+    for(uintIndex = 0; uintIndex < pInternalSocketManager->uintMaxSockets; uintIndex++)
+    {
+        uintTempEvent = uintEvent;
+
+        /* if socket used and valid */
+        if(     (pInternalSocketManager->pSockets[uintIndex].bSocketIsInUse  != OpcUa_False)
+            &&  (pInternalSocketManager->pSockets[uintIndex].bInvalidSocket  == OpcUa_False))
+        {
+            /* is connect event wished by caller? */
+            if((uintTempEvent & OPCUA_SOCKET_CONNECT_EVENT) != 0)
+            {
+                /* and is connect event wished by socket? */
+                if(((pInternalSocketManager->pSockets[uintIndex].Flags.EventMask) & OPCUA_SOCKET_CONNECT_EVENT) != 0)
+                {
+                    /* then set to connect only */
+                    uintTempEvent = OPCUA_SOCKET_CONNECT_EVENT;
+                }
+                else
+                {
+                    /* else remove connect event */
+                    uintTempEvent &= ~ OPCUA_SOCKET_CONNECT_EVENT;
+                }
+            }
+
+            /* if only uintTemp is wished, set the socket in the fd_set */
+            if(((pInternalSocketManager->pSockets[uintIndex].Flags.EventMask) & uintTempEvent) == uintTempEvent)
+            {
+                OPCUA_P_SOCKET_ARRAY_SET(pInternalSocketManager->pSockets[uintIndex].rawSocket, pSocketArray);
+                if (pInternalSocketManager->pSockets[uintIndex].rawSocket > max)
+                {
+                    max = pInternalSocketManager->pSockets[uintIndex].rawSocket;
+                }
+            }
+        }
+    }
+
+    return max;
+}
+
+/*============================================================================
+* CreateServer
+*===========================================================================*/
+/* create a socket and configure it as a server socket */
+OpcUa_RawSocket OpcUa_P_Socket_CreateServer(    OpcUa_StringA       IpAddress,
+                                                OpcUa_Int16         Port,
+                                                OpcUa_StatusCode*   Status)
+{
+    OpcUa_StatusCode    uStatus     = OpcUa_Good;
+    OpcUa_RawSocket     RawSocket   = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+    OpcUa_Boolean       bIpV6       = OpcUa_True;
+
+    if(IpAddress == OpcUa_Null)
+    {
+        /* bind to everything */
+        uStatus = OpcUa_P_RawSocket_CreateV6(   &RawSocket,
+                                                OpcUa_True,     /* Nagle off */
+                                                OpcUa_True,     /* Reuse on  */
+                                                OpcUa_False);   /* IPv4+6    */
+        if(OpcUa_IsBad(uStatus))
+        {
+            bIpV6 = OpcUa_False;
+            uStatus = OpcUa_P_RawSocket_Create(   &RawSocket,
+                                                  OpcUa_True,     /* Nagle off */
+                                                  OpcUa_True);    /* Reuse on  */
+        }
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+    else if(strchr(IpAddress, ':'))
+    {
+        uStatus = OpcUa_P_RawSocket_CreateV6(   &RawSocket,
+                                                OpcUa_True,     /* Nagle off */
+                                                OpcUa_True,     /* Reuse on  */
+                                                OpcUa_True);    /* IPv6 only */
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+    else
+    {
+        bIpV6 = OpcUa_False;
+        uStatus = OpcUa_P_RawSocket_Create(     &RawSocket,
+                                                OpcUa_True,     /* Nagle off */
+                                                OpcUa_True);    /* Reuse on  */
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    OpcUa_GotoErrorIfTrue((RawSocket == (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID), OpcUa_BadCommunicationError);
+
+    /* set nonblocking */
+    uStatus = OpcUa_P_RawSocket_SetBlockMode(   RawSocket,
+                                                OpcUa_False);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    if(bIpV6)
+    {
+        uStatus = OpcUa_P_RawSocket_BindV6(RawSocket, IpAddress, Port);
+    }
+    else if(IpAddress == OpcUa_Null)
+    {
+        uStatus = OpcUa_P_RawSocket_Bind(RawSocket, Port);
+    }
+    else
+    {
+        uStatus = OpcUa_P_RawSocket_BindEx(RawSocket, IpAddress, Port);
+    }
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    uStatus = OpcUa_P_RawSocket_Listen(RawSocket);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    if(Status != OpcUa_Null)
+    {
+        *Status = uStatus;
+    }
+
+    return RawSocket;
+
+Error:
+    if(Status != OpcUa_Null)
+    {
+        *Status = uStatus;
+    }
+
+    /* ignore errors which may happen, when RawSocket is invalid */
+    if(RawSocket != (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+    {
+        OpcUa_P_RawSocket_Close(RawSocket);
+    }
+
+    return (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+}
+
+/*============================================================================
+* HandleFdSet
+*===========================================================================*/
+OpcUa_Void OpcUa_P_Socket_HandleFdSet(  OpcUa_SocketManager     a_pSocketManager,
+                                        OpcUa_P_Socket_Array*   a_pSocketArray,
+                                        OpcUa_UInt32            a_uEvent)
+{
+    OpcUa_InternalSocketManager*    pInternalSocketManager         = (OpcUa_InternalSocketManager*)a_pSocketManager;
+    OpcUa_UInt32                    uintIndex           = 0;
+    OpcUa_UInt32                    uintLocalEvent      = 0;
+    OpcUa_UInt32                    uintTimeDifference  = 0; /* seconds */
+
+    for(uintIndex = 1; uintIndex < pInternalSocketManager->uintMaxSockets; uintIndex++)
+    {
+        uintLocalEvent = a_uEvent;
+
+        if(    (pInternalSocketManager->pSockets[uintIndex].bSocketIsInUse != OpcUa_False)
+           &&  (pInternalSocketManager->pSockets[uintIndex].bInvalidSocket == OpcUa_False))
+        {
+            if(   (pInternalSocketManager->pSockets[uintIndex].Flags.bClosedSocket == OpcUa_False)
+               && OPCUA_P_SOCKET_ARRAY_ISSET(pInternalSocketManager->pSockets[uintIndex].rawSocket, a_pSocketArray))
+            {
+                if((uintLocalEvent == OPCUA_SOCKET_READ_EVENT) && (pInternalSocketManager->pSockets[uintIndex].Flags.EventMask & OPCUA_SOCKET_ACCEPT_EVENT))
+                {
+                    uintLocalEvent = OPCUA_SOCKET_ACCEPT_EVENT;
+                }
+
+                if(uintLocalEvent & OPCUA_SOCKET_CONNECT_EVENT)
+                {
+                    if(pInternalSocketManager->pSockets[uintIndex].Flags.EventMask & OPCUA_SOCKET_CONNECT_EVENT)
+                    {
+                        uintLocalEvent = OPCUA_SOCKET_CONNECT_EVENT;
+                    }
+                    else
+                    {
+                        uintLocalEvent &=~ OPCUA_SOCKET_CONNECT_EVENT;
+                    }
+                }
+
+                /* the real reason for exception events is received through getsockopt with SO_ERROR */
+                if(uintLocalEvent == OPCUA_SOCKET_CONNECT_EVENT)
+                {
+                    int       apiResult = 0, value = 0;
+                    socklen_t size      = sizeof(value);
+                    apiResult = getsockopt(pInternalSocketManager->pSockets[uintIndex].rawSocket, SOL_SOCKET, SO_ERROR, (char*)&value, &size);
+                    if(apiResult == 0 && value != 0)
+                    {
+                        uintLocalEvent = OPCUA_SOCKET_EXCEPT_EVENT;
+                    }
+                }
+
+                OpcUa_Socket_HandleEvent(&pInternalSocketManager->pSockets[uintIndex], uintLocalEvent);
+            }
+
+            else if(uintLocalEvent == OPCUA_SOCKET_EXCEPT_EVENT)
+            {
+                /* Only check timeout, if a timeout value is set for the socket */
+                if(pInternalSocketManager->pSockets[uintIndex].uintTimeout != 0)
+                {
+                    /* check for Timeout too */
+                    uintTimeDifference = OpcUa_P_GetTickCount() - pInternalSocketManager->pSockets[uintIndex].uintLastAccess;
+
+                    if((int)uintTimeDifference > (int)pInternalSocketManager->pSockets[uintIndex].uintTimeout)
+                    {
+                        /* the connection on this socket timed out */
+                        OpcUa_Socket_HandleEvent(&pInternalSocketManager->pSockets[uintIndex], OPCUA_SOCKET_TIMEOUT_EVENT);
+                    }
+                }
+            }
+
+            if(pInternalSocketManager->pSockets[uintIndex].Flags.bClosedSocket != OpcUa_False)
+            {
+                OpcUa_Socket_HandleEvent(&pInternalSocketManager->pSockets[uintIndex], OPCUA_SOCKET_CLOSE_EVENT);
+
+                OpcUa_P_RawSocket_Close(pInternalSocketManager->pSockets[uintIndex].rawSocket);
+
+                pInternalSocketManager->pSockets[uintIndex].rawSocket = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+
+                pInternalSocketManager->pSockets[uintIndex].bSocketIsInUse = OpcUa_False;
+            }
+
+        }
+
+    }
+
+    return;
+}
+
+/*============================================================================
+* HandleExternalEvent
+*===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Socket_HandleExternalEvent(    OpcUa_SocketManager a_pSocketManager)
+{
+    OpcUa_UInt32                 uExternalEvent         = OPCUA_SOCKET_NO_EVENT;
+    OpcUa_InternalSocketManager* pInternalSocketManager = (OpcUa_InternalSocketManager*)a_pSocketManager;
+    unsigned char                dummy[32];
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_HandleExternalEvent");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocketManager);
+
+    OpcUa_P_RawSocket_Read(pInternalSocketManager->pSockets[0].rawSocket, dummy, sizeof(dummy));
+
+    if(pInternalSocketManager->uintLastExternalEvent != OPCUA_SOCKET_NO_EVENT)
+    {
+        uExternalEvent = pInternalSocketManager->uintLastExternalEvent;
+
+        /* check for renew event set externally in list */
+        if((uExternalEvent & OPCUA_SOCKET_RENEWLOOP_EVENT) != OPCUA_SOCKET_NO_EVENT)
+        {
+            /* loop has been interrupted externally to restart with the new/changed list */
+            pInternalSocketManager->uintLastExternalEvent &= (~OPCUA_SOCKET_RENEWLOOP_EVENT);
+            uStatus = OpcUa_GoodCallAgain;
+        }
+
+        /* was this the Shutdown Event, raised by the system? */
+        if((uExternalEvent & OPCUA_SOCKET_SHUTDOWN_EVENT) != OPCUA_SOCKET_NO_EVENT)
+        {
+            /* if uStatus !=  */
+            uStatus = OpcUa_GoodShutdownEvent;
+        }
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Internal Function
+ *===========================================================================*/
+OpcUa_RawSocket OpcUa_P_Socket_CreateClient(    OpcUa_UInt16                    a_uPort,
+                                                OpcUa_UInt16                    a_uRemotePort,
+                                                OpcUa_StringA                   a_sRemoteAddress,
+                                                OpcUa_StatusCode*               a_uStatus)
+{
+    OpcUa_StatusCode    uStatus     = OpcUa_Good;
+    OpcUa_RawSocket     RawSocket   = (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+    OpcUa_Boolean       bIpV6       = OpcUa_True;
+
+    if(strchr(a_sRemoteAddress, ':'))
+    {
+        uStatus = OpcUa_P_RawSocket_CreateV6(  &RawSocket,
+                                               OpcUa_True,     /* Nagle off */
+                                               OpcUa_False,    /* Reuse off */
+                                               OpcUa_False);   /* IPv4+6    */
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+    else
+    {
+        bIpV6 = OpcUa_False;
+        uStatus = OpcUa_P_RawSocket_Create(    &RawSocket,
+                                               OpcUa_True,     /* Nagle off */
+                                               OpcUa_False);   /* Reuse off */
+        OpcUa_GotoErrorIfBad(uStatus);
+    }
+
+    if(RawSocket == (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+    {
+        goto Error;
+    }
+
+    /* set nonblocking */
+    uStatus = OpcUa_P_RawSocket_SetBlockMode(   RawSocket,
+                                                OpcUa_False);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    if(a_uPort != (OpcUa_UInt16)0)
+    {
+        if(bIpV6)
+        {
+            /* bind always to any IP address */
+            uStatus = OpcUa_P_RawSocket_BindV6(RawSocket, OpcUa_Null, a_uPort);
+            OpcUa_GotoErrorIfBad(uStatus);
+        }
+        else
+        {
+            /* bind always to any IP address */
+            uStatus = OpcUa_P_RawSocket_Bind(RawSocket, a_uPort);
+            OpcUa_GotoErrorIfBad(uStatus);
+        }
+    }
+
+    if(a_uRemotePort != 0)
+    {
+        if(bIpV6)
+        {
+            uStatus = OpcUa_P_RawSocket_ConnectV6(  RawSocket,
+                                                    a_uRemotePort,
+                                                    a_sRemoteAddress);
+        }
+        else
+        {
+            uStatus = OpcUa_P_RawSocket_Connect(    RawSocket,
+                                                    a_uRemotePort,
+                                                    a_sRemoteAddress);
+        }
+
+        if(OpcUa_IsBad(uStatus))
+        {
+            /* we are nonblocking and would block is not an error in this mode */
+            if(uStatus != OpcUa_BadWouldBlock)
+            {
+                goto Error;
+            }
+            else
+            {
+                uStatus = OpcUa_Good;
+            }
+        }
+    }
+
+    if(a_uStatus != OpcUa_Null)
+    {
+        *a_uStatus = uStatus;
+    }
+
+    return RawSocket;
+
+Error:
+
+    if(a_uStatus != OpcUa_Null)
+    {
+        if(OpcUa_IsBad(uStatus))
+        {
+            *a_uStatus = uStatus;
+        }
+    }
+
+    if(RawSocket != (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID)
+    {
+        OpcUa_P_RawSocket_Close(RawSocket); /* just in case */
+    }
+
+    return (OpcUa_RawSocket)OPCUA_P_SOCKET_INVALID;
+}

--- a/Stack/platforms/vxworks/opcua_p_socket_internal.h
+++ b/Stack/platforms/vxworks/opcua_p_socket_internal.h
@@ -1,0 +1,302 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_Socket_Internal_H_
+#define _OpcUa_Socket_Internal_H_ 1
+
+OPCUA_BEGIN_EXTERN_C
+
+/*============================================================================
+ * The Socket Type
+ *===========================================================================*/
+
+/** The Socket Service Table.  */
+typedef const struct _OpcUa_SocketServiceTable
+{
+   OpcUa_StatusCode    (* SocketRead)               ( OpcUa_Socket                hSocket,
+                                                      OpcUa_Byte*                 pBuffer,
+                                                      OpcUa_UInt32                BufferSize,
+                                                      OpcUa_UInt32*               puintBytesRead);
+   OpcUa_Int32         (* SocketWrite)              ( OpcUa_Socket                hSocket,
+                                                      OpcUa_Byte*                 pBuffer,
+                                                      OpcUa_UInt32                BufferSize,
+                                                      OpcUa_Boolean               bBlock);
+   OpcUa_StatusCode    (* SocketClose)              ( OpcUa_Socket                hSocket);
+   OpcUa_StatusCode    (* SocketGetPeerInfo)        ( OpcUa_Socket                hSocket,
+                                                      OpcUa_CharA*                achPeerInfoBuffer,
+                                                      OpcUa_UInt32                uiPeerInfoBufferSize);
+   OpcUa_StatusCode    (* SocketGetLastError)       ( OpcUa_Socket                hSocket);
+   OpcUa_StatusCode    (* SocketSetUserData)        ( OpcUa_Socket                hSocket,
+                                                      OpcUa_Void*                 pvUserData);
+} OpcUa_SocketServiceTable;
+
+/* forward definition of the OpcUa_Socket structure */
+typedef struct _OpcUa_InternalSocket OpcUa_InternalSocket;
+
+/* forward definition of the OpcUa_SocketManager structure */
+typedef struct _OpcUa_InternalSocketManager OpcUa_InternalSocketManager;
+
+/**
+* Internal representation for a logical socket (client and server). Includes
+* beside the system socket additional information for handling.
+*/
+struct _OpcUa_InternalSocket
+{
+    OpcUa_SocketServiceTable*    pSocketServiceTable;/* socket service table */
+    OpcUa_RawSocket              rawSocket;          /* system socket */
+    OpcUa_Socket_EventCallback   pfnEventCallback;   /* function to call on event */
+    OpcUa_Void*                  pvUserData;         /* data for callback */
+    OpcUa_InternalSocketManager* pSocketManager;     /* the socket manager, this socket belongs to */
+    OpcUa_UInt16                 usPort;             /* the socket port of this socket */
+    volatile OpcUa_Boolean       bInvalidSocket;     /* is the socket usable */
+    volatile OpcUa_Boolean       bSocketIsInUse;     /* true if this list member is currently connected or listening */
+    struct _Flags
+    {
+        OpcUa_UInt               EventMask:11;       /* mask and unmask eventhandling */
+        OpcUa_UInt               bClosedSocket:1;    /* is the socket closed */
+        OpcUa_UInt               bOwnThread:1;       /* if this socket is handled by an own thread */
+        OpcUa_UInt               bFromApplication:1; /* Application is explicitely waiting for an event on this socket. */
+    } Flags;
+    OpcUa_UInt32                 uintTimeout;        /* interval until connection is considered timed out */
+    OpcUa_UInt32                 uintLastAccess;     /* system tick count in seconds when last action on this socket took place */
+};
+
+/**
+* List of sockets for one listening socket (included).
+*/
+struct _OpcUa_InternalSocketManager
+{
+    OpcUa_InternalSocket*   pSockets;                 /* the sockets */
+    OpcUa_UInt32            uintMaxSockets;           /* how many socket entries can this list hold at maximum. Mind the signal socket!  */
+    OpcUa_RawSocket         pCookie;                  /* wakeup event socket */
+    OpcUa_UInt32            uintLastExternalEvent;    /* the last occurred event */
+#if OPCUA_MULTITHREADED
+    OpcUa_InternalSocketManager** pSocketManagers;    /* the spawned socket managers go there */
+    OpcUa_RawThread         pSpawnedThread;           /* the spawned accept thread */
+    OpcUa_Semaphore         pStartupSemaphore;        /* wait on this semaphore to synchronize the accept thread */
+    OpcUa_RawThread         pThreadToJoin;            /* the next thread to be joined */
+    OpcUa_RawThread         pThread;                  /* each socket list has its own thread... */
+#endif /* OPCUA_MULTITHREADED */
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_Mutex             pMutex;                   /* ... and therefore its own mutex! */
+#endif /* OPCUA_USE_SYNCHRONISATION */
+    struct _SocketManagerFlags
+    {
+        OpcUa_UInt  bSpawnThreadOnAccept:1;           /* is a new thread spawned on a new connection accept? */
+        OpcUa_UInt  bRejectOnThreadFail :1;           /* reject an accept when there is no free thread? */
+        OpcUa_UInt  bDontCloseOnExcept  :1;           /* override default closing of a socket on except event */
+    } Flags;
+};
+
+/*
+* Sets a socket to invalid.
+*/
+#if OPCUA_USE_SYNCHRONISATION
+#define OPCUA_SOCKET_INVALIDATE(a)      do {                                                    \
+                                             OpcUa_P_Mutex_Lock((a)->pSocketManager->pMutex);   \
+                                             (a)->bSocketIsInUse = OpcUa_False;                 \
+                                             OpcUa_P_Mutex_Unlock((a)->pSocketManager->pMutex); \
+                                        } while(0)
+#define OPCUA_SOCKET_SETVALID(a)        do {                                                    \
+                                             OpcUa_P_Mutex_Lock((a)->pSocketManager->pMutex);   \
+                                             (a)->bInvalidSocket = OpcUa_False;                 \
+                                             OpcUa_P_Mutex_Unlock((a)->pSocketManager->pMutex); \
+                                        } while(0)
+#else
+#define OPCUA_SOCKET_INVALIDATE(a)      ((a)->bSocketIsInUse = OpcUa_False)
+#define OPCUA_SOCKET_SETVALID(a)        ((a)->bInvalidSocket = OpcUa_False)
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+
+/*============================================================================
+ * Initialize Socket Type
+ *===========================================================================*/
+OpcUa_Void          OpcUa_Socket_Initialize(    OpcUa_Socket pSocket);
+
+/*============================================================================
+ * Clear Socket Type
+ *===========================================================================*/
+OpcUa_Void          OpcUa_Socket_Clear(         OpcUa_Socket pSocket);
+
+
+/**************************** The SocketManager Type ****************************/
+
+/*============================================================================
+ * Allocate SocketManager Type
+ *===========================================================================*/
+OpcUa_SocketManager OpcUa_SocketManager_Alloc(void);
+
+/*============================================================================
+ * Initialize SocketManager Type
+ *===========================================================================*/
+OpcUa_Void          OpcUa_SocketManager_Initialize(OpcUa_SocketManager pSocketManager);
+
+
+
+/*============================================================================
+ * Create the Sockets in the given list
+ *===========================================================================*/
+OpcUa_StatusCode    OpcUa_SocketManager_CreateSockets(  OpcUa_SocketManager     pSocketManager,
+                                                        OpcUa_UInt32            uintMaxSockets);
+
+/*============================================================================
+ * Set the event mask for this socket.
+ *===========================================================================*/
+OpcUa_StatusCode    OpcUa_Socket_SetEventMask(  OpcUa_Socket                pSocket,
+                                                OpcUa_UInt32                uintEventMask);
+
+/*============================================================================
+ * Get the currently set event mask for this socket.
+ *===========================================================================*/
+OpcUa_StatusCode    OpcUa_Socket_GetEventMask(  OpcUa_Socket                pSocket,
+                                                OpcUa_UInt32*               puintEventMask);
+
+/*============================================================================
+ * Network Byte Order Conversion Helper Functions
+ *===========================================================================*/
+OpcUa_UInt32        OpcUa_Socket_NToHL(         OpcUa_UInt32 netLong);
+OpcUa_UInt16        OpcUa_Socket_NToHS(         OpcUa_UInt16 netShort);
+
+OpcUa_UInt32        OpcUa_Socket_HToNL(         OpcUa_UInt32 hstLong);
+OpcUa_UInt16        OpcUa_Socket_HToNS(         OpcUa_UInt16 hstShort);
+
+
+/*============================================================================
+ * Find a free socket.
+ *===========================================================================*/
+OpcUa_Socket        OpcUa_SocketManager_FindFreeSocket( OpcUa_SocketManager pSocketManager,
+                                                        OpcUa_Boolean       bIsSignalSocket);
+
+/*============================================================================
+ * Take action based on socket and event.
+ *===========================================================================*/
+OpcUa_StatusCode    OpcUa_Socket_HandleEvent(   OpcUa_Socket        pSocket,
+                                                OpcUa_UInt32        uintEvent);
+
+/*!
+ * @brief Fill the socket array with sockets from the given socket list and selected based on the given event.
+ *
+ * @param pSocketManager   [in]    The source of the sockets.
+ * @param pSocketArray  [out]   The sockets in this array get set based on the socket list.
+ * @param Event         [in]    Only set sockets with this event set.
+ * @param max           [in]    previously used max file descriptor
+ *
+ * @return new max file descriptor used
+ */
+int OpcUa_P_Socket_FillFdSet(OpcUa_SocketManager   SocketManager,
+                             OpcUa_P_Socket_Array* pSocketArray,
+                             OpcUa_UInt32          Event,
+                             int                   max);
+
+/*!
+ * @brief Handle all signaled events in the socket array.
+ *
+ * @param pSocketManager   [in]    The list with the OpcUa_Sockets which store the handler routines.
+ * @param pSocketArray  [in]    The array with the system sockets to be checked.
+ * @param Event         [in]    Handle all sockets waiting for this event.
+ */
+OpcUa_Void OpcUa_P_Socket_HandleFdSet(OpcUa_SocketManager   SocketManager,
+                                      OpcUa_P_Socket_Array* SocketArray,
+                                      OpcUa_UInt32          Event);
+
+/*!
+ * @brief Handle an externally triggered event.
+ *
+ * @param pSocketManager   [in]    The current socket list.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_Socket_HandleExternalEvent(OpcUa_SocketManager SocketManager);
+
+/*!
+ * @brief Create and initialize a listening OpcUa_Socket.
+ *
+ * @param IpAddress [in]    The IP address to listen on.
+ * @param Port      [in]    The port to listen on.
+ * @param Status    [out]   How the operation went.
+ *
+ * @return The created system socket. An invalid socket in case of error.
+ */
+OpcUa_RawSocket OpcUa_P_Socket_CreateServer(OpcUa_StringA     IpAddress,
+                                            OpcUa_Int16       Port,
+                                            OpcUa_StatusCode* Status);
+
+/*!
+ * @brief Create a OpcUa_Socket and connect to specified network node.
+ *
+ * @param Port          [in]    Non zero to bind the socket locally.
+ * @param RemotePort    [in]    The port on the server side.
+ * @param RemoteAdress  [in]    The IP address of the server as string (ascii).
+ * @param Status        [out]   Status how the operation finished.
+ *
+ * @return The created system socket. An invalid socket in case of error.
+ */
+OpcUa_RawSocket OpcUa_P_Socket_CreateClient(OpcUa_UInt16                    Port,
+                                            OpcUa_UInt16                    RemotePort,
+                                            OpcUa_StringA                   RemoteAddress,
+                                            OpcUa_StatusCode*               Status);
+
+/*!
+ * @brief Check the socket list for events and handle them.
+ *
+ * @param pSocketManager [in]    The socket list holding the sockets for the select call.
+ * @param msecTimeout    [in]    The maximum number of milliseconds, this function blocks the calling thread.
+ * @param bRunOnce       [in]    Run the event loop only once.
+ *
+ * @return A "Good" status code if no error occurred, a "Bad" status code otherwise.
+ */
+OpcUa_StatusCode OpcUa_P_SocketManager_ServeLoopInternal(   OpcUa_SocketManager   SocketManager,
+                                                            OpcUa_UInt32          msecTimeout,
+                                                            OpcUa_Boolean         bRunOnce);
+
+/*============================================================================
+ * Network Byte Order Conversion Helper Functions
+ *===========================================================================*/
+OpcUa_UInt32 OpcUa_Socket_NToHL(OpcUa_UInt32 a_netLong);
+
+OpcUa_UInt16 OpcUa_Socket_NToHS(OpcUa_UInt16 a_netShort);
+
+OpcUa_UInt32 OpcUa_Socket_HToNL(OpcUa_UInt32 a_hstLong);
+
+OpcUa_UInt16 OpcUa_Socket_HToNS(OpcUa_UInt16 a_hstShort);
+
+/*============================================================================
+ * Set socket to nonblocking mode
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_SocketManager_InternalCreateServer(  OpcUa_SocketManager         a_pSocketManager,
+                                                            OpcUa_StringA               a_sIpAddress,
+                                                            OpcUa_UInt16                a_uPort,
+                                                            OpcUa_Socket_EventCallback  a_pfnSocketCallBack,
+                                                            OpcUa_Void*                 a_pCallbackData,
+                                                            OpcUa_Socket*               a_ppSocket);
+
+
+OPCUA_END_EXTERN_C
+
+#endif /* _OpcUa_Socket_Internal_H_ */

--- a/Stack/platforms/vxworks/opcua_p_socket_ssl.c
+++ b/Stack/platforms/vxworks/opcua_p_socket_ssl.c
@@ -1,0 +1,1164 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* System Headers */
+#include <stdlib.h>
+#include <memory.h>
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+
+/* platform layer includes */
+#include <opcua_p_mutex.h>
+#include <opcua_p_pkifactory.h>
+
+/* own headers */
+#include <opcua_p_socket.h>
+#include <opcua_p_memory.h>
+#include <opcua_p_socket_internal.h>
+#include <opcua_p_socket_interface.h>
+#include <opcua_p_socket_ssl.h>
+
+#if OPCUA_P_SOCKETMANAGER_SUPPORT_SSL
+
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+
+/*============================================================================
+ * The Ssl Socket Type
+ *===========================================================================*/
+
+/**
+* Internal representation for a logical socket (client and server). Includes
+* beside the system socket additional information for handling.
+*/
+struct _OpcUa_InternalSslSocket
+{
+    OpcUa_SocketServiceTable*        pSocketServiceTable;/* socket service table */
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_Mutex                      pMutex;             /* critical section; synchronize object access */
+#endif /* OPCUA_USE_SYNCHRONISATION */
+    OpcUa_Socket_CertificateCallback pfnCertificateValidation;
+    OpcUa_Socket_EventCallback       pfnEventCallback;   /* function to call on event */
+    OpcUa_Void*                      pvUserData;         /* data for callback */
+    OpcUa_ByteString*                pServerCertificate;
+    OpcUa_Key*                       pServerPrivateKey;
+    OpcUa_Void*                      pPKIConfig;
+    SSL_CTX*                         pSslContext;
+    SSL*                             pSslConnection;
+    BIO*                             pRawBio;
+    OpcUa_Socket                     pRawSocket;         /* underlying system socket */
+    OpcUa_UInt                       bListenSocket:1;    /* is the socket opened in listen mode */
+    OpcUa_UInt                       bWantShutdown:1;    /* is the socket already closing down  */
+    OpcUa_UInt                       bWriteBlocked:1;    /* is an unfinished ssl write pending  */
+    OpcUa_UInt                       bReadBlocked:1;     /* does the application refuse to read */
+    OpcUa_UInt                       bSslProgress:1;     /* did the ssl protocol make progress  */
+    OpcUa_UInt                       bSslError:1;        /* a fatal ssl protocol error occurred */
+#ifndef OPENSSL_NO_DH
+    DH*                              pDHparams;          /* optional DH param on listen socket  */
+#endif /* OPENSSL_NO_DH */
+};
+
+typedef struct _OpcUa_InternalSslSocket OpcUa_InternalSslSocket;
+
+/*============================================================================
+ * Process the SSL Protocol
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_SslSocket_DoStateMachine( OpcUa_InternalSslSocket* pInternalSocket,
+                                                        OpcUa_Boolean            bCanCallBack,
+                                                        OpcUa_Byte*              pWriteData,
+                                                        OpcUa_UInt32*            pWriteSize)
+{
+    OpcUa_UInt32        nBytesRead;
+    OpcUa_Int32         result;
+    int                 ssl_result;
+    int                 ssl_error;
+    char*               buf;
+    int                 wpending0;
+    int                 wpending1;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SslSocket_DoStateMachine");
+
+    do
+    {
+        uStatus = OpcUa_Good;
+
+        if(bCanCallBack)
+        {
+            result = BIO_nwrite0(pInternalSocket->pRawBio, &buf);
+            if(result > 0)
+            {
+                uStatus = OpcUa_P_Socket_Read(pInternalSocket->pRawSocket,
+                                              (OpcUa_Byte*)buf, result, &nBytesRead);
+                if(OpcUa_IsGood(uStatus) && nBytesRead > 0)
+                {
+                    BIO_nwrite(pInternalSocket->pRawBio, NULL, nBytesRead);
+                    uStatus = OpcUa_GoodCallAgain;
+                }
+                else
+                {
+                    if(OpcUa_IsNotEqual(OpcUa_BadWouldBlock))
+                    {
+                        result = BIO_shutdown_wr(pInternalSocket->pRawBio);
+                    }
+                    uStatus = OpcUa_Good;
+                }
+            }
+        }
+
+        if(pInternalSocket->bWantShutdown)
+        {
+            ssl_result = SSL_shutdown(pInternalSocket->pSslConnection);
+            ssl_error = SSL_get_error(pInternalSocket->pSslConnection, ssl_result);
+            if(ssl_result > 0 && BIO_nread0(pInternalSocket->pRawBio, NULL) > 0)
+            {
+                ssl_result = 0;
+            }
+            if(ssl_result != 0 && ssl_error != SSL_ERROR_WANT_READ
+               && ssl_error != SSL_ERROR_WANT_WRITE)
+            {
+                OpcUa_P_Socket_Close(pInternalSocket->pRawSocket);
+                OpcUa_GotoErrorWithStatus(OpcUa_BadDisconnect);
+            }
+        }
+        else if(pWriteSize != OpcUa_Null && *pWriteSize > 0)
+        {
+            ssl_result = SSL_write(pInternalSocket->pSslConnection, pWriteData, *pWriteSize);
+            ssl_error = SSL_get_error(pInternalSocket->pSslConnection, ssl_result);
+            if(ssl_result > 0)
+            {
+                pInternalSocket->bSslProgress = OpcUa_True;
+                pWriteData  += ssl_result;
+                *pWriteSize -= ssl_result;
+            }
+            else if(ssl_error == SSL_ERROR_SSL || ssl_error == SSL_ERROR_SYSCALL)
+            {
+                pInternalSocket->bSslError = OpcUa_True;
+                OpcUa_SslSocket_DoStateMachine(pInternalSocket, OpcUa_False,
+                                               OpcUa_Null, OpcUa_Null);
+                OpcUa_P_Socket_Close(pInternalSocket->pRawSocket);
+                OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+            }
+        }
+        else if(bCanCallBack)
+        {
+            wpending0 = BIO_wpending(pInternalSocket->pRawBio);
+            pInternalSocket->bSslProgress = OpcUa_False;
+            if(pInternalSocket->bWriteBlocked)
+            {
+                pInternalSocket->bWriteBlocked = OpcUa_False;
+
+#if OPCUA_USE_SYNCHRONISATION
+                OpcUa_P_Mutex_Unlock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+                pInternalSocket->pfnEventCallback(pInternalSocket, OPCUA_SOCKET_WRITE_EVENT,
+                                                  pInternalSocket->pvUserData, 0, OpcUa_True);
+
+#if OPCUA_USE_SYNCHRONISATION
+                OpcUa_P_Mutex_Lock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+                if(pInternalSocket->bSslError)
+                {
+                    OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+                }
+            }
+            if(!pInternalSocket->bReadBlocked)
+            {
+                pInternalSocket->bReadBlocked = OpcUa_True;
+
+#if OPCUA_USE_SYNCHRONISATION
+                OpcUa_P_Mutex_Unlock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+                pInternalSocket->pfnEventCallback(pInternalSocket, OPCUA_SOCKET_READ_EVENT,
+                                                  pInternalSocket->pvUserData, 0, OpcUa_True);
+
+#if OPCUA_USE_SYNCHRONISATION
+                OpcUa_P_Mutex_Lock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+                if(pInternalSocket->bSslError)
+                {
+                    OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+                }
+            }
+            wpending1 = BIO_wpending(pInternalSocket->pRawBio);
+            if(wpending1 > 0 && (wpending0 > wpending1 || pInternalSocket->bSslProgress))
+            {
+                uStatus = OpcUa_GoodCallAgain;
+            }
+        }
+
+        result = BIO_nread0(pInternalSocket->pRawBio, &buf);
+        if(result > 0)
+        {
+            result = OpcUa_P_Socket_Write(pInternalSocket->pRawSocket,
+                                          (OpcUa_Byte*)buf, result, OpcUa_False);
+            if(result > 0)
+            {
+                BIO_nread(pInternalSocket->pRawBio, NULL, result);
+                uStatus = OpcUa_GoodCallAgain;
+            }
+            else if(result < 0)
+            {
+                pInternalSocket->bSslError = OpcUa_True;
+                OpcUa_P_Socket_Close(pInternalSocket->pRawSocket);
+                OpcUa_GotoErrorWithStatus(OpcUa_BadDisconnect);
+            }
+        }
+    }
+    while(uStatus == OpcUa_GoodCallAgain);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Read SSL Socket.
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_P_SocketService_SslRead( OpcUa_Socket    a_pSocket,
+                                                       OpcUa_Byte*     a_pBuffer,
+                                                       OpcUa_UInt32    a_nBufferSize,
+                                                       OpcUa_UInt32*   a_pBytesRead)
+{
+    OpcUa_InternalSslSocket*   pInternalSocket     = (OpcUa_InternalSslSocket*)a_pSocket;
+    int                        ssl_result;
+    int                        ssl_error;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SslRead");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+    OpcUa_GotoErrorIfArgumentNull(a_pBuffer);
+    OpcUa_GotoErrorIfArgumentNull(a_pBytesRead);
+
+    *a_pBytesRead = 0;
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    if(pInternalSocket->bListenSocket || pInternalSocket->bWantShutdown || pInternalSocket->bSslError)
+    {
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Unlock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidState);
+    }
+
+    pInternalSocket->bReadBlocked = OpcUa_False;
+    ssl_result = SSL_read(pInternalSocket->pSslConnection,
+                          a_pBuffer, a_nBufferSize);
+    ssl_error = SSL_get_error(pInternalSocket->pSslConnection, ssl_result);
+
+    if(ssl_result > 0)
+    {
+        *a_pBytesRead = (OpcUa_UInt32)ssl_result;
+        pInternalSocket->bSslProgress = OpcUa_True;
+    }
+    else
+    {
+        switch(ssl_error)
+        {
+            case SSL_ERROR_WANT_WRITE:
+            case SSL_ERROR_WANT_READ:
+                uStatus = OpcUa_BadWouldBlock;
+                break;
+            case SSL_ERROR_ZERO_RETURN:
+                uStatus = OpcUa_BadDisconnect;
+                break;
+            case SSL_ERROR_SSL:
+            case SSL_ERROR_SYSCALL:
+                pInternalSocket->bSslError = OpcUa_True;
+                OpcUa_SslSocket_DoStateMachine(pInternalSocket, OpcUa_False,
+                                               OpcUa_Null, OpcUa_Null);
+                OpcUa_P_Socket_Close(pInternalSocket->pRawSocket);
+                uStatus = OpcUa_BadInternalError;
+                break;
+            default:
+                uStatus = OpcUa_BadCommunicationError;
+                break;
+        }
+    }
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Write SSL Socket.
+ *===========================================================================*/
+/* returns number of bytes written to the socket */
+static OpcUa_Int32 OpcUa_P_SocketService_SslWrite( OpcUa_Socket    a_pSocket,
+                                                   OpcUa_Byte*     a_pBuffer,
+                                                   OpcUa_UInt32    a_uBufferSize,
+                                                   OpcUa_Boolean   a_bBlock)
+{
+    OpcUa_InternalSslSocket*    pInternalSocket     = (OpcUa_InternalSslSocket*)a_pSocket;
+    OpcUa_Int32                 result;
+    OpcUa_UInt32                RemainingBufferSize = a_uBufferSize;
+
+    OpcUa_ReturnErrorIfNull(a_pSocket, OPCUA_SOCKET_ERROR);
+    OpcUa_ReturnErrorIfNull(a_pBuffer, OPCUA_SOCKET_ERROR);
+
+    if(a_bBlock != OpcUa_False)
+    {
+        OpcUa_Trace(OPCUA_TRACE_LEVEL_ERROR, "OpcUa_P_Socket_Write: Blocking write not supported.\n");
+        return OPCUA_SOCKET_ERROR;
+    }
+
+    if(a_uBufferSize == 0)
+    {
+        return OPCUA_SOCKET_ERROR;
+    }
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    if(pInternalSocket->bListenSocket || pInternalSocket->bWantShutdown || pInternalSocket->bSslError)
+    {
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Unlock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+        return OPCUA_SOCKET_ERROR;
+    }
+
+    OpcUa_SslSocket_DoStateMachine(pInternalSocket, OpcUa_False,
+                                   a_pBuffer, &RemainingBufferSize);
+
+    /* update size before returning */
+    result = a_uBufferSize - RemainingBufferSize;
+    pInternalSocket->bWriteBlocked = RemainingBufferSize > 0;
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    return result;
+}
+
+/*============================================================================
+ * Close SSL Socket.
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_P_SocketService_SslClose(OpcUa_Socket a_pSocket)
+{
+    OpcUa_InternalSslSocket* pInternalSocket = (OpcUa_InternalSslSocket*)a_pSocket;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SslClose");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    if(pInternalSocket->bListenSocket)
+    {
+        OpcUa_P_Socket_Close(pInternalSocket->pRawSocket);
+    }
+    else if(!pInternalSocket->bSslError)
+    {
+        /* Initiate SSL Shutdown */
+        pInternalSocket->bWantShutdown = OpcUa_True;
+        OpcUa_SslSocket_DoStateMachine(pInternalSocket, OpcUa_False,
+                                       OpcUa_Null, OpcUa_Null);
+    }
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Get IP Address and Port Number of the Peer
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_P_SocketService_SslGetPeerInfo(  OpcUa_Socket  a_pSocket,
+                                                               OpcUa_CharA*  a_achPeerInfoBuffer,
+                                                               OpcUa_UInt32  a_uiPeerInfoBufferSize)
+{
+    OpcUa_InternalSslSocket* pInternalSocket = (OpcUa_InternalSslSocket*)a_pSocket;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SslGetPeerInfo");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+    OpcUa_GotoErrorIfArgumentNull(a_achPeerInfoBuffer);
+
+    uStatus = OpcUa_P_Socket_GetPeerInfo(pInternalSocket->pRawSocket, a_achPeerInfoBuffer, a_uiPeerInfoBufferSize);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Get last socket error
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_P_SocketService_SslGetLastError(OpcUa_Socket a_pSocket)
+{
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SslGetLastError");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Set socket user data
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_P_SocketService_SslSetUserData(OpcUa_Socket a_pSocket,
+                                                             OpcUa_Void*  a_pvUserData)
+{
+    OpcUa_InternalSocket*   pInternalSocket = (OpcUa_InternalSocket*)a_pSocket;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SslSetUserData");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+
+    pInternalSocket->pvUserData = a_pvUserData;
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Initialize Socket Service Table
+ *===========================================================================*/
+static OpcUa_SocketServiceTable OpcUa_SslSocketServiceTable =
+{
+  OpcUa_P_SocketService_SslRead,
+  OpcUa_P_SocketService_SslWrite,
+  OpcUa_P_SocketService_SslClose,
+  OpcUa_P_SocketService_SslGetPeerInfo,
+  OpcUa_P_SocketService_SslGetLastError,
+  OpcUa_P_SocketService_SslSetUserData
+};
+
+/*============================================================================
+ * Close and Delete the Ssl Socket
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_SslSocket_InternalClose( OpcUa_InternalSslSocket* pInternalSocket)
+{
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SslSocket_InternalClose");
+
+    pInternalSocket->pfnEventCallback(pInternalSocket, OPCUA_SOCKET_CLOSE_EVENT,
+                                      pInternalSocket->pvUserData, 0, OpcUa_True);
+
+    if(!pInternalSocket->bListenSocket)
+    {
+        BIO_free(pInternalSocket->pRawBio);
+        SSL_free(pInternalSocket->pSslConnection);
+        SSL_CTX_free(pInternalSocket->pSslContext);
+    }
+#ifndef OPENSSL_NO_DH
+    else if(pInternalSocket->pDHparams != OpcUa_Null)
+    {
+        DH_free(pInternalSocket->pDHparams);
+    }
+#endif /* OPENSSL_NO_DH */
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Delete(&pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    OpcUa_P_Memory_Free(pInternalSocket);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Verify SSL Client Certificate
+ *===========================================================================*/
+static int OpcUa_SslSocket_VerifyCertificate( X509_STORE_CTX *ctx, void *arg)
+{
+    OpcUa_InternalSslSocket* pInternalSocket   = (OpcUa_InternalSslSocket*)arg;
+#if OPENSSL_VERSION_NUMBER >= 0x1010000fL
+    STACK_OF(X509)*          pChain            = X509_STORE_CTX_get0_untrusted(ctx);
+#else
+    STACK_OF(X509)*          pChain            = ctx->untrusted;
+#endif
+    int                      n;
+    unsigned char*           p;
+    OpcUa_StatusCode         uStatus;
+    OpcUa_ByteString         ClientCert;
+    OpcUa_PKIProvider        PKIProvider;
+    OpcUa_Handle             hCertificateStore = OpcUa_Null;
+    OpcUa_Int                validationCode    = X509_V_ERR_APPLICATION_VERIFICATION;
+
+    ClientCert.Length = 0;
+    for(n=0; n<sk_X509_num(pChain); n++)
+    {
+        ClientCert.Length += i2d_X509(sk_X509_value(pChain, n), OpcUa_Null);
+    }
+
+    ClientCert.Data = (OpcUa_Byte*)OpcUa_P_Memory_Alloc(ClientCert.Length);
+    if(ClientCert.Data == OpcUa_Null)
+    {
+        X509_STORE_CTX_set_error(ctx, X509_V_ERR_OUT_OF_MEM);
+        return -1;
+    }
+
+    p = ClientCert.Data;
+    for(n=0; n<sk_X509_num(pChain); n++)
+    {
+        i2d_X509(sk_X509_value(pChain, n), &p);
+    }
+
+    OpcUa_MemSet(&PKIProvider, 0, sizeof(PKIProvider));
+    uStatus = OpcUa_P_PKIFactory_CreatePKIProvider(pInternalSocket->pPKIConfig, &PKIProvider);
+    if(OpcUa_IsGood(uStatus))
+    {
+        uStatus = PKIProvider.OpenCertificateStore(&PKIProvider, &hCertificateStore);
+        if(OpcUa_IsGood(uStatus))
+        {
+            uStatus = PKIProvider.ValidateCertificate(&PKIProvider, &ClientCert, hCertificateStore,
+                                                      &validationCode);
+            PKIProvider.CloseCertificateStore(&PKIProvider, &hCertificateStore);
+        }
+        OpcUa_P_PKIFactory_DeletePKIProvider(&PKIProvider);
+    }
+
+    if(OpcUa_IsBad(uStatus))
+    {
+        if(validationCode == X509_V_OK)
+        {
+            validationCode = X509_V_ERR_APPLICATION_VERIFICATION;
+        }
+        if(pInternalSocket->pfnCertificateValidation != OpcUa_Null)
+        {
+            uStatus = pInternalSocket->pfnCertificateValidation(pInternalSocket, pInternalSocket->pvUserData,
+                                                                &ClientCert, uStatus);
+            if(OpcUa_IsEqual(OpcUa_BadContinue))
+            {
+                validationCode = X509_V_OK;
+            }
+        }
+    }
+    else
+    {
+        validationCode = X509_V_OK;
+        if(pInternalSocket->pfnCertificateValidation != OpcUa_Null)
+        {
+            uStatus = pInternalSocket->pfnCertificateValidation(pInternalSocket, pInternalSocket->pvUserData,
+                                                                &ClientCert, uStatus);
+            if(OpcUa_IsBad(uStatus) && OpcUa_IsNotEqual(OpcUa_BadContinue))
+            {
+                validationCode = X509_V_ERR_APPLICATION_VERIFICATION;
+            }
+        }
+    }
+
+    ERR_clear_error();
+    OpcUa_P_Memory_Free(ClientCert.Data);
+    X509_STORE_CTX_set_error(ctx, validationCode);
+    return validationCode == X509_V_OK ? 1 : 0;
+}
+
+/*============================================================================
+ * Verify SSL Client Certificate
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_SslSocket_InitializeSslContext( OpcUa_InternalSslSocket* pInternalSocket)
+{
+    EVP_PKEY*            pKey;
+    X509*                pCert;
+    const unsigned char* p;
+    int                  result;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "InitializeSslContext");
+
+    p = pInternalSocket->pServerPrivateKey->Key.Data;
+    pKey = d2i_PrivateKey(EVP_PKEY_RSA, OpcUa_Null, &p,
+                          pInternalSocket->pServerPrivateKey->Key.Length);
+    if(pKey == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+    }
+    result = SSL_CTX_use_PrivateKey(pInternalSocket->pSslContext, pKey);
+    EVP_PKEY_free(pKey);
+    if(result <= 0)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+    }
+
+    p = pInternalSocket->pServerCertificate->Data;
+    pCert = d2i_X509(OpcUa_Null, &p, pInternalSocket->pServerCertificate->Length);
+    if(pCert == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+    }
+    result = SSL_CTX_use_certificate(pInternalSocket->pSslContext, pCert);
+    X509_free(pCert);
+    if(result <= 0)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+    }
+
+    while(p < pInternalSocket->pServerCertificate->Data + pInternalSocket->pServerCertificate->Length)
+    {
+        pCert = d2i_X509(OpcUa_Null, &p, pInternalSocket->pServerCertificate->Data
+                         + pInternalSocket->pServerCertificate->Length - p);
+        if(pCert == OpcUa_Null)
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+        }
+        result = SSL_CTX_add_extra_chain_cert(pInternalSocket->pSslContext, pCert);
+        if(result <= 0)
+        {
+            X509_free(pCert);
+            OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+        }
+    }
+
+    SSL_CTX_set_cert_verify_callback( pInternalSocket->pSslContext,
+                                      OpcUa_SslSocket_VerifyCertificate,
+                                      pInternalSocket);
+    SSL_CTX_set_verify( pInternalSocket->pSslContext,
+                        OPCUA_P_SOCKETMANAGER_SSL_VERIFY_OPTION,
+                        OpcUa_Null);
+    SSL_CTX_set_options( pInternalSocket->pSslContext,
+                         OPCUA_P_SOCKETMANAGER_SSL_PROTOCOL_OPTION);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Accept a SSL server socket
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_SslSocket_InternalAccept( OpcUa_InternalSslSocket* a_pInternalSocket,
+                                                        OpcUa_Socket             a_pRawSocket)
+{
+    OpcUa_InternalSslSocket* pInternalSocket = OpcUa_Null;
+    BIO*                     pSslBio         = OpcUa_Null;
+    int                      result;
+#ifndef OPENSSL_NO_ECDH
+    EC_KEY*                  ecdh;
+#endif
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "InternalAccept");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pInternalSocket);
+    OpcUa_GotoErrorIfArgumentNull(a_pRawSocket);
+    OpcUa_GotoErrorIfTrue(!a_pInternalSocket->bListenSocket, OpcUa_BadInvalidArgument);
+
+    pInternalSocket = (OpcUa_InternalSslSocket*)OpcUa_P_Memory_Alloc(sizeof(OpcUa_InternalSslSocket));
+    OpcUa_GotoErrorIfAllocFailed(pInternalSocket);
+
+    OpcUa_MemSet(pInternalSocket, 0, sizeof(OpcUa_InternalSslSocket));
+
+#if OPCUA_USE_SYNCHRONISATION
+    uStatus = OpcUa_P_Mutex_Create(&pInternalSocket->pMutex);
+    OpcUa_GotoErrorIfBad(uStatus);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    pInternalSocket->pSocketServiceTable      = &OpcUa_SslSocketServiceTable;
+    pInternalSocket->pfnCertificateValidation = a_pInternalSocket->pfnCertificateValidation;
+    pInternalSocket->pfnEventCallback         = a_pInternalSocket->pfnEventCallback;
+    pInternalSocket->pvUserData               = a_pInternalSocket->pvUserData;
+    pInternalSocket->pServerCertificate       = a_pInternalSocket->pServerCertificate;
+    pInternalSocket->pServerPrivateKey        = a_pInternalSocket->pServerPrivateKey;
+    pInternalSocket->pPKIConfig               = a_pInternalSocket->pPKIConfig;
+    pInternalSocket->pRawSocket               = a_pRawSocket;
+    pInternalSocket->bListenSocket            = OpcUa_False;
+    pInternalSocket->bWantShutdown            = OpcUa_False;
+    pInternalSocket->bWriteBlocked            = OpcUa_False;
+    pInternalSocket->bReadBlocked             = OpcUa_False;
+    pInternalSocket->bSslProgress             = OpcUa_False;
+    pInternalSocket->bSslError                = OpcUa_False;
+
+    pInternalSocket->pSslContext              = SSL_CTX_new(SSLv23_server_method());
+    OpcUa_GotoErrorIfAllocFailed(pInternalSocket->pSslContext);
+
+    uStatus = OpcUa_SslSocket_InitializeSslContext(pInternalSocket);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+#ifndef OPENSSL_NO_ECDH
+    /* Enable Perfect Forward Secrecy, using EECDH. */
+    ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+    if(ecdh != OpcUa_Null)
+    {
+        SSL_CTX_set_tmp_ecdh(pInternalSocket->pSslContext, ecdh);
+        EC_KEY_free(ecdh);
+    }
+#endif /* OPENSSL_NO_ECDH */
+#ifndef OPENSSL_NO_DH
+    if(a_pInternalSocket->pDHparams != OpcUa_Null)
+    {
+        SSL_CTX_set_tmp_dh(pInternalSocket->pSslContext,
+                           a_pInternalSocket->pDHparams);
+        SSL_CTX_set_options(pInternalSocket->pSslContext,
+                            SSL_OP_SINGLE_DH_USE);
+    }
+#endif /* OPENSSL_NO_DH */
+
+    pInternalSocket->pSslConnection           = SSL_new(pInternalSocket->pSslContext);
+    OpcUa_GotoErrorIfAllocFailed(pInternalSocket->pSslConnection);
+
+    pInternalSocket->pRawBio                  = BIO_new(BIO_s_bio());
+    OpcUa_GotoErrorIfAllocFailed(pInternalSocket->pRawBio);
+
+    pSslBio                                   = BIO_new(BIO_s_bio());
+    OpcUa_GotoErrorIfAllocFailed(pSslBio);
+
+    result = BIO_make_bio_pair(pSslBio, pInternalSocket->pRawBio);
+    OpcUa_GotoErrorIfTrue(result <= 0, OpcUa_BadInternalError);
+
+    SSL_set_bio(pInternalSocket->pSslConnection, pSslBio, pSslBio);
+    pSslBio = OpcUa_Null;
+    SSL_set_accept_state(pInternalSocket->pSslConnection);
+
+    uStatus = OpcUa_P_Socket_SetUserData(pInternalSocket->pRawSocket, pInternalSocket);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    pInternalSocket->pfnEventCallback(pInternalSocket, OPCUA_SOCKET_ACCEPT_EVENT,
+                                      pInternalSocket->pvUserData, 0, OpcUa_True);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    OpcUa_P_Socket_SetUserData(a_pRawSocket, OpcUa_Null);
+    OpcUa_P_Socket_Close(a_pRawSocket);
+
+    if(pSslBio != OpcUa_Null)
+    {
+        BIO_free(pSslBio);
+    }
+
+    if(pInternalSocket != OpcUa_Null)
+    {
+        if(pInternalSocket->pRawBio != OpcUa_Null)
+        {
+            BIO_free(pInternalSocket->pRawBio);
+        }
+
+        if(pInternalSocket->pSslConnection != OpcUa_Null)
+        {
+            SSL_free(pInternalSocket->pSslConnection);
+        }
+
+        if(pInternalSocket->pSslContext != OpcUa_Null)
+        {
+            SSL_CTX_free(pInternalSocket->pSslContext);
+        }
+
+#if OPCUA_USE_SYNCHRONISATION
+        if(pInternalSocket->pMutex != OpcUa_Null)
+        {
+            OpcUa_P_Mutex_Delete(&pInternalSocket->pMutex);
+        }
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+        OpcUa_P_Memory_Free(pInternalSocket);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Read data from the Raw Socket
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_SslSocket_InternalRead( OpcUa_InternalSslSocket* pInternalSocket)
+{
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SslSocket_InternalRead");
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    OpcUa_SslSocket_DoStateMachine(pInternalSocket, OpcUa_True,
+                                   OpcUa_Null, OpcUa_Null);
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Write data to the Raw Socket
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_SslSocket_InternalWrite( OpcUa_InternalSslSocket* pInternalSocket)
+{
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "SslSocket_InternalWrite");
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    OpcUa_SslSocket_DoStateMachine(pInternalSocket, OpcUa_True,
+                                   OpcUa_Null, OpcUa_Null);
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(pInternalSocket->pMutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Handle Events from the Raw Socket
+ *===========================================================================*/
+static OpcUa_StatusCode OpcUa_RawSocket_EventCallback( OpcUa_Socket   a_hSocket,
+                                                       OpcUa_UInt32   a_uintSocketEvent,
+                                                       OpcUa_Void*    a_pUserData,
+                                                       OpcUa_UInt16   a_usPortNumber,
+                                                       OpcUa_Boolean  a_bIsSSL)
+{
+    OpcUa_InternalSslSocket* pInternalSocket = (OpcUa_InternalSslSocket*)a_pUserData;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "RawSocket_EventCallback");
+
+    OpcUa_GotoErrorIfArgumentNull(a_hSocket);
+    OpcUa_GotoErrorIfArgumentNull(a_pUserData);
+    OpcUa_ReferenceParameter(a_usPortNumber);
+    OpcUa_ReferenceParameter(a_bIsSSL);
+
+    switch(a_uintSocketEvent)
+    {
+    case OPCUA_SOCKET_READ_EVENT:
+        {
+            OpcUa_SslSocket_InternalRead(pInternalSocket);
+            break;
+        }
+    case OPCUA_SOCKET_WRITE_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_RawSocket_EventCallback OPCUA_SOCKET_WRITE_EVENT\n");
+            OpcUa_SslSocket_InternalWrite(pInternalSocket);
+            break;
+        }
+    case OPCUA_SOCKET_CONNECT_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_RawSocket_EventCallback: OPCUA_SOCKET_CONNECT_EVENT\n");
+            pInternalSocket->pfnEventCallback(pInternalSocket, OPCUA_SOCKET_CONNECT_EVENT,
+                                              pInternalSocket->pvUserData, 0, OpcUa_True);
+            break;
+        }
+    case OPCUA_SOCKET_CLOSE_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_RawSocket_EventCallback: OPCUA_SOCKET_CLOSE_EVENT\n");
+            OpcUa_SslSocket_InternalClose(pInternalSocket);
+            break;
+        }
+    case OPCUA_SOCKET_TIMEOUT_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_RawSocket_EventCallback: OPCUA_SOCKET_TIMEOUT_EVENT\n");
+            pInternalSocket->pfnEventCallback(pInternalSocket, OPCUA_SOCKET_TIMEOUT_EVENT,
+                                              pInternalSocket->pvUserData, 0, OpcUa_True);
+            OpcUa_P_Socket_Close(pInternalSocket->pRawSocket);
+            break;
+        }
+    case OPCUA_SOCKET_EXCEPT_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_RawSocket_EventCallback: OPCUA_SOCKET_EXCEPT_EVENT\n");
+            pInternalSocket->pfnEventCallback(pInternalSocket, OPCUA_SOCKET_EXCEPT_EVENT,
+                                              pInternalSocket->pvUserData, 0, OpcUa_True);
+            OpcUa_P_Socket_Close(pInternalSocket->pRawSocket);
+            break;
+        }
+    case OPCUA_SOCKET_ACCEPT_EVENT:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_DEBUG, "OpcUa_RawSocket_EventCallback: OPCUA_SOCKET_ACCEPT_EVENT\n");
+            OpcUa_SslSocket_InternalAccept(pInternalSocket, a_hSocket);
+            break;
+        }
+    default:
+        {
+            OpcUa_Trace(OPCUA_TRACE_LEVEL_WARNING, "OpcUa_RawSocket_EventCallback: Unknown event!\n");
+            break;
+        }
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Create a SSL server socket
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_CreateSslServer(  OpcUa_SocketManager              a_pSocketManager,
+                                                                       OpcUa_StringA                    a_sAddress,
+                                                                       OpcUa_Boolean                    a_bListenOnAllInterfaces,
+                                                                       OpcUa_ByteString*                a_pServerCertificate,
+                                                                       OpcUa_Key*                       a_pServerPrivateKey,
+                                                                       OpcUa_Void*                      a_pPKIConfig,
+                                                                       OpcUa_Socket_EventCallback       a_pfnSocketCallBack,
+                                                                       OpcUa_Socket_CertificateCallback a_pfnCertificateCallBack,
+                                                                       OpcUa_Void*                      a_pCallbackData,
+                                                                       OpcUa_Socket*                    a_pSocket)
+{
+    OpcUa_InternalSslSocket* pInternalSocket = OpcUa_Null;
+#ifndef OPENSSL_NO_DH
+    OpcUa_StringA            pFileName;
+    BIO*                     bio;
+#endif /* OPENSSL_NO_DH */
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "CreateSslServer");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pServerCertificate);
+    OpcUa_GotoErrorIfArgumentNull(a_pServerPrivateKey);
+    OpcUa_GotoErrorIfArgumentNull(a_pfnSocketCallBack);
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+
+    if(a_pServerPrivateKey->Type != OpcUa_Crypto_KeyType_Rsa_Private
+       || a_pServerPrivateKey->Key.Data == OpcUa_Null
+       || a_pServerCertificate->Data == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    *a_pSocket = OpcUa_Null;
+    pInternalSocket = (OpcUa_InternalSslSocket*)OpcUa_P_Memory_Alloc(sizeof(OpcUa_InternalSslSocket));
+    OpcUa_GotoErrorIfAllocFailed(pInternalSocket);
+
+    OpcUa_MemSet(pInternalSocket, 0, sizeof(OpcUa_InternalSslSocket));
+
+#if OPCUA_USE_SYNCHRONISATION
+    uStatus = OpcUa_P_Mutex_Create(&pInternalSocket->pMutex);
+    OpcUa_GotoErrorIfBad(uStatus);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    pInternalSocket->pSocketServiceTable      = &OpcUa_SslSocketServiceTable;
+    pInternalSocket->pfnCertificateValidation = a_pfnCertificateCallBack;
+    pInternalSocket->pfnEventCallback         = a_pfnSocketCallBack;
+    pInternalSocket->pvUserData               = a_pCallbackData;
+    pInternalSocket->pServerCertificate       = a_pServerCertificate;
+    pInternalSocket->pServerPrivateKey        = a_pServerPrivateKey;
+    pInternalSocket->pPKIConfig               = a_pPKIConfig;
+    pInternalSocket->bListenSocket            = OpcUa_True;
+
+#ifndef OPENSSL_NO_DH
+    pInternalSocket->pDHparams                = OpcUa_Null;
+    pFileName = OpcUa_P_PKIFactory_GetDHParamFileName(a_pPKIConfig);
+    if(pFileName != OpcUa_Null)
+    {
+        bio = BIO_new_file(pFileName, "r");
+        if(bio != OpcUa_Null)
+        {
+            pInternalSocket->pDHparams = PEM_read_bio_DHparams(bio, NULL, NULL, "");
+            BIO_free(bio);
+        }
+    }
+#endif /* OPENSSL_NO_DH */
+
+    *a_pSocket = pInternalSocket;
+
+    uStatus = OpcUa_P_SocketManager_CreateServer( a_pSocketManager,
+                                                  a_sAddress,
+                                                  a_bListenOnAllInterfaces,
+                                                  OpcUa_RawSocket_EventCallback,
+                                                  pInternalSocket,
+                                                  &pInternalSocket->pRawSocket);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(a_pSocket != OpcUa_Null)
+    {
+        *a_pSocket = OpcUa_Null;
+    }
+
+    if(pInternalSocket != OpcUa_Null)
+    {
+#if OPCUA_USE_SYNCHRONISATION
+        if(pInternalSocket->pMutex != OpcUa_Null)
+        {
+            OpcUa_P_Mutex_Delete(&pInternalSocket->pMutex);
+        }
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+#ifndef OPENSSL_NO_DH
+        if(pInternalSocket->pDHparams != OpcUa_Null)
+        {
+            DH_free(pInternalSocket->pDHparams);
+        }
+#endif /* OPENSSL_NO_DH */
+
+        OpcUa_P_Memory_Free(pInternalSocket);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+/*============================================================================
+ * Create a SSL client socket
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_CreateSslClient(  OpcUa_SocketManager              a_pSocketManager,
+                                                                       OpcUa_StringA                    a_sRemoteAddress,
+                                                                       OpcUa_UInt16                     a_uLocalPort,
+                                                                       OpcUa_ByteString*                a_pClientCertificate,
+                                                                       OpcUa_Key*                       a_pClientPrivateKey,
+                                                                       OpcUa_Void*                      a_pPKIConfig,
+                                                                       OpcUa_Socket_EventCallback       a_pfnSocketCallBack,
+                                                                       OpcUa_Socket_CertificateCallback a_pfnCertificateCallBack,
+                                                                       OpcUa_Void*                      a_pCallbackData,
+                                                                       OpcUa_Socket*                    a_pSocket)
+{
+    OpcUa_InternalSslSocket* pInternalSocket = OpcUa_Null;
+    BIO*                     pSslBio         = OpcUa_Null;
+    int                      result;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "CreateSslClient");
+
+    OpcUa_GotoErrorIfArgumentNull(a_pClientCertificate);
+    OpcUa_GotoErrorIfArgumentNull(a_pClientPrivateKey);
+    OpcUa_GotoErrorIfArgumentNull(a_pfnSocketCallBack);
+    OpcUa_GotoErrorIfArgumentNull(a_pSocket);
+
+    if(a_pClientPrivateKey->Type != OpcUa_Crypto_KeyType_Rsa_Private
+       || a_pClientPrivateKey->Key.Data == OpcUa_Null
+       || a_pClientCertificate->Data == OpcUa_Null)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInvalidArgument);
+    }
+
+    *a_pSocket = OpcUa_Null;
+    pInternalSocket = (OpcUa_InternalSslSocket*)OpcUa_P_Memory_Alloc(sizeof(OpcUa_InternalSslSocket));
+    OpcUa_GotoErrorIfAllocFailed(pInternalSocket);
+
+    OpcUa_MemSet(pInternalSocket, 0, sizeof(OpcUa_InternalSslSocket));
+
+#if OPCUA_USE_SYNCHRONISATION
+    uStatus = OpcUa_P_Mutex_Create(&pInternalSocket->pMutex);
+    OpcUa_GotoErrorIfBad(uStatus);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    pInternalSocket->pSocketServiceTable      = &OpcUa_SslSocketServiceTable;
+    pInternalSocket->pfnCertificateValidation = a_pfnCertificateCallBack;
+    pInternalSocket->pfnEventCallback         = a_pfnSocketCallBack;
+    pInternalSocket->pvUserData               = a_pCallbackData;
+    pInternalSocket->pServerCertificate       = a_pClientCertificate;
+    pInternalSocket->pServerPrivateKey        = a_pClientPrivateKey;
+    pInternalSocket->pPKIConfig               = a_pPKIConfig;
+    pInternalSocket->bListenSocket            = OpcUa_False;
+    pInternalSocket->bWantShutdown            = OpcUa_False;
+    pInternalSocket->bWriteBlocked            = OpcUa_False;
+    pInternalSocket->bReadBlocked             = OpcUa_False;
+    pInternalSocket->bSslProgress             = OpcUa_False;
+    pInternalSocket->bSslError                = OpcUa_False;
+
+    pInternalSocket->pSslContext              = SSL_CTX_new(SSLv23_client_method());
+    OpcUa_GotoErrorIfAllocFailed(pInternalSocket->pSslContext);
+
+    uStatus = OpcUa_SslSocket_InitializeSslContext(pInternalSocket);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+    pInternalSocket->pSslConnection           = SSL_new(pInternalSocket->pSslContext);
+    OpcUa_GotoErrorIfAllocFailed(pInternalSocket->pSslConnection);
+
+    pInternalSocket->pRawBio                  = BIO_new(BIO_s_bio());
+    OpcUa_GotoErrorIfAllocFailed(pInternalSocket->pRawBio);
+
+    pSslBio                                   = BIO_new(BIO_s_bio());
+    OpcUa_GotoErrorIfAllocFailed(pSslBio);
+
+    result = BIO_make_bio_pair(pSslBio, pInternalSocket->pRawBio);
+    OpcUa_GotoErrorIfTrue(result <= 0, OpcUa_BadInternalError);
+
+    SSL_set_bio(pInternalSocket->pSslConnection, pSslBio, pSslBio);
+    pSslBio = OpcUa_Null;
+    SSL_set_connect_state(pInternalSocket->pSslConnection);
+
+    *a_pSocket = pInternalSocket;
+
+    uStatus = OpcUa_P_SocketManager_CreateClient( a_pSocketManager,
+                                                  a_sRemoteAddress,
+                                                  a_uLocalPort,
+                                                  OpcUa_RawSocket_EventCallback,
+                                                  pInternalSocket,
+                                                  &pInternalSocket->pRawSocket);
+    OpcUa_GotoErrorIfBad(uStatus);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(a_pSocket != OpcUa_Null)
+    {
+        *a_pSocket = OpcUa_Null;
+    }
+
+    if(pSslBio != OpcUa_Null)
+    {
+        BIO_free(pSslBio);
+    }
+
+    if(pInternalSocket != OpcUa_Null)
+    {
+        if(pInternalSocket->pRawBio != OpcUa_Null)
+        {
+            BIO_free(pInternalSocket->pRawBio);
+        }
+
+        if(pInternalSocket->pSslConnection != OpcUa_Null)
+        {
+            SSL_free(pInternalSocket->pSslConnection);
+        }
+
+        if(pInternalSocket->pSslContext != OpcUa_Null)
+        {
+            SSL_CTX_free(pInternalSocket->pSslContext);
+        }
+
+#if OPCUA_USE_SYNCHRONISATION
+        if(pInternalSocket->pMutex != OpcUa_Null)
+        {
+            OpcUa_P_Mutex_Delete(&pInternalSocket->pMutex);
+        }
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+        OpcUa_P_Memory_Free(pInternalSocket);
+    }
+
+OpcUa_FinishErrorHandling;
+}
+
+#endif /* OPCUA_P_SOCKETMANAGER_SUPPORT_SSL */

--- a/Stack/platforms/vxworks/opcua_p_socket_ssl.h
+++ b/Stack/platforms/vxworks/opcua_p_socket_ssl.h
@@ -1,0 +1,69 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_Socket_Ssl_H_
+#define _OpcUa_Socket_Ssl_H_ 1
+
+OPCUA_BEGIN_EXTERN_C
+
+#if OPCUA_P_SOCKETMANAGER_SUPPORT_SSL
+
+/*============================================================================
+ * Create a SSL server socket
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_CreateSslServer(  OpcUa_SocketManager              pSocketManager,
+                                                                       OpcUa_StringA                    sAddress,
+                                                                       OpcUa_Boolean                    bListenOnAllInterfaces,
+                                                                       OpcUa_ByteString*                pServerCertificate,
+                                                                       OpcUa_Key*                       pServerPrivateKey,
+                                                                       OpcUa_Void*                      pPKIConfig,
+                                                                       OpcUa_Socket_EventCallback       pfnSocketCallBack,
+                                                                       OpcUa_Socket_CertificateCallback pfnCertificateCallBack,
+                                                                       OpcUa_Void*                      pCallbackData,
+                                                                       OpcUa_Socket*                    pSocket);
+
+/*============================================================================
+ * Create a SSL client socket
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketManager_CreateSslClient(  OpcUa_SocketManager              pSocketManager,
+                                                                       OpcUa_StringA                    sRemoteAddress,
+                                                                       OpcUa_UInt16                     uLocalPort,
+                                                                       OpcUa_ByteString*                pClientCertificate,
+                                                                       OpcUa_Key*                       pClientPrivateKey,
+                                                                       OpcUa_Void*                      pPKIConfig,
+                                                                       OpcUa_Socket_EventCallback       pfnSocketCallBack,
+                                                                       OpcUa_Socket_CertificateCallback pfnCertificateCallBack,
+                                                                       OpcUa_Void*                      pCallbackData,
+                                                                       OpcUa_Socket*                    pSocket);
+
+#endif /* OPCUA_P_SOCKETMANAGER_SUPPORT_SSL */
+
+OPCUA_END_EXTERN_C
+
+#endif /* _OpcUa_Socket_Ssl_H_ */

--- a/Stack/platforms/vxworks/opcua_p_string.c
+++ b/Stack/platforms/vxworks/opcua_p_string.c
@@ -1,0 +1,133 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* System Headers */
+#include <stdio.h>
+#include <string.h>
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+
+/* own headers */
+#include <opcua_string.h>
+#include <opcua_p_string.h>
+
+/*============================================================================
+ * Copy uintCount Characters from a OpcUa_StringA to another OpcUa_StringA
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_String_strncpy(OpcUa_StringA strDestination, OpcUa_UInt32 uiDestSize, OpcUa_StringA strSource, OpcUa_UInt32 uiLength)
+{
+    if(strncpy(strDestination, strSource, uiLength) != strDestination)
+    {
+        return OpcUa_Bad;
+    }
+
+    if(uiDestSize > uiLength)
+    {
+        strDestination[uiLength] = '\0';
+    }
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * Append uintCount Characters from a OpcUa_String to another OpcUa_String.
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_String_strncat(OpcUa_StringA strDestination, OpcUa_UInt32 uiDestSize, OpcUa_StringA strSource, OpcUa_UInt32 uiLength)
+{
+    OpcUa_ReferenceParameter(uiDestSize);
+
+    if(strncat(strDestination, strSource, uiLength) != strDestination)
+    {
+        return OpcUa_Bad;
+    }
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * Get the Length from a OpcUa_String
+ *===========================================================================*/
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_String_strlen(OpcUa_StringA a_pCString)
+{
+    return (OpcUa_Int32) strlen(a_pCString);
+}
+
+/*============================================================================
+ * Compare two OpcUa_Strings Case Sensitive
+ *===========================================================================*/
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_String_strncmp(OpcUa_StringA string1, OpcUa_StringA string2, OpcUa_UInt32 uiLength)
+{
+    return (OpcUa_Int32)strncmp(string1, string2, uiLength);
+}
+
+/*============================================================================
+* Compare two OpcUa_Strings NOT Case Sensitive
+*===========================================================================*/
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_String_strnicmp(OpcUa_StringA string1, OpcUa_StringA string2, OpcUa_UInt32 uiLength)
+{
+    return (OpcUa_Int32) strncasecmp(string1, string2, uiLength);
+}
+
+/*============================================================================
+ * Write Values to a OpcUa_String
+ *===========================================================================*/
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_String_vsnprintf(OpcUa_StringA sDest, OpcUa_UInt32 nCount, const OpcUa_StringA sFormat, varg_list vaList)
+{
+    OpcUa_Int   nRetval;
+
+    nRetval = vsnprintf(sDest, nCount, sFormat, vaList);
+    if (nRetval >= (OpcUa_Int)nCount)
+    {
+        /* In case of truncation, we do not follow C99, and return -1 instead. */
+        nRetval = -1;
+    }
+
+    return (OpcUa_Int32)nRetval;
+}
+
+
+/*============================================================================
+ * Write Values to a OpcUa_String
+ *===========================================================================*/
+/* OPCUA_DLLCALL with varglist wont work ... -> vsnprintf */
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_String_snprintf(  OpcUa_StringA a_sTarget,
+                                                    OpcUa_UInt32  a_nCount,
+                                                    OpcUa_StringA a_sFormat,
+                                                    ...)
+{
+    OpcUa_Int   nRetval;
+    va_list     vaList;
+
+    va_start(vaList, a_sFormat);
+    nRetval = vsnprintf(a_sTarget, a_nCount, a_sFormat, vaList);
+    va_end( vaList );
+
+    return (OpcUa_Int32)nRetval;
+}

--- a/Stack/platforms/vxworks/opcua_p_string.h
+++ b/Stack/platforms/vxworks/opcua_p_string.h
@@ -1,0 +1,63 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/*============================================================================
+* Copy uintCount Characters from a OpcUa_StringA to another OpcUa_StringA
+*===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_String_strncpy(OpcUa_StringA strDestination, OpcUa_UInt32 uiDestSize, OpcUa_StringA strSource, OpcUa_UInt32 uiLength);
+
+/*============================================================================
+* Append uintCount Characters from a OpcUa_String to another OpcUa_String.
+*===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_String_strncat(OpcUa_StringA strDestination, OpcUa_UInt32 uiDestSize, OpcUa_StringA strSource, OpcUa_UInt32 uiLength);
+
+/*============================================================================
+* Get the Length from a OpcUa_String
+*===========================================================================*/
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_String_strlen(OpcUa_StringA   a_pCString);
+
+/*============================================================================
+* Compare two OpcUa_Strings Case Sensitive
+*===========================================================================*/
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_String_strncmp(OpcUa_StringA string1, OpcUa_StringA string2, OpcUa_UInt32 uiLength);
+
+/*============================================================================
+* Compare two OpcUa_Strings NOT Case Sensitive
+*===========================================================================*/
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_String_strnicmp(OpcUa_StringA string1, OpcUa_StringA string2, OpcUa_UInt32 uiLength);
+
+/*============================================================================
+* Print a list of values into a string.
+*===========================================================================*/
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_String_vsnprintf(OpcUa_StringA sDest, OpcUa_UInt32 uCount, const OpcUa_StringA sFormat, varg_list argptr) OPCUA_PRINTF_VALIST(3);
+
+/*============================================================================
+* Print a list of values into a string with a max length.
+*===========================================================================*/
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_String_snprintf(OpcUa_StringA sTarget, OpcUa_UInt32  nCount, OpcUa_StringA sFormat, ...) OPCUA_PRINTF_ARGS(3);

--- a/Stack/platforms/vxworks/opcua_p_thread.c
+++ b/Stack/platforms/vxworks/opcua_p_thread.c
@@ -1,0 +1,239 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+06nov18,lan  use VxWorks native api to implement OPC-UA thread.
+*/
+
+#include <vxWorks.h>
+#include <taskLib.h>
+#include <sysLib.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <opcua_p_internal.h>
+#include <opcua_p_thread.h>
+#include <opcua_p_memory.h>
+#include <opcua_p_openssl.h>
+
+/*============================================================================
+ * Port Layer Thread Main
+ *===========================================================================*/
+
+#define TASKNAME_SIZE   16
+
+typedef struct _OpcUa_P_ThreadArg
+    {
+    TASK_ID                      hThread;
+    OpcUa_CharA                  taskName[TASKNAME_SIZE];
+    OpcUa_Int                    taskPrio;
+    size_t                       taskStackSize;
+    OpcUa_PfnInternalThreadMain* pfnInternalThreadMain;
+    OpcUa_Void*                  ThreadArgs;
+    } OpcUa_P_ThreadArg;
+
+/**
+* This is the function, the new thread starts with. The only thing to do here,
+* is calling the InternalThreadMain from OpcUa_Thread.c and your internal stuff.
+*/
+
+static int task_start
+    (
+    void* args
+    )
+    {
+    OpcUa_P_ThreadArg*  pThreadArguments;
+    
+    if (args == OpcUa_Null)
+        {
+        return -1;
+        }
+
+    pThreadArguments = (OpcUa_P_ThreadArg*) args ;
+
+    /* run stack thread! */
+    pThreadArguments->pfnInternalThreadMain (pThreadArguments->ThreadArgs);
+
+#if OPCUA_REQUIRE_OPENSSL
+    OpcUa_P_OpenSSL_Thread_Cleanup();
+#endif
+
+    return 0;
+    }
+
+/*============================================================================
+ * Create a platform thread
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Thread_Create
+    (
+    OpcUa_RawThread* pRawThread
+    )
+    {
+    OpcUa_StatusCode    uStatus     = OpcUa_Good;
+    OpcUa_P_ThreadArg*  pThreadArgs = OpcUa_Null;
+    static OpcUa_Int32  taskNum  = 0;
+
+    *pRawThread = OpcUa_Null;
+
+    pThreadArgs = (OpcUa_P_ThreadArg *) OpcUa_P_Memory_Alloc (sizeof(OpcUa_P_ThreadArg));
+    OpcUa_ReturnErrorIfAllocFailed(pThreadArgs);
+
+    pThreadArgs->hThread                = TASK_ID_ERROR;
+    pThreadArgs->pfnInternalThreadMain  = OpcUa_Null;
+    pThreadArgs->ThreadArgs             = OpcUa_Null;
+    pThreadArgs->taskPrio               = 200; 
+    pThreadArgs->taskStackSize          = 1024 * 4; 
+    
+    (void) OpcUa_P_String_snprintf (pThreadArgs->taskName, TASKNAME_SIZE, 
+                                    "tOpcUa%d", taskNum);
+    ++taskNum;
+    *pRawThread = (OpcUa_RawThread) pThreadArgs;
+    return uStatus;
+    }
+
+/*============================================================================
+ * Delete Raw Thread
+ *===========================================================================*/
+OpcUa_Void OpcUa_P_Thread_Delete
+    (
+    OpcUa_RawThread* pRawThread
+    )
+    {
+    OpcUa_P_ThreadArg* pThreadArgs;
+
+    if (pRawThread == OpcUa_Null || *pRawThread == OpcUa_Null)
+        {
+        return;    
+        }
+    else
+        {
+        pThreadArgs = (OpcUa_P_ThreadArg*)*pRawThread;
+        if (pThreadArgs->hThread != TASK_ID_ERROR)
+            {
+            (void) taskWait (pThreadArgs->hThread, WAIT_FOREVER);
+            }
+        }
+    OpcUa_P_Memory_Free (*pRawThread);
+    *pRawThread = OpcUa_Null;
+    return;
+    }
+
+/*============================================================================
+ * Create Thread
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Thread_Start
+    (  
+    OpcUa_RawThread             pThread,
+    OpcUa_PfnInternalThreadMain pfnStartFunction,
+    OpcUa_Void*                 pArguments
+    )
+    {
+    OpcUa_P_ThreadArg*  pThreadArguments;
+    TASK_ID             tid;
+    _Vx_usr_arg_t       targ     = 0;
+
+    if(pThread == OpcUa_Null)
+        {
+        return OpcUa_BadInvalidArgument;
+        }
+
+    pThreadArguments = (OpcUa_P_ThreadArg*) pThread;
+
+    pThreadArguments->pfnInternalThreadMain = pfnStartFunction;
+    pThreadArguments->ThreadArgs            = pArguments;
+
+    tid = taskSpawn (pThreadArguments->taskName, 
+                     pThreadArguments->taskPrio, VX_FP_TASK, 
+                     pThreadArguments->taskStackSize,
+                     (FUNCPTR) task_start, (_Vx_usr_arg_t) pThreadArguments, 
+                     targ, targ, targ, targ, targ, targ, targ, targ, targ);
+    if (tid == TASK_ID_ERROR)
+        {
+        return OpcUa_BadResourceUnavailable;
+        }
+    pThreadArguments->hThread = tid;
+    return OpcUa_Good;
+    }
+
+/*============================================================================
+ * Send the thread to sleep.
+ *===========================================================================*/
+OpcUa_Void OpcUa_P_Thread_Sleep
+    (
+    OpcUa_UInt32 msecTimeout
+    )
+    {
+    struct timespec ntp;
+
+    ntp.tv_sec = msecTimeout / 1000;
+    ntp.tv_nsec = (msecTimeout % 1000) * 1000 * 1000;
+
+    clock_nanosleep (CLOCK_REALTIME, 0, &ntp, NULL);
+    }
+
+/*============================================================================
+ * Get Current Thread Id
+ *===========================================================================*/
+unsigned long OpcUa_P_Thread_GetCurrentThreadId (OpcUa_Void)
+    {
+    return (unsigned long) taskIdSelf ();
+    }
+
+/*============================================================================
+ * Set the platform thread attribute. 
+ * It should be called before the thread start.
+ *===========================================================================*/
+OpcUa_StatusCode    OpcUa_P_Thread_SetAttribute
+    (
+    OpcUa_RawThread pThread, 
+    OpcUa_CharA *   pName,
+    OpcUa_Int       priority,
+    size_t          stackSize
+    )
+    {
+    OpcUa_P_ThreadArg*  pThreadArguments;
+
+    if (pThread == OpcUa_Null || pName == OpcUa_Null || 
+        priority < 0 || stackSize < 1024)
+        {
+        return OpcUa_BadInvalidArgument;
+        }
+    pThreadArguments = (OpcUa_P_ThreadArg*) pThread; 
+    (void) OpcUa_P_String_snprintf (pThreadArguments->taskName, TASKNAME_SIZE, 
+                                    "%s", pName);
+    pThreadArguments->taskPrio = priority;
+    pThreadArguments->taskStackSize = stackSize;
+
+    return OpcUa_Good;
+    }

--- a/Stack/platforms/vxworks/opcua_p_thread.h
+++ b/Stack/platforms/vxworks/opcua_p_thread.h
@@ -1,0 +1,72 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+07nov18,lan  use VxWorks native api to implement OPC-UA thread.
+*/
+
+/*============================================================================
+ * Create a platform thread
+ *===========================================================================*/
+OpcUa_StatusCode    OpcUa_P_Thread_Create(      OpcUa_RawThread* pThread);
+
+/*============================================================================
+ * Set the platform thread attribute
+ *===========================================================================*/
+OpcUa_StatusCode    OpcUa_P_Thread_SetAttribute(OpcUa_RawThread pThread, 
+                                                OpcUa_CharA *   pName,
+                                                OpcUa_Int       priority,
+                                                size_t          stackSize);
+
+/*============================================================================
+ * Delete Raw Thread
+ *===========================================================================*/
+OpcUa_Void          OpcUa_P_Thread_Delete(      OpcUa_RawThread* pRawThread);
+
+/*============================================================================
+ * Start Thread
+ *===========================================================================*/
+OpcUa_StatusCode    OpcUa_P_Thread_Start(   OpcUa_RawThread             pThread,
+                                            OpcUa_PfnInternalThreadMain pfnStartFunction,
+                                            OpcUa_Void*                 pArguments);
+
+/*============================================================================
+ * Send the thread to sleep.
+ *===========================================================================*/
+OpcUa_Void          OpcUa_P_Thread_Sleep(   OpcUa_UInt32                msecTimeout);
+
+/*============================================================================
+ * Get Current Thread Id
+ *===========================================================================*/
+/* the return type "unsigned long" is necessary to hold a "pthread_t" value */
+unsigned long       OpcUa_P_Thread_GetCurrentThreadId(  void);

--- a/Stack/platforms/vxworks/opcua_p_timer.c
+++ b/Stack/platforms/vxworks/opcua_p_timer.c
@@ -1,0 +1,561 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+07nov18,lan  port to vxWorks.
+*/
+
+#include <opcua_p_internal.h>
+#include <opcua_p_memory.h>
+#include <opcua_p_mutex.h>
+#include <opcua_p_utilities.h>
+
+#include <opcua_p_thread.h>
+#include <opcua_p_semaphore.h>
+
+#include <opcua_p_socket.h>
+
+#include <opcua_p_timer.h>
+
+/*============================================================================
+* Global Variables
+*===========================================================================*/
+
+extern int OpcUa_Stack_P_Priority;
+
+/* The timer list. */
+OpcUa_P_InternalTimer   g_OpcUa_P_Timer_Timers[OPCUA_P_TIMER_NO_OF_TIMERS];
+
+#if OPCUA_USE_SYNCHRONISATION
+/* Synchronize access to the timer list. */
+OpcUa_Mutex             g_OpcUa_P_Timer_pTimers_Mutex   = OpcUa_Null;
+#endif /* OPCUA_USE_SYNCHRONISATION | OPCUA_MULTITHREADED */
+
+#if OPCUA_MULTITHREADED
+/* In MT config, the timer is realized by a thread. */
+OpcUa_RawThread         g_pTimerThread                  = OpcUa_Null;
+OpcUa_Semaphore         g_hTimerAddedSemaphore          = OpcUa_Null;
+OpcUa_Boolean           g_bStopTimerThread              = OpcUa_False;
+
+static OpcUa_Void OpcUa_P_Timer_Thread(OpcUa_Void* pArguments);
+#endif /* OPCUA_MULTITHREADED */
+
+/*============================================================================
+* Fire and recalculate timers.
+*===========================================================================*/
+/**
+ * Description
+ * @return Description
+ */
+static
+OpcUa_UInt32 OpcUa_P_Timer_ProcessTimers(OpcUa_Void)
+{
+    OpcUa_UInt16            uIndex;
+    OpcUa_P_InternalTimer*  pInternalTimer;
+    OpcUa_UInt32            uNow;
+    OpcUa_UInt32            uProStart;
+    OpcUa_UInt32            uElapsed;
+    OpcUa_UInt32            uNearest = OPCUA_TIMER_MAX_WAIT;
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+#if OPCUA_MULTITHREADED
+    if(g_bStopTimerThread)
+    {
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Unlock(g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+        return 0;
+    }
+#endif /* OPCUA_MULTITHREADED */
+
+    uProStart       = OpcUa_P_GetTickCount();
+    for(uIndex = 0; uIndex < OPCUA_P_TIMER_NO_OF_TIMERS; uIndex++)
+    {
+        if(g_OpcUa_P_Timer_Timers[uIndex].bUsed != OpcUa_False)
+        {
+            pInternalTimer  = &g_OpcUa_P_Timer_Timers[uIndex];
+            uNow            = OpcUa_P_GetTickCount();
+
+            /* check for overflow of GetTickCount/uNow */
+            uElapsed = uNow - pInternalTimer->uLastFired;
+
+            /*if(uNow >= pInternalTimer->uDueTime)*/
+            if(uElapsed >= pInternalTimer->msecInterval)
+            {
+                /* Fire Timer */
+                pInternalTimer->uLastFired  = uNow;
+
+                if(pInternalTimer->TimerCallback != OpcUa_Null)
+                {
+                    pInternalTimer->TimerCallback(  pInternalTimer->CallbackData,
+                                                    pInternalTimer,
+                                                    uElapsed);
+                }
+
+                /* update duetime */
+                pInternalTimer->uDueTime = pInternalTimer->uLastFired + pInternalTimer->msecInterval;
+            }
+
+            /* calculate time to next fire event for the current timer */
+            /* HINT: use uElapsed as helper only! */
+            uElapsed = pInternalTimer->uDueTime - uProStart;
+            if (uElapsed == 0) uElapsed = 1;
+
+            /* get the minimum */
+            if(uElapsed < uNearest)
+            {
+                uNearest = uElapsed;
+            }
+        } /* if(g_OpcUa_P_Timer_Timers[uIndex].bUsed != OpcUa_False) */
+    } /* for(uIndex = 0; uIndex < OPCUA_P_TIMER_NO_OF_TIMERS; uIndex++) */
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    return uNearest;
+}
+
+
+/*============================================================================
+* Initialize the Timer System
+*===========================================================================*/
+/**
+ * Description
+ * @return Description
+ */
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_InitializeTimers(OpcUa_Void)
+{
+    OpcUa_StatusCode uStatus = OpcUa_Good;
+
+#if OPCUA_USE_SYNCHRONISATION
+    uStatus = OpcUa_P_Mutex_Create(&g_OpcUa_P_Timer_pTimers_Mutex);
+    OpcUa_ReturnErrorIfBad(uStatus);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+#if OPCUA_MULTITHREADED
+    uStatus = OpcUa_P_Semaphore_Create( &g_hTimerAddedSemaphore,
+                                        0,  /* not signalled */
+                                        1); /* max 1 post */
+    if(OpcUa_IsBad(uStatus))
+    {
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Delete(&g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+        return uStatus;
+    }
+
+    g_bStopTimerThread = OpcUa_False;
+
+    uStatus = OpcUa_P_Thread_Create(&g_pTimerThread);
+    if(OpcUa_IsBad(uStatus))
+    {
+        OpcUa_P_Semaphore_Delete(&g_hTimerAddedSemaphore);
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Delete(&g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+        return uStatus;
+    }
+
+    (void) OpcUa_P_Thread_SetAttribute (g_pTimerThread, 
+    		                            "tUaStackT", OpcUa_Stack_P_Priority, 
+                                        1024*4);
+    uStatus = OpcUa_P_Thread_Start( g_pTimerThread,
+                                    OpcUa_P_Timer_Thread,
+                                    OpcUa_Null);
+    if(OpcUa_IsBad(uStatus))
+    {
+        OpcUa_P_Thread_Delete(&g_pTimerThread);
+        OpcUa_P_Semaphore_Delete(&g_hTimerAddedSemaphore);
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Delete(&g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+        return uStatus;
+    }
+#endif /* OPCUA_MULTITHREADED */
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+* Cleanup the Timer System
+*===========================================================================*/
+/**
+ * Description
+ * @return Description
+ */
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Timer_CleanupTimers(OpcUa_Void)
+{
+    OpcUa_UInt32 uIndex = 0;
+
+#if OPCUA_MULTITHREADED
+    /* signal thread to stop */
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+    g_bStopTimerThread = OpcUa_True;
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    OpcUa_P_Semaphore_Post(g_hTimerAddedSemaphore, 1);
+    OpcUa_P_Thread_Delete(&g_pTimerThread);
+#endif /* OPCUA_MULTITHREADED */
+
+    /* no other thread should access this list by now! */
+    for(uIndex = 0; uIndex < OPCUA_P_TIMER_NO_OF_TIMERS; uIndex++)
+    {
+        if(g_OpcUa_P_Timer_Timers[uIndex].bUsed != OpcUa_False)
+        {
+            /* we should have a clear for this ... */
+            OpcUa_P_InternalTimer* pInternalTimer = &g_OpcUa_P_Timer_Timers[uIndex];
+            OpcUa_P_Timer_Delete((OpcUa_Timer*)&pInternalTimer);
+        }
+    }
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Delete(&g_OpcUa_P_Timer_pTimers_Mutex);
+#endif
+#if OPCUA_MULTITHREADED
+    OpcUa_P_Semaphore_Delete(&g_hTimerAddedSemaphore);
+#endif /* OPCUA_MULTITHREADED */
+
+    return;
+}
+
+/*============================================================================
+* Initialize A Timer
+*===========================================================================*/
+/**
+ * Description
+ * @param a_pInternalTimer Description
+ * @param a_msecInterval Description
+ * @param a_fpTimerCallback Description
+ * @param a_fpKillCallback Description
+ * @param a_pvCallbackData Description
+ * @return Description
+ */
+static OpcUa_StatusCode OpcUa_P_Timer_Initialize(OpcUa_P_InternalTimer*  a_pInternalTimer,
+                                                 OpcUa_UInt32            a_msecInterval,
+                                                 OpcUa_P_Timer_Callback* a_fpTimerCallback,
+                                                 OpcUa_P_Timer_Callback* a_fpKillCallback,
+                                                 OpcUa_Void*             a_pvCallbackData)
+{
+    OpcUa_ReturnErrorIfArgumentNull(a_pInternalTimer);
+    OpcUa_ReturnErrorIfTrue((a_msecInterval == 0), OpcUa_BadInvalidArgument);
+
+    a_pInternalTimer->bUsed         = OpcUa_False;
+    a_pInternalTimer->CallbackData  = a_pvCallbackData;
+    a_pInternalTimer->KillCallback  = a_fpKillCallback;
+    a_pInternalTimer->TimerCallback = a_fpTimerCallback;
+    a_pInternalTimer->msecInterval  = a_msecInterval;
+    a_pInternalTimer->uLastFired    = OpcUa_P_GetTickCount();
+    a_pInternalTimer->uDueTime      = a_pInternalTimer->uLastFired + a_msecInterval;
+
+    return OpcUa_Good;
+}
+
+#if OPCUA_MULTITHREADED
+/*============================================================================
+* The thread watching and triggering the timer events.
+*===========================================================================*/
+static
+OpcUa_Void OpcUa_P_Timer_Thread(OpcUa_Void* a_pvArguments)
+{
+    OpcUa_UInt32 uTimeout = 0;
+
+    OpcUa_ReferenceParameter(a_pvArguments);
+
+    for(;;)
+    {
+        uTimeout = OpcUa_P_Timer_ProcessTimers();
+
+        if(uTimeout != 0)
+        {
+            /* wait for timeout */
+            OpcUa_P_Semaphore_TimedWait(g_hTimerAddedSemaphore, uTimeout);
+        }
+        else
+        {
+            /* exit thread */
+            break;
+        }
+    }
+
+    return;
+}
+
+#else /* OPCUA_MULTITHREADED */
+/*============================================================================
+* Timeout expired callback function
+*===========================================================================*/
+/**
+ * Description
+ * @param pData Description
+ * @param pTimer Description
+ * @param msecElapsed Description
+ * @return Description
+ */
+static
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_SocketTimerCallback(OpcUa_Void*     pData,
+                                                           OpcUa_Timer     pTimer,
+                                                           OpcUa_UInt32    msecElapsed)
+{
+    OpcUa_ReferenceParameter(pData);
+    OpcUa_ReferenceParameter(pTimer);
+    OpcUa_ReferenceParameter(msecElapsed);
+
+    return(OpcUa_Good);
+}
+
+/*============================================================================
+* Timeout deleted callback function
+*===========================================================================*/
+/**
+ * Description
+ * @param pData Description
+ * @param pTimer Description
+ * @param msecElapsed Description
+ * @return Description
+ */
+static
+OpcUa_StatusCode OPCUA_DLLCALL  OpcUa_P_SocketKillTimerCallback(OpcUa_Void*     pData,
+                                                                OpcUa_Timer     pTimer,
+                                                                OpcUa_UInt32    msecElapsed)
+{
+    OpcUa_ReferenceParameter(pData);
+    OpcUa_ReferenceParameter(pTimer);
+    OpcUa_ReferenceParameter(msecElapsed);
+
+    return(OpcUa_Good);
+}
+
+/*============================================================================
+* Select wrapper used in singlethreaded configuration.
+*===========================================================================*/
+/**
+ * Standard select wrapper, which uses timers instead of timeout.
+ * @param a_MaxFds Description
+ * @param a_pFdSetRead Description
+ * @param a_pFdSetWrite Description
+ * @param a_pFdSetException Description
+ * @param a_pTimeout Description
+ * @return Description
+ */
+OpcUa_StatusCode OpcUa_P_Socket_TimeredSelect(  OpcUa_RawSocket         a_MaxFds,
+                                                OpcUa_P_Socket_Array*   a_pFdSetRead,
+                                                OpcUa_P_Socket_Array*   a_pFdSetWrite,
+                                                OpcUa_P_Socket_Array*   a_pFdSetException,
+                                                OpcUa_UInt32            a_uTimeout)
+{
+    OpcUa_UInt32    uNearest    = 0;
+    OpcUa_Timer     pTimer      = OpcUa_Null;
+
+OpcUa_InitializeStatus(OpcUa_Module_Socket, "P_Select");
+
+    /* Set a timer as timeout for the following select. */
+    uStatus = OpcUa_P_Timer_Create( &pTimer,
+                                    a_uTimeout,
+                                    OpcUa_P_SocketTimerCallback,    /* ignores event; just for debug */
+                                    OpcUa_P_SocketKillTimerCallback,/* ignores event; just for debug */
+                                    OpcUa_Null);
+
+    if(pTimer == OpcUa_Null)
+    {
+        uStatus = OpcUa_BadOutOfMemory;
+    }
+    else
+    {
+        uNearest = OpcUa_P_Timer_ProcessTimers();
+
+        uStatus = OpcUa_P_RawSocket_Select( a_MaxFds,
+                                            a_pFdSetRead,
+                                            a_pFdSetWrite,
+                                            a_pFdSetException,
+                                            uNearest);
+
+        /* Kill the timer used for the last timeout. */
+        OpcUa_P_Timer_Delete(&pTimer);
+    }
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+OpcUa_FinishErrorHandling;;
+}
+#endif /* OPCUA_MULTITHREADED */
+
+/*============================================================================
+* Create A Timer
+*===========================================================================*/
+/**
+ * Description
+ * @param phTimer Description
+ * @param msecInterval Description
+ * @param fpTimerCallback Description
+ * @param fpKillCallback Description
+ * @param pvCallbackData Description
+ * @return Description
+ */
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Timer_Create(OpcUa_Timer*            a_phTimer,
+                                                    OpcUa_UInt32            a_msecInterval,
+                                                    OpcUa_P_Timer_Callback* a_fpTimerCallback,
+                                                    OpcUa_P_Timer_Callback* a_fpKillCallback,
+                                                    OpcUa_Void*             a_pvCallbackData)
+{
+    OpcUa_P_InternalTimer*  pInternalTimer   = OpcUa_Null;
+    OpcUa_StatusCode        uStatus          = OpcUa_Good;
+    OpcUa_UInt16            uIndex           = 0;
+
+    if(a_phTimer == OpcUa_Null)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+    *a_phTimer = OpcUa_Null;
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    /* look for free timer slot */
+    for(uIndex = 0; uIndex < OPCUA_P_TIMER_NO_OF_TIMERS; uIndex++)
+    {
+        if(g_OpcUa_P_Timer_Timers[uIndex].bUsed == OpcUa_False)
+        {
+            pInternalTimer = &g_OpcUa_P_Timer_Timers[uIndex];
+            pInternalTimer->bUsed = OpcUa_True;
+            break;
+        }
+    }
+
+    if(pInternalTimer == OpcUa_Null)
+    {
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Unlock(g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+        return OpcUa_BadResourceUnavailable;
+    }
+
+    uStatus = OpcUa_P_Timer_Initialize(pInternalTimer,
+        a_msecInterval,
+        a_fpTimerCallback,
+        a_fpKillCallback,
+        a_pvCallbackData);
+
+    if(OpcUa_IsBad(uStatus))
+    {
+        pInternalTimer->bUsed = OpcUa_False;
+
+#if OPCUA_USE_SYNCHRONISATION
+        OpcUa_P_Mutex_Unlock(g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+        return uStatus;
+    }
+
+    pInternalTimer->bUsed = OpcUa_True;
+
+#if OPCUA_MULTITHREADED
+    /* trigger event for timer thread. */
+    OpcUa_P_Semaphore_Post(g_hTimerAddedSemaphore, 1);
+#endif /* OPCUA_MULTITHREADED */
+
+    *a_phTimer = pInternalTimer;
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    return OpcUa_Good;
+}
+
+/*============================================================================
+* Delete A Timer
+*===========================================================================*/
+/**
+ * Description
+ * @param phTimer Description
+ * @return Description
+ */
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Timer_Delete(OpcUa_Timer* a_phTimer)
+{
+    OpcUa_P_InternalTimer* pInternalTimer = OpcUa_Null;
+    OpcUa_UInt32           uNow           = 0;
+    OpcUa_UInt32           uElapsed       = 0;
+    OpcUa_UInt16           uIndex         = 0;
+
+    OpcUa_ReturnErrorIfArgumentNull(a_phTimer);
+    OpcUa_ReturnErrorIfArgumentNull(*a_phTimer);
+
+    pInternalTimer = (OpcUa_P_InternalTimer*)*a_phTimer;
+    if(pInternalTimer->bUsed == OpcUa_False)
+    {
+        return OpcUa_BadInvalidArgument;
+    }
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Lock(g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    uNow     = OpcUa_P_GetTickCount();
+    uElapsed = uNow - pInternalTimer->uLastFired;
+
+    /* notify about kill */
+    if(pInternalTimer->KillCallback != OpcUa_Null)
+    {
+        pInternalTimer->KillCallback(   pInternalTimer->CallbackData,
+                                        pInternalTimer,
+                                        uElapsed);
+    }
+
+    /* look for matching timer slot and free it */
+    for(uIndex = 0; uIndex < OPCUA_P_TIMER_NO_OF_TIMERS; uIndex++)
+    {
+        if(&g_OpcUa_P_Timer_Timers[uIndex] == pInternalTimer)
+        {
+            g_OpcUa_P_Timer_Timers[uIndex].bUsed = OpcUa_False;
+            break;
+        }
+    }
+
+#if OPCUA_USE_SYNCHRONISATION
+    OpcUa_P_Mutex_Unlock(g_OpcUa_P_Timer_pTimers_Mutex);
+#endif /* OPCUA_USE_SYNCHRONISATION */
+
+    *a_phTimer = OpcUa_Null;
+
+    return OpcUa_Good;
+}

--- a/Stack/platforms/vxworks/opcua_p_timer.h
+++ b/Stack/platforms/vxworks/opcua_p_timer.h
@@ -1,0 +1,101 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_P_Timer_H_
+#define _OpcUa_P_Timer_H_ 1
+
+OPCUA_BEGIN_EXTERN_C
+
+/*============================================================================
+ * Defines
+ *===========================================================================*/
+/** @brief The number of timers available to the system. */
+#ifndef OPCUA_P_TIMER_NO_OF_TIMERS
+#define OPCUA_P_TIMER_NO_OF_TIMERS   200
+#endif
+
+/*============================================================================
+ * The Timer Type
+ *===========================================================================*/
+typedef struct _OpcUa_P_InternalTimer
+{
+    /** @brief  */
+    OpcUa_Boolean           bUsed;
+    /** @brief  */
+    OpcUa_UInt32            msecInterval;
+    /** @brief  */
+    OpcUa_P_Timer_Callback* TimerCallback;
+    /** @brief  */
+    OpcUa_P_Timer_Callback* KillCallback;
+    /** @brief  */
+    OpcUa_Void*             CallbackData;
+    /** @brief  */
+    OpcUa_UInt32            uLastFired;
+    /** @brief  */
+    OpcUa_UInt32            uDueTime;
+
+} OpcUa_P_InternalTimer;
+
+/*============================================================================
+ * Create A Timer
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Timer_Create(    OpcUa_Timer*            phTimer,
+                                                        OpcUa_UInt32            msecInterval,
+                                                        OpcUa_P_Timer_Callback* fpTimerCallback,
+                                                        OpcUa_P_Timer_Callback* fpKillCallback,
+                                                        OpcUa_Void*             pvCallbackData);
+
+/*============================================================================
+ * Delete A Timer
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Timer_Delete(    OpcUa_Timer*            phTimer);
+
+/*============================================================================
+ * Initialize the Timer System
+ *===========================================================================*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_InitializeTimers(void);
+
+/*============================================================================
+ * Cleanup the Timer System
+ *===========================================================================*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Timer_CleanupTimers(   void);
+
+#if !OPCUA_MULTITHREADED
+/*============================================================================
+ * Select wrapper used in singlethreaded configuration.
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_Socket_TimeredSelect(          OpcUa_RawSocket         MaxFds,
+                                                        OpcUa_P_Socket_Array*   pFdSetRead,
+                                                        OpcUa_P_Socket_Array*   pFdSetWrite,
+                                                        OpcUa_P_Socket_Array*   pFdSetException,
+                                                        OpcUa_UInt32            uTimeout);
+#endif /* OPCUA_MULTITHREADED */
+
+OPCUA_END_EXTERN_C
+#endif /* _OpcUa_P_Timer_H_ */

--- a/Stack/platforms/vxworks/opcua_p_trace.c
+++ b/Stack/platforms/vxworks/opcua_p_trace.c
@@ -1,0 +1,105 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* System Headers */
+ #include <stdio.h>
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+
+/* additional UA dependencies */
+#include <opcua_p_mutex.h>
+#include <opcua_p_thread.h>
+
+/* own headers */
+#include <opcua_p_trace.h>
+#include <opcua_p_datetime.h>
+
+OPCUA_EXPORT OpcUa_P_TraceHook g_OpcUa_P_TraceHook;
+
+/*============================================================================
+ * Trace Initialize
+ *===========================================================================*/
+/**
+* Initialize all resources needed for tracing.
+*/
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Trace_Initialize(OpcUa_Void)
+{
+    return OpcUa_Good;
+}
+
+/*============================================================================
+ * Trace Clear
+ *===========================================================================*/
+/**
+* Clear all resources needed for tracing.
+*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Trace_Clear(OpcUa_Void)
+{
+    return;
+}
+
+/*============================================================================
+ * Tracefunction
+ *===========================================================================*/
+/**
+ * Writes the given string to the trace device, if the given trace level is
+ * activated in the header file.
+ */
+
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Trace(
+#if OPCUA_TRACE_FILE_LINE_INFO
+                                        OpcUa_UInt32 level,
+                                        OpcUa_CharA* sFile,
+                                        OpcUa_UInt32 line,
+#endif
+                                        OpcUa_CharA* a_sMessage)
+{
+#if OPCUA_TRACE_FILE_LINE_INFO
+    OpcUa_ReferenceParameter(level);
+    OpcUa_ReferenceParameter(sFile);
+    OpcUa_ReferenceParameter(line);
+#endif
+
+    /* send to tracehook if registered */
+    if(g_OpcUa_P_TraceHook != OpcUa_Null)
+    {
+        g_OpcUa_P_TraceHook(a_sMessage);
+    }
+    else /* send to console */
+    {
+        char dtbuffer[25];
+        OpcUa_DateTime timestamp;
+
+        timestamp = OpcUa_P_DateTime_UtcNow();
+        OpcUa_P_DateTime_GetStringFromDateTime(timestamp, dtbuffer, 25);
+
+        printf("|%ld| %s %s", OpcUa_P_Thread_GetCurrentThreadId(), &dtbuffer[11], a_sMessage);
+    }
+}

--- a/Stack/platforms/vxworks/opcua_p_trace.h
+++ b/Stack/platforms/vxworks/opcua_p_trace.h
@@ -1,0 +1,59 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/*============================================================================
+ * Trace Initialize
+ *===========================================================================*/
+/**
+ * Initialize all resources needed for tracing.
+ */
+OpcUa_StatusCode OPCUA_DLLCALL OpcUa_P_Trace_Initialize(void);
+
+/*============================================================================
+ * Trace Initialize
+ *===========================================================================*/
+/**
+ * Clear all resources needed for tracing.
+ */
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Trace_Clear(void);
+
+/*============================================================================
+ * Tracefunction
+ *===========================================================================*/
+/**
+ * Writes the given string to the trace device, if the given trace level is
+ * activated in the header file.
+ */
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_Trace(
+#if OPCUA_TRACE_FILE_LINE_INFO
+                                        OpcUa_UInt32 level,
+                                        OpcUa_CharA* sFile,
+                                        OpcUa_UInt32 line,
+#endif
+                                        OpcUa_CharA* a_sMessage);

--- a/Stack/platforms/vxworks/opcua_p_types.h
+++ b/Stack/platforms/vxworks/opcua_p_types.h
@@ -1,0 +1,323 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* This are the UA Proxy/Stub internal data type definitions! */
+
+/* This is the VxWorks version of this file! */
+
+#ifndef _OpcUa_P_Types_H_
+#define _OpcUa_P_Types_H_ 1
+
+/*============================================================================
+* Type definitions for basic data types.
+*===========================================================================*/
+
+typedef int                 OpcUa_Int;
+typedef unsigned int        OpcUa_UInt;
+typedef void                OpcUa_Void;
+typedef void*               OpcUa_Handle;
+typedef unsigned char       OpcUa_Boolean;
+typedef signed char         OpcUa_SByte;
+typedef unsigned char       OpcUa_Byte;
+typedef short               OpcUa_Int16;
+typedef unsigned short      OpcUa_UInt16;
+typedef int                 OpcUa_Int32;
+typedef unsigned int        OpcUa_UInt32;
+
+
+typedef long long           OpcUa_Int64;
+typedef unsigned long long  OpcUa_UInt64;
+
+typedef float               OpcUa_Float;
+typedef double              OpcUa_Double;
+typedef char                OpcUa_CharA;
+typedef unsigned char       OpcUa_UCharA;
+typedef OpcUa_CharA*        OpcUa_StringA;
+typedef unsigned short      OpcUa_Char;
+
+
+struct _OpcUa_DateTime
+{
+    OpcUa_UInt32 dwLowDateTime;
+    OpcUa_UInt32 dwHighDateTime;
+};
+
+typedef struct _OpcUa_DateTime OpcUa_DateTime;
+
+
+/**
+ * @brief OpcUa_SocketManager Type
+ */
+typedef OpcUa_Void* OpcUa_SocketManager;
+
+/**
+ * @brief OpcUa_Socket Type
+ */
+typedef OpcUa_Void* OpcUa_Socket;
+
+/**
+ * @brief OpcUa_Thread Type
+ */
+typedef OpcUa_Void* OpcUa_Thread;
+
+
+/**
+ * @brief Internally used thread main entry function.
+ */
+typedef OpcUa_Void      (OpcUa_PfnInternalThreadMain)(OpcUa_Void* pArguments);
+
+/**
+ * @brief The handle for the platform thread.
+ */
+typedef OpcUa_UInt32        OpcUa_StatusCode;
+
+/**
+ * @brief The handle for the mutex.
+ */
+typedef OpcUa_Void*     OpcUa_Mutex;
+
+/**
+ * @brief The handle for the semaphore.
+ */
+typedef OpcUa_Void*     OpcUa_Semaphore;
+
+/**
+ * @brief The handle for a timer.
+ */
+typedef OpcUa_Void*     OpcUa_Timer;
+
+/**
+ * @brief A function used to compare elements when sorting or searching.
+ *
+ * @param pContext  [in] The context passed to the sorting/searching function.
+ * @param pElement1 [in] The first element to compare.
+ * @param pElement2 [in] The second element to compare.
+ *
+ * @return Zero if elements are equal, < 0 if element1 is less that element2.
+ */
+typedef OpcUa_Int (OPCUA_CDECL OpcUa_PfnCompare)(   const OpcUa_Void* pElement1,
+                                                const OpcUa_Void* pElement2);
+
+/*============================================================================
+* Type definitions for data types on the wire.
+*===========================================================================*/
+typedef OpcUa_Boolean       OpcUa_Boolean_Wire;
+typedef OpcUa_SByte         OpcUa_SByte_Wire;
+typedef OpcUa_Byte          OpcUa_Byte_Wire;
+typedef OpcUa_Int16         OpcUa_Int16_Wire;
+typedef OpcUa_UInt16        OpcUa_UInt16_Wire;
+typedef OpcUa_Int32         OpcUa_Int32_Wire;
+typedef OpcUa_UInt32        OpcUa_UInt32_Wire;
+typedef OpcUa_Int64         OpcUa_Int64_Wire;
+typedef OpcUa_UInt64        OpcUa_UInt64_Wire;
+typedef OpcUa_Float         OpcUa_Float_Wire;
+typedef OpcUa_Double        OpcUa_Double_Wire;
+typedef OpcUa_CharA         OpcUa_Char_Wire;
+
+/*============================================================================
+* Type definitions for structured data types.
+*===========================================================================*/
+#define OPCUA_GUID_STATICINITIALIZER {0, 0, 0, {0,0,0,0,0,0,0,0}}
+typedef struct _OpcUa_Guid
+{
+    OpcUa_UInt32    Data1;
+    OpcUa_UInt16    Data2;
+    OpcUa_UInt16    Data3;
+    OpcUa_UCharA    Data4[8];
+} OpcUa_Guid, *OpcUa_pGuid;
+
+#define OPCUA_STRING_STATICINITIALIZER {0, 0, OpcUa_Null}
+#ifdef _DEBUG
+typedef struct _OpcUa_String
+{
+    OpcUa_UInt16 flags;
+    OpcUa_UInt32 uLength;
+    OpcUa_CharA* strContent;
+} OpcUa_String, *OpcUa_pString;
+#else
+typedef struct _OpcUa_String
+{
+    OpcUa_UInt16        uReserved1;     /* Content is private to String Implementation */
+    OpcUa_UInt32        uReserved2;     /* Content is private to String Implementation */
+    OpcUa_Void*         uReserved4;     /* Content is private to String Implementation */
+} OpcUa_String, *OpcUa_pString;
+#endif
+
+#define OPCUA_BYTESTRING_STATICINITIALIZER {-1, OpcUa_Null}
+typedef struct _OpcUa_ByteString
+{
+    OpcUa_Int32 Length;
+    OpcUa_Byte* Data;
+} OpcUa_ByteString;
+
+#define OPCUA_DATETIME_STATICINITIALIZER {0, 0}
+typedef struct _OpcUa_FileTime
+{
+    OpcUa_UInt32 uiLowDateTime;
+    OpcUa_UInt32 uiHighDateTime;
+} OpcUa_FileTime, *OpcUa_pFileTime;
+
+/**
+* @brief Holds a time value with a maximum resolution of micro seconds.
+*/
+typedef struct _OpcUa_TimeVal OpcUa_TimeVal;
+
+struct _OpcUa_TimeVal
+{
+    /** @brief The number of full seconds since 1970. */
+    OpcUa_Int64 uintSeconds;
+    /** @brief The fraction of the last second. */
+    OpcUa_UInt32 uintMicroSeconds;
+};
+
+
+/*============================================================================
+* constant definitions.
+*===========================================================================*/
+#define OpcUa_Ignore        0           /* Ignore signal */
+#define OpcUa_Infinite      0xFFFFFFFF  /* Infinite timeout */
+
+
+#define OpcUa_False         0
+#define OpcUa_True          (!OpcUa_False)
+#define OpcUa_Null          0
+#define OpcUa_SByte_Min     (OpcUa_SByte)-128
+#define OpcUa_SByte_Max     (OpcUa_SByte)127
+#define OpcUa_Byte_Min      (OpcUa_Byte)0
+#define OpcUa_Byte_Max      (OpcUa_Byte)255
+#define OpcUa_Int16_Min     (OpcUa_Int16)-32768
+#define OpcUa_Int16_Max     (OpcUa_Int16)32767
+#define OpcUa_UInt16_Min    (OpcUa_UInt16)0
+#define OpcUa_UInt16_Max    (OpcUa_UInt16)65535
+#define OpcUa_Int32_Min     (OpcUa_Int32)(-2147483647L-1)
+#define OpcUa_Int32_Max     (OpcUa_Int32)2147483647
+#define OpcUa_UInt32_Min    (OpcUa_UInt32)0
+#define OpcUa_UInt32_Max    (OpcUa_UInt32)4294967295U
+#define OpcUa_Int64_Max     (OpcUa_Int64)9223372036854775807LL
+#define OpcUa_Int64_Min     (OpcUa_Int64)(-OpcUa_Int64_Max - 1LL)
+#define OpcUa_UInt64_Min    (OpcUa_UInt64)0
+#define OpcUa_UInt64_Max    (OpcUa_UInt64)18446744073709551615ULL
+/* defined as FLT_MIN in "%ProgramFiles\Microsoft Visual Studio 8\VC\include\float.h" */
+/* #define FLT_MIN         1.175494351e-38F */
+#define OpcUa_Float_Min     (OpcUa_Float)1.175494351e-38F
+/* defined as FLT_MAX in "%ProgramFiles\Microsoft Visual Studio 8\VC\include\float.h" */
+/* #define FLT_MAX         3.402823466e+38F */
+#define OpcUa_Float_Max     (OpcUa_Float)3.402823466e+38F
+/* defined as DBL_MIN in "%ProgramFiles\Microsoft Visual Studio 8\VC\include\float.h" */
+/* #define DBL_MIN         2.2250738585072014e-308 */
+#define OpcUa_Double_Min    (OpcUa_Double)2.2250738585072014e-308
+/* defined as DBL_MAX in "%ProgramFiles\Microsoft Visual Studio 8\VC\include\float.h" */
+/* #define DBL_MAX         1.7976931348623158e+308 */
+#define OpcUa_Double_Max    (OpcUa_Double)1.7976931348623158e+308
+
+#define OpcUa_DateTime_Min  0
+#define OpcUa_DateTime_Max  3155378975999999999
+
+/* set to OPCUA_CONFIG_YES to use the untested optimized byteswap */
+#define OPCUA_SWAP_ALTERNATIVE OPCUA_CONFIG_NO
+
+#if OPCUA_SWAP_ALTERNATIVE
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+
+    /* this is the wire format */
+
+    #define OpcUa_SwapBytes_2(xDst, xSrc) \
+    { \
+        *xDst = *xSrc; \
+    }
+
+    #define OpcUa_SwapBytes_4(xDst, xSrc) \
+    { \
+        *xDst = *xSrc; \
+    }
+
+    #define OpcUa_SwapBytes_8(xDst, xSrc) \
+    { \
+        *xDst = *xSrc; \
+    }
+
+#elif BYTE_ORDER == BIG_ENDIAN
+
+    #define OpcUa_SwapBytes_2(xDst, xSrc) \
+    { \
+        ((unsigned char*)xDst)[0] = ((unsigned char*)xSrc)[1]; \
+        ((unsigned char*)xDst)[1] = ((unsigned char*)xSrc)[0]; \
+    }
+
+    #define OpcUa_SwapBytes_4(xDst, xSrc) \
+    { \
+        ((unsigned char*)xDst)[0] = ((unsigned char*)xSrc)[3]; \
+        ((unsigned char*)xDst)[1] = ((unsigned char*)xSrc)[2]; \
+        ((unsigned char*)xDst)[2] = ((unsigned char*)xSrc)[1]; \
+        ((unsigned char*)xDst)[3] = ((unsigned char*)xSrc)[0]; \
+    }
+
+    #define OpcUa_SwapBytes_8(xDst, xSrc) \
+    { \
+        ((unsigned char*)xDst)[0] = ((unsigned char*)xSrc)[7]; \
+        ((unsigned char*)xDst)[1] = ((unsigned char*)xSrc)[6]; \
+        ((unsigned char*)xDst)[2] = ((unsigned char*)xSrc)[5]; \
+        ((unsigned char*)xDst)[3] = ((unsigned char*)xSrc)[4]; \
+        ((unsigned char*)xDst)[4] = ((unsigned char*)xSrc)[3]; \
+        ((unsigned char*)xDst)[5] = ((unsigned char*)xSrc)[2]; \
+        ((unsigned char*)xDst)[6] = ((unsigned char*)xSrc)[1]; \
+        ((unsigned char*)xDst)[7] = ((unsigned char*)xSrc)[0]; \
+    }
+
+#endif
+
+#else /* OPCUA_SWAP_ALTERNATIVE */
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+    #define OpcUa_SwapBytes(xDst, xSrc, xCount) \
+    { \
+        memcpy(xDst, xSrc, xCount); \
+    }
+#elif BYTE_ORDER == BIG_ENDIAN
+    #define OpcUa_SwapBytes(xDst, xSrc, xCount) \
+    { \
+        OpcUa_UInt32 ii = 0; \
+        OpcUa_UInt32 jj = xCount-1; \
+        OpcUa_Byte* dst = (OpcUa_Byte*)xDst; \
+        OpcUa_Byte* src = (OpcUa_Byte*)xSrc; \
+        \
+        for (; ii < xCount; ii++, jj--) \
+        { \
+            dst[ii] = src[jj]; \
+        } \
+    }
+#endif
+
+#endif /* OPCUA_SWAP_ALTERNATIVE */
+
+#endif /* _OpcUa_PlatformDefs_H_ */
+/*----------------------------------------------------------------------------------------------------*\
+|   End of File                                                                          End of File   |
+\*----------------------------------------------------------------------------------------------------*/

--- a/Stack/platforms/vxworks/opcua_p_utilities.c
+++ b/Stack/platforms/vxworks/opcua_p_utilities.c
@@ -1,0 +1,259 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* System Headers */
+#include <stdlib.h>
+#include <errno.h>
+#include <sys/time.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+
+/* UA platform definitions */
+#include <opcua_p_internal.h>
+#include <opcua_p_memory.h>
+
+/* own headers */
+#include <opcua_p_utilities.h>
+
+/*============================================================================
+ * Quick Sort
+ *===========================================================================*/
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_QSort( OpcUa_Void*       pElements,
+                                        OpcUa_UInt32      nElementCount,
+                                        OpcUa_UInt32      nElementSize,
+                                        OpcUa_PfnCompare* pfnCompare,
+                                        OpcUa_Void*       pContext)
+{
+    /*qsort_s(pElements, nElementCount, nElementSize, pfnCompare, pContext);*/
+    OpcUa_ReferenceParameter(pContext);
+    qsort(pElements, nElementCount, nElementSize, pfnCompare);
+}
+
+/*============================================================================
+ * Binary Search on sorted array
+ *===========================================================================*/
+OpcUa_Void* OPCUA_DLLCALL OpcUa_P_BSearch(  OpcUa_Void*       pKey,
+                                            OpcUa_Void*       pElements,
+                                            OpcUa_UInt32      nElementCount,
+                                            OpcUa_UInt32      nElementSize,
+                                            OpcUa_PfnCompare* pfnCompare,
+                                            OpcUa_Void*       pContext)
+{
+    /*return bsearch_s(pKey, pElements, nElementCount, nElementSize, pfnCompare, pContext);*/
+    OpcUa_ReferenceParameter(pContext);
+    return bsearch(pKey, pElements, nElementCount, nElementSize, pfnCompare);
+}
+
+/*============================================================================
+ * Access to errno
+ *===========================================================================*/
+OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetLastError(OpcUa_Void)
+{
+    return errno;
+}
+
+/*============================================================================
+ * OpcUa_GetTickCount
+ *===========================================================================*/
+OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetTickCount(OpcUa_Void)
+{
+    struct timeval now;
+    OpcUa_UInt32 ticks = 0;
+
+    if(gettimeofday(&now, NULL) == 0)
+    {
+        ticks = now.tv_sec;
+        ticks *= 1000;
+        ticks += now.tv_usec / 1000;
+    }
+
+    return ticks;
+}
+
+/*============================================================================
+ * OpcUa_CharAToInt
+ *===========================================================================*/
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_CharAToInt(OpcUa_StringA sValue)
+{
+    return (OpcUa_Int32)atoi(sValue);
+}
+
+/*============================================================================
+ * OpcUa_P_ParseUrl
+ *===========================================================================*/
+OpcUa_StatusCode OpcUa_P_ParseUrl(  OpcUa_StringA   a_psUrl,
+                                    OpcUa_StringA*  a_psIpAddress,
+                                    OpcUa_UInt16*   a_puPort)
+{
+    OpcUa_StringA       sHostName         = OpcUa_Null;
+    OpcUa_UInt32        uHostNameLength   = 0;
+
+    OpcUa_CharA*        sPort             = OpcUa_Null;
+
+    OpcUa_CharA*        pcCursor;
+
+    OpcUa_Int           nIndex1           = 0;
+    OpcUa_Int           nIpStart;
+
+    struct addrinfo*    pAddrInfo         = OpcUa_Null;
+
+OpcUa_InitializeStatus(OpcUa_Module_Utilities, "P_ParseUrl");
+
+    OpcUa_ReturnErrorIfArgumentNull(a_psUrl);
+    OpcUa_ReturnErrorIfArgumentNull(a_psIpAddress);
+    OpcUa_ReturnErrorIfArgumentNull(a_puPort);
+
+
+    *a_psIpAddress = OpcUa_Null;
+
+    /* check for // (end of protocol header) */
+    pcCursor = strstr(a_psUrl, "//");
+
+    if(pcCursor != OpcUa_Null)
+    {
+        /* begin of host address */
+        pcCursor += 2;
+        nIndex1 = (OpcUa_Int)(pcCursor - a_psUrl);
+    }
+
+    /* skip protocol prefix and store beginning of ip adress */
+    nIpStart = nIndex1;
+
+    /* skip host address (IPv6 address can contain colons!) */
+    while(a_psUrl[nIndex1] != '/' && a_psUrl[nIndex1] != 0)
+    {
+        if(a_psUrl[nIndex1] == ':')
+        {
+            sPort = &a_psUrl[nIndex1 + 1];
+            uHostNameLength = nIndex1 - nIpStart;
+        }
+        /* handle "opc.tcp://[::1]:4880/" */
+        if(a_psUrl[nIndex1] == ']' && sPort != OpcUa_Null && a_psUrl[nIpStart] == '[')
+        {
+            nIpStart++;
+            uHostNameLength = nIndex1 - nIpStart;
+            sPort = OpcUa_Null;
+            if(a_psUrl[nIndex1 + 1] == ':')
+            {
+                sPort = &a_psUrl[nIndex1 + 2];
+            }
+            break;
+        }
+        nIndex1++;
+    }
+
+    if(uHostNameLength == 0)
+    {
+        uHostNameLength = nIndex1 - nIpStart;
+    }
+
+    /* scan port */
+    if(sPort != OpcUa_Null)
+    {
+        /* convert port */
+        *a_puPort = (OpcUa_UInt16)OpcUa_P_CharAToInt(sPort);
+    }
+    else
+    {
+        /* return default port */
+        *a_puPort = OPCUA_TCP_DEFAULT_PORT;
+    }
+
+    sHostName = (OpcUa_StringA)OpcUa_P_Memory_Alloc(uHostNameLength + 1);
+
+    if(sHostName == NULL)
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadOutOfMemory);
+    }
+
+    memcpy(sHostName, &a_psUrl[nIpStart], uHostNameLength);
+    sHostName[uHostNameLength] = '\0';
+
+    if(getaddrinfo(sHostName, NULL, NULL, &pAddrInfo))
+    {
+        /* hostname could not be resolved */
+        pAddrInfo = NULL;
+        OpcUa_GotoErrorWithStatus(OpcUa_BadHostUnknown);
+    }
+
+    if(pAddrInfo->ai_family == AF_INET)
+    {
+        struct sockaddr_in* pAddr = (struct sockaddr_in*)pAddrInfo->ai_addr;
+        OpcUa_P_Memory_Free(sHostName);
+        sHostName = OpcUa_P_Memory_Alloc(INET_ADDRSTRLEN);
+        OpcUa_GotoErrorIfAllocFailed(sHostName);
+        if(inet_ntop(AF_INET, (void*)&pAddr->sin_addr,
+                     sHostName, INET_ADDRSTRLEN) == NULL)
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+        }
+    }
+    else if(pAddrInfo->ai_family == AF_INET6)
+    {
+        struct sockaddr_in6* pAddr = (struct sockaddr_in6*)pAddrInfo->ai_addr;
+        OpcUa_P_Memory_Free(sHostName);
+        sHostName = OpcUa_P_Memory_Alloc(INET6_ADDRSTRLEN);
+        OpcUa_GotoErrorIfAllocFailed(sHostName);
+        if(inet_ntop(AF_INET6, (void*)&pAddr->sin6_addr,
+                     sHostName, INET6_ADDRSTRLEN) == NULL)
+        {
+            OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+        }
+        if(pAddr->sin6_scope_id)
+        {
+            char *pScopeAddress = OpcUa_P_Memory_Alloc(strlen(sHostName) + 12);
+            OpcUa_GotoErrorIfAllocFailed(pScopeAddress);
+            sprintf(pScopeAddress, "%s%%%u", sHostName, pAddr->sin6_scope_id);
+            OpcUa_P_Memory_Free(sHostName);
+            sHostName = pScopeAddress;
+        }
+    }
+    else
+    {
+        OpcUa_GotoErrorWithStatus(OpcUa_BadInternalError);
+    }
+
+    *a_psIpAddress = sHostName;
+    freeaddrinfo(pAddrInfo);
+
+OpcUa_ReturnStatusCode;
+OpcUa_BeginErrorHandling;
+
+    if(sHostName != OpcUa_Null)
+    {
+        OpcUa_P_Memory_Free(sHostName);
+    }
+
+    if(pAddrInfo != NULL)
+    {
+        freeaddrinfo(pAddrInfo);
+    }
+
+OpcUa_FinishErrorHandling;
+}

--- a/Stack/platforms/vxworks/opcua_p_utilities.h
+++ b/Stack/platforms/vxworks/opcua_p_utilities.h
@@ -1,0 +1,78 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+#ifndef _OpcUa_P_Utilities_H_
+#define _OpcUa_P_Utilities_H_ 1
+
+OPCUA_BEGIN_EXTERN_C
+
+/**
+ * @see OpcUa_P_QSort
+ */
+OpcUa_Void OPCUA_DLLCALL OpcUa_P_QSort( OpcUa_Void*       pElements,
+                                        OpcUa_UInt32      nElementCount,
+                                        OpcUa_UInt32      nElementSize,
+                                        OpcUa_PfnCompare* pfnCompare,
+                                        OpcUa_Void*       pContext);
+
+/**
+ * @see OpcUa_P_BSearch
+ */
+OpcUa_Void* OPCUA_DLLCALL OpcUa_P_BSearch(  OpcUa_Void*       pKey,
+                                            OpcUa_Void*       pElements,
+                                            OpcUa_UInt32      nElementCount,
+                                            OpcUa_UInt32      nElementSize,
+                                            OpcUa_PfnCompare* pfnCompare,
+                                            OpcUa_Void*       pContext);
+
+/**
+ * @see OpcUa_P_GetLastError
+ */
+OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetLastError(void);
+
+/**
+ * @see OpcUa_P_GetTickCount
+ */
+OpcUa_UInt32 OPCUA_DLLCALL OpcUa_P_GetTickCount(void);
+
+/**
+ * @see OpcUa_P_CharAToInt
+ */
+OpcUa_Int32 OPCUA_DLLCALL OpcUa_P_CharAToInt(   OpcUa_StringA sValue);
+
+/**
+ * @see OpcUa_P_ParseUrl
+ */
+OpcUa_StatusCode OpcUa_P_ParseUrl(  OpcUa_StringA   psUrl,
+                                    OpcUa_StringA*  psIpAddress,
+                                    OpcUa_UInt16*   puPort);
+
+OPCUA_END_EXTERN_C
+
+#endif /* _OpcUa_P_Utilities_H_ */

--- a/Stack/platforms/vxworks/opcua_platformdefs.h
+++ b/Stack/platforms/vxworks/opcua_platformdefs.h
@@ -1,0 +1,199 @@
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* These are the VxWorks platform definitions! */
+
+#ifndef _OpcUa_PlatformDefs_H_
+#define _OpcUa_PlatformDefs_H_ 1
+
+#include <endian.h>
+#include <stdio.h>
+
+#define OPCUA_EXPORT
+#define OPCUA_IMPORT
+#define OPCUA_DLLCALL
+#define OPCUA_IMEXPORT
+
+#define OPCUA_EXPORT_SYNC_SERVER_API OPCUA_EXPORT
+
+/* calling convention used by stack functions that explicitely use cdecl */
+#define OPCUA_CDECL
+
+/* used ie. for unlimited timespans */
+#define OPCUA_INFINITE 0xFFFFFFFF
+
+/* Some compilers support applying printf-style warnings. */
+#if defined(__GNUC__)
+#define OPCUA_PRINTF_ARGS(formatIndex) __attribute__((__format__(__printf__, (formatIndex), (formatIndex) + 1)))
+#define OPCUA_PRINTF_VALIST(formatIndex) __attribute__((__format__(__printf__, (formatIndex), 0)))
+#else
+#define OPCUA_PRINTF_ARGS(formatIndex)
+#define OPCUA_PRINTF_VALIST(formatIndex)
+#endif
+
+/*============================================================================
+* Additional basic headers
+*===========================================================================*/
+/* configuration switches */
+#include <opcua_config.h>
+/* basic type mapping */
+#include <opcua_p_types.h>
+#include <memory.h>
+#include <string.h>
+/**********************************************************************************/
+/*   Check configuration.                                                         */
+/**********************************************************************************/
+#if OPCUA_USE_SAFE_FUNCTIONS
+  #error "Use of _s functions limited to windows."
+#endif /* OPCUA_USE_SAFE_FUNCTIONS */
+
+/**********************************************************************************/
+/*   Security Configuration section.                                              */
+/**********************************************************************************/
+#ifndef OPCUA_SUPPORT_SECURITYPOLICY_BASIC128RSA15
+#define OPCUA_SUPPORT_SECURITYPOLICY_BASIC128RSA15  OPCUA_CONFIG_YES
+#endif  /* OPCUA_SUPPORT_SECURITYPOLICY_BASIC128RSA15 */
+
+#ifndef OPCUA_SUPPORT_SECURITYPOLICY_BASIC256
+#define OPCUA_SUPPORT_SECURITYPOLICY_BASIC256       OPCUA_CONFIG_YES
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_BASIC256 */
+
+#ifndef OPCUA_SUPPORT_SECURITYPOLICY_BASIC256SHA256
+#define OPCUA_SUPPORT_SECURITYPOLICY_BASIC256SHA256 OPCUA_CONFIG_YES
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_BASIC256SHA256 */
+
+#ifndef OPCUA_SUPPORT_SECURITYPOLICY_AES128SHA256RSAOAEP
+#define OPCUA_SUPPORT_SECURITYPOLICY_AES128SHA256RSAOAEP OPCUA_CONFIG_YES
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_AES128SHA256RSAOAEP */
+
+#ifndef OPCUA_SUPPORT_SECURITYPOLICY_AES256SHA256RSAPSS
+#define OPCUA_SUPPORT_SECURITYPOLICY_AES256SHA256RSAPSS OPCUA_CONFIG_YES
+#endif /* OPCUA_SUPPORT_SECURITYPOLICY_AES256SHA256RSAPSS */
+
+#ifndef OPCUA_SUPPORT_SECURITYPOLICY_NONE
+#define OPCUA_SUPPORT_SECURITYPOLICY_NONE           OPCUA_CONFIG_YES
+#endif  /* OPCUA_SUPPORT_SECURITYPOLICY_NONE */
+
+#ifndef OPCUA_SUPPORT_PKI
+#define OPCUA_SUPPORT_PKI                           OPCUA_CONFIG_YES
+#endif  /* OPCUA_SUPPORT_PKI */
+
+#if OPCUA_SUPPORT_PKI
+#define OPCUA_SUPPORT_PKI_OVERRIDE                  OPCUA_CONFIG_YES
+#define OPCUA_SUPPORT_PKI_OPENSSL                   OPCUA_CONFIG_YES
+#endif /* OPCUA_SUPPORT_PKI */
+
+/*============================================================================
+* Types and mapping.
+*===========================================================================*/
+#ifdef __cplusplus
+# define OPCUA_BEGIN_EXTERN_C extern "C" {
+# define OPCUA_END_EXTERN_C }
+#else
+# define OPCUA_BEGIN_EXTERN_C
+# define OPCUA_END_EXTERN_C
+#endif
+
+OPCUA_BEGIN_EXTERN_C
+
+/*============================================================================
+ * Memory allocation functions.
+ *
+ * Note: Realloc and Free behave gracefully if passed a null pointer. Changing
+ * these functions to a macro call to free will cause problems.
+ *===========================================================================*/
+
+/*OpcUa_Void* memset(OpcUa_Void* Dst, OpcUa_Int Val, OpcUa_UInt Size);*/
+#define OpcUa_MemSet(xDst, xValue, xDstSize)        memset(xDst, xValue, xDstSize)
+
+#ifdef _DEBUG
+#define OpcUa_MemSetD(xDst, xValue, xDstSize)
+#else
+#define OpcUa_MemSetD(xDst, xValue, xDstSize)   memset(xDst, xValue, xDstSize)
+#endif
+
+/*OpcUa_Int memcmp(const OpcUa_Void* Buf1, const OpcUa_Void* Buf2, OpcUa_UInt Size);*/
+#define OpcUa_MemCmp(xBuf1, xBuf2, xBufSize)        memcmp(xBuf1, xBuf2, xBufSize)
+
+/*OpcUa_Int memcpy(OpcUa_Void* Buf1, const OpcUa_Void* Buf2, OpcUa_UInt Size);*/
+#define OpcUa_MemCpy(xDst, xDstSize, xSrc, xCount)  OpcUa_Memory_MemCpy(xDst, xDstSize, xSrc, xCount)
+
+#define OpcUa_Alloc(xSize)                          OpcUa_Memory_Alloc(xSize)
+#define OpcUa_ReAlloc(xSrc, xSize)                  OpcUa_Memory_ReAlloc(xSrc, xSize)
+#define OpcUa_Free(xSrc)                            OpcUa_Memory_Free(xSrc)
+
+#define OpcUa_DestroySecretData(xDst, xSize)        OpcUa_Memory_DestroySecretData(xDst, xSize)
+
+/* shortcuts to utility functions */
+#define OpcUa_qSort(xBase, xNum, xWidth, xCmp, xCtx)            OpcUa_QSort(xBase, xNum, xWidth, xCmp, xCtx)
+#define OpcUa_bSearch(xKey, xBase, xNum, xWidth, xCmp, xCtx)    OpcUa_BSearch(xKey, xBase, xNum, xWidth, xCmp, xCtx)
+
+/*============================================================================
+ * String handling functions.
+ *===========================================================================*/
+
+/* mapping of ansi char functions on lib functions: */
+/*#define OpcUa_CharAToInt(xChar)                       OpcUa_P_CharAToInt(xChar)*/
+
+/* mapping of ansi string functions on lib functions: */
+/*OpcUa_Int strcmp(OpcUa_StringA s1, OpcUa_StringA s2);*/
+#define OpcUa_StrCmpA(xStr1, xStr2)                   strcmp(xStr1, xStr2)
+#define OpcUa_StrnCmpA(xStr1, xStr2, xCount)          strncmp(xStr1, xStr2, xCount)
+#define OpcUa_StriCmpA(xStr1, xStr2)                  stricmp(xStr1, xStr2)
+#define OpcUa_StrinCmpA(xStr1, xStr2, xCount)         strnicmp(xStr1, xStr2, xCount)
+#define OpcUa_StrLenA(xStr)                           (OpcUa_UInt32)strlen(xStr)
+#define OpcUa_StrChrA(xString, xChar)                 strchr(xString, xChar)
+#define OpcUa_StrrChrA(xString, xChar)                strrchr(xString, xChar)
+#define OpcUa_StrStrA(xString, xSubstring)            strstr(xString, xSubstring)
+#define OpcUa_StrnCpyA(xDst, xDstSize, xSrc, xCount)  strncpy(xDst, xSrc, xCount)
+#define OpcUa_StrnCatA(xDst, xDstSize, xSrc, xCount)  strncat(xDst, xSrc, xCount)
+
+/* import prototype for direct mapping on sprintf (TODO has to go) */
+/* OpcUa_Int sprintf(char *buffer, const char *format, ...); */
+#define OpcUa_SPrintfA                                sprintf
+
+/* import prototype for direct mapping on sscanf (TODO has to go) */
+/* OpcUa_Int sscanf(const OpcUa_CharA *buffer, const OpcUa_CharA *format, ... ); */
+#define OpcUa_SScanfA                                 sscanf
+
+OpcUa_Int32 OpcUa_P_String_snprintf(OpcUa_StringA sTarget, OpcUa_UInt32 nCount, OpcUa_StringA sFormat, ...) OPCUA_PRINTF_ARGS(3);
+#define OpcUa_SnPrintfA                               OpcUa_P_String_snprintf
+
+/* shortcuts to OpcUa_String functions */
+#define OpcUa_StrLen(xStr)                            OpcUa_String_StrLen(xStr)
+
+#define OpcUa_StrCpy(xDst, xSrc)                      OpcUa_String_StrCpy(xDst, xSrc, OPCUA_STRING_LENDONTCARE, OpcUa_True)
+#define OpcUa_StrnCpy(xDst, xDstLength, xSrc, xCount) OpcUa_String_StrnCpy(xDst, xDstLength, xSrc, xCount)
+
+#define OpcUa_StrCat(xDst, xSrc)                      OpcUa_String_StrCat(xDst, xSrc, OPCUA_STRING_LENDONTCARE)
+#define OpcUa_StrnCat(xDst, xDstLength, xSrc, xCount) OpcUa_String_StrnCat(xDst, xDstLength, xSrc, xCount)
+
+OPCUA_END_EXTERN_C
+
+#endif /* _OpcUa_PlatformDefs_H_ */

--- a/Stack/platforms/vxworks/opcua_vxworks_diren.c
+++ b/Stack/platforms/vxworks/opcua_vxworks_diren.c
@@ -1,0 +1,155 @@
+/* opcua_vxworks_dirent.c - POSIX directory handling definitions for OPCUA */
+
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+07sep18,lan  written.
+*/
+
+#include <vxWorks.h>
+#include <stdlib.h>
+#include <dirent.h>
+#include <string.h>
+#include <errnoLib.h>
+
+#include <opcua_vxworks_dirent.h>
+
+#define MAX_DIR_ENTRY    64
+
+/*******************************************************************************
+*
+* scandir - scan a directory for matching entries
+* 
+* The scandir() function scans the directory 'dirp', calling the function 
+* referenced by 'filter' on each directory entry. Entries for which the function 
+* referenced by 'filter' returns non-zero shall be stored in strings allocated 
+* as if by a call to malloc(), and sorted as if by a call to qsort() with the 
+* comparison function 'compar', except that 'compar' need not provide total 
+* ordering.  
+*
+*/
+
+int scandir 
+    (
+    const char *      dirp, 
+	struct dirent *** namelist,
+    int (*filter)(const struct dirent *),
+    int (*compar)(const struct dirent **, const struct dirent **)
+    )
+    {
+    DIR *            odir;
+    struct dirent ** lst;
+    struct dirent *  ent;
+    struct dirent *  pa;
+    int              nCount = 0;
+    BOOL             outofmemory = FALSE;
+
+    if ((dirp == NULL) || (namelist == NULL))
+        {
+        return -1;
+        }
+
+    odir = opendir (dirp);
+    if (odir == NULL)
+        {
+        (void) errnoSet (ENOTDIR);    	
+        return -1;
+        }
+
+    lst = (struct dirent **) malloc (MAX_DIR_ENTRY * sizeof (struct dirent *));
+    if (lst == NULL)
+        {
+        (void) closedir (odir);
+        (void) errnoSet (ENOMEM);        
+        return -1;
+        }
+
+    while ((ent = readdir (odir)) != NULL)
+        {
+        if (filter && !filter (ent))
+            continue;
+        pa = (struct dirent *) malloc (sizeof (struct dirent));
+        if (pa == NULL)
+            {
+            outofmemory = TRUE;
+            break;
+            }
+
+        (void) memcpy ((void *) pa, (void *) ent, sizeof (struct dirent));
+        lst[nCount] = pa;
+        nCount ++;
+        }
+
+    /* out of memory to free memory */
+
+    if (outofmemory)
+        {
+        while (nCount)
+            {
+            free (lst[nCount]);
+            }
+        free(lst);
+        return -1;
+        }
+
+    if (nCount > 0 && compar)
+        {
+        qsort(lst, nCount, sizeof (struct dirent **), compar);
+        }
+    * namelist = lst;
+	return nCount;	
+    }
+     
+/*******************************************************************************
+ * 
+ * alphasort - sort the directory entries, 'a' and 'b', into alphabetical order
+ * 
+ * The alphasort() function be used as the comparison function for the 'scandir'
+ * function to sort the directory entries, 'a' and 'b', into alphabetical order. 
+ *
+ */
+
+int alphasort
+    (
+    const struct dirent ** a, 
+	const struct dirent ** b
+	)
+    {
+    if (a == NULL || b == NULL)
+        {
+        return 0;
+        }
+
+    return strcmp ((*a)->d_name, (*b)->d_name);
+    }

--- a/Stack/platforms/vxworks/opcua_vxworks_dirent.h
+++ b/Stack/platforms/vxworks/opcua_vxworks_dirent.h
@@ -1,0 +1,68 @@
+/* opcua_vxworks_dirent.h - POSIX directory handling definitions for OPCUA */
+
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+07sep18,lan  written.
+*/
+
+#ifndef __INopcua_vxworks_dirent
+#define __INopcua_vxworks_dirent
+
+#include <vxWorks.h>			/* for SEM_ID, BOOL, STATUS */
+#include <dirent.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+extern int scandir 
+    (
+    const char *      dirp, 
+	struct dirent *** namelist,
+    int (*filter)(const struct dirent *),
+    int (*compar)(const struct dirent **, const struct dirent **)
+    );
+             
+extern int alphasort
+    (
+    const struct dirent **a, 
+	const struct dirent **b
+	);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __INopcua_vxworks_dirent */

--- a/Stack/platforms/vxworks/opcua_vxworks_socket.c
+++ b/Stack/platforms/vxworks/opcua_vxworks_socket.c
@@ -1,0 +1,126 @@
+/* opcua_vxworks_socket.c - socketpair for OPCUA */
+
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+08nov18,lan  written.
+*/
+
+#include <vxWorks.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ioLib.h>
+#include <errnoLib.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <opcua_vxworks_socket.h>
+
+/*******************************************************************************
+*
+* socketpair - create a pair of connected sockets
+* 
+* The socketpair() function creates an unbound pair of connected sockets in a 
+* specified domain, of a specified type, under the protocol optionally specified 
+* by the protocol argument. The file descriptors used in referencing the 
+* created sockets be returned in socket_vector[0] and socket_vector[1].
+*
+* Note: For OPCUA, we only need socketpair() to send/receive events.
+*       This function only implements streaming.
+*/
+
+int socketpair
+    (
+    int domain,  
+    int type, 
+    int protocol, 
+    int sv[2]
+    )
+    {
+    struct addrinfo * res = NULL;
+    struct addrinfo   hints;
+    int               ret;
+    int               listenSock  = -1;
+    int               connectSock = -1;
+    int               acceptSock  = -1;
+    socklen_t         addrlen;
+    
+    (void) memset (&hints, 0, sizeof(hints));
+    hints.ai_family   = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
+
+    ret = getaddrinfo(NULL, "0", &hints, &res);
+    if (ret < 0)
+    	goto fail;
+    listenSock = socket(res->ai_family, SOCK_STREAM, res->ai_protocol);
+    if (listenSock == -1)
+    	goto fail;
+    
+    connectSock = socket(res->ai_family, SOCK_STREAM, res->ai_protocol);
+    if (connectSock == -1)
+    	goto fail;  
+
+    /* Bind to an ephemeral port */
+    if (bind(listenSock, res->ai_addr, (socklen_t) res->ai_addrlen) != 0)
+        goto fail;  
+
+    addrlen = (socklen_t) res->ai_addrlen;
+    
+    if (getsockname(listenSock, res->ai_addr, &addrlen) != 0)
+        goto fail; 
+
+    if (listen(listenSock, 1) != 0)
+        goto fail;
+
+    if (connect(connectSock, res->ai_addr, (socklen_t) res->ai_addrlen) != 0)
+        goto fail;
+
+    acceptSock = accept(listenSock, NULL, NULL);
+    if (acceptSock == -1)
+        goto fail;
+    
+    sv[0] = connectSock;
+    sv[1] = acceptSock;
+    close (listenSock);
+    freeaddrinfo(res);
+    return 0;
+fail:
+    if (res != NULL)
+    	freeaddrinfo(res);
+    if (listenSock != -1)
+    	close (listenSock);
+    if (connectSock != -1)
+    	close (connectSock);
+    return -1;        
+    }

--- a/Stack/platforms/vxworks/opcua_vxworks_socket.h
+++ b/Stack/platforms/vxworks/opcua_vxworks_socket.h
@@ -1,0 +1,59 @@
+/* opcua_vxworks_socket.h - socketpair for OPCUA */
+
+/* ========================================================================
+ * Copyright (c) 2005-2018 The OPC Foundation, Inc. All rights reserved.
+ *
+ * OPC Foundation MIT License 1.00
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * The complete license agreement can be found here:
+ * http://opcfoundation.org/License/MIT/1.00/
+ * ======================================================================*/
+
+/* Copyright 2018 Wind River Systems, Inc. */
+
+/*
+modification history
+--------------------
+08nov18,lan  written.
+*/
+
+#ifndef __INopcua_vxworks_socket
+#define __INopcua_vxworks_socket
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+extern int socketpair
+    (
+    int domain, 
+    int type, 
+    int protocol, 
+    int sv[2]
+    );
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __INopcua_vxworks_socket */


### PR DESCRIPTION
Port the UA ANSI C Stack to VxWorks-7, implement the VxWorks abstraction layer.
Highlight: 
Use VxWorks native api to implement OPC-UA thread.
use VxWorks native api to implement OPC-UA semaphore.
use VxWorks native api to implement OPC-UA mutex.

So OPC UA can take advantage of the real-time of VxWorks.

The OPC UA can work in VxWorks-7 in IA 32-bit/64-bit, PPC 32-bit/64-bit, ARM 32-bit/64-bit CPU.
